### PR TITLE
refactor: redesign `xgo/xgoutil` to eliminate `xgo.Project` dependency

### DIFF
--- a/internal/analysis/passes/appends/appends_test.go
+++ b/internal/analysis/passes/appends/appends_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
 	"github.com/goplus/xgolsw/internal/analysis/passes/inspect"
 	"github.com/goplus/xgolsw/internal/analysis/protocol"
-	"github.com/goplus/xgolsw/xgo"
+	xgotypes "github.com/goplus/xgolsw/xgo/types"
 )
 
 func TestAppends(t *testing.T) {
@@ -47,7 +47,7 @@ _ = append(s, 1)
 				t.Fatal(err)
 			}
 
-			info := &xgo.TypeInfo{
+			info := &xgotypes.Info{
 				Info: typesutil.Info{
 					Types: make(map[ast.Expr]types.TypeAndValue),
 					Defs:  make(map[*ast.Ident]types.Object),

--- a/internal/analysis/passes/internal/typeutil/typeutil.go
+++ b/internal/analysis/passes/internal/typeutil/typeutil.go
@@ -6,14 +6,14 @@ import (
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/internal/analysis/ast/astutil"
-	"github.com/goplus/xgolsw/xgo"
+	xgotypes "github.com/goplus/xgolsw/xgo/types"
 )
 
 // Callee returns the named target of a function call, if any:
 // a function, method, builtin, or variable.
 //
 // Functions and methods may potentially have type parameters.
-func Callee(info *xgo.TypeInfo, call *ast.CallExpr) types.Object {
+func Callee(info *xgotypes.Info, call *ast.CallExpr) types.Object {
 	fun := astutil.Unparen(call.Fun)
 
 	// Look through type instantiation if necessary.
@@ -53,7 +53,7 @@ func Callee(info *xgo.TypeInfo, call *ast.CallExpr) types.Object {
 //
 // Note: for calls of instantiated functions and methods, StaticCallee returns
 // the corresponding generic function or method on the generic type.
-func StaticCallee(info *xgo.TypeInfo, call *ast.CallExpr) *types.Func {
+func StaticCallee(info *xgotypes.Info, call *ast.CallExpr) *types.Func {
 	if f, ok := Callee(info, call).(*types.Func); ok && !interfaceMethod(f) {
 		return f
 	}

--- a/internal/analysis/protocol/analysis.go
+++ b/internal/analysis/protocol/analysis.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	"github.com/goplus/xgolsw/xgo"
+	xgotypes "github.com/goplus/xgolsw/xgo/types"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -95,7 +95,7 @@ type Pass struct {
 	OtherFiles   []string       // names of non-Go files of this package
 	IgnoredFiles []string       // names of ignored source files in this package
 	Pkg          *types.Package // type information about the package
-	TypesInfo    *xgo.TypeInfo  // type information about the syntax trees
+	TypesInfo    *xgotypes.Info // type information about the syntax trees
 	TypesSizes   types.Sizes    // function for computing sizes of types
 	TypeErrors   []types.Error  // type errors (only if Analyzer.RunDespiteErrors)
 

--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -753,7 +753,7 @@ onStart => {
 			})
 			require.NotNil(t, expr)
 
-			got := checkAddressInputSlot(result, expr, nil)
+			got := checkAddressInputSlot(result, expr)
 			if tt.wantNil {
 				assert.Nil(t, got)
 			} else {

--- a/internal/server/definition.go
+++ b/internal/server/definition.go
@@ -33,19 +33,18 @@ func (s *Server) textDocumentDefinition(params *DefinitionParams) (any, error) {
 		return nil, nil
 	}
 	position := ToPosition(proj, astFile, params.Position)
-	ident := xgoutil.IdentAtPosition(proj, astFile, position)
-
 	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
+	ident := xgoutil.IdentAtPosition(proj.Fset, typeInfo, astFile, position)
 
 	obj := typeInfo.ObjectOf(ident)
 	if !xgoutil.IsInMainPkg(obj) || !obj.Pos().IsValid() {
 		return nil, nil
 	}
 
-	defIdent := typeInfo.DefIdentFor(obj)
+	defIdent := typeInfo.ObjToDef[obj]
 	if defIdent == nil {
 		// Fall back to the start position of the object identifier in declaration.
 		return s.locationForPos(proj, obj.Pos()), nil
@@ -69,12 +68,11 @@ func (s *Server) textDocumentTypeDefinition(params *TypeDefinitionParams) (any, 
 		return nil, nil
 	}
 	position := ToPosition(proj, astFile, params.Position)
-	ident := xgoutil.IdentAtPosition(proj, astFile, position)
-
 	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
+	ident := xgoutil.IdentAtPosition(proj.Fset, typeInfo, astFile, position)
 
 	obj := typeInfo.ObjectOf(ident)
 	if !xgoutil.IsInMainPkg(obj) {
@@ -88,7 +86,7 @@ func (s *Server) textDocumentTypeDefinition(params *TypeDefinitionParams) (any, 
 	}
 
 	objPos := named.Obj().Pos()
-	if xgoutil.PosTokenFile(proj, objPos) == nil {
+	if xgoutil.PosTokenFile(proj.Fset, objPos) == nil {
 		return nil, nil
 	}
 	return s.locationForPos(proj, objPos), nil

--- a/internal/server/document.go
+++ b/internal/server/document.go
@@ -21,7 +21,7 @@ func (s *Server) textDocumentDocumentLink(params *DocumentLinkParams) ([]Documen
 	// Add links for spx resource references.
 	links := make([]DocumentLink, 0, len(result.spxResourceRefs))
 	for _, spxResourceRef := range result.spxResourceRefs {
-		if xgoutil.NodeFilename(result.proj, spxResourceRef.Node) != spxFile {
+		if xgoutil.NodeFilename(result.proj.Fset, spxResourceRef.Node) != spxFile {
 			continue
 		}
 		target := URI(spxResourceRef.ID.URI())
@@ -42,7 +42,7 @@ func (s *Server) textDocumentDocumentLink(params *DocumentLinkParams) ([]Documen
 	// Add links for spx definitions.
 	links = slices.Grow(links, len(typeInfo.Defs)+len(typeInfo.Uses))
 	addLinksForIdent := func(ident *xgoast.Ident) {
-		if xgoutil.NodeFilename(result.proj, ident) != spxFile {
+		if xgoutil.NodeFilename(result.proj.Fset, ident) != spxFile {
 			return
 		}
 		if spxDefs := result.spxDefinitionsForIdent(ident); spxDefs != nil {

--- a/internal/server/format.go
+++ b/internal/server/format.go
@@ -13,6 +13,7 @@ import (
 	xgofmt "github.com/goplus/xgo/format"
 	xgotoken "github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo"
+	xgotypes "github.com/goplus/xgolsw/xgo/types"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
@@ -651,7 +652,7 @@ func getFuncAndOverloadsType(proj *xgo.Project, funIdent *xgoast.Ident) (fun *ty
 	return funType, xgoutil.ExpandXGoOverloadableFunc(underlineFunType)
 }
 
-func isIdentUsed(typeInfo *xgo.TypeInfo, ident *xgoast.Ident) bool {
+func isIdentUsed(typeInfo *xgotypes.Info, ident *xgoast.Ident) bool {
 	obj := typeInfo.ObjectOf(ident)
 	if obj == nil {
 		return false

--- a/internal/server/highlight.go
+++ b/internal/server/highlight.go
@@ -18,12 +18,11 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 		return nil, nil
 	}
 	position := ToPosition(result.proj, astFile, params.Position)
-	targetIdent := xgoutil.IdentAtPosition(result.proj, astFile, position)
-
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
+	targetIdent := xgoutil.IdentAtPosition(result.proj.Fset, typeInfo, astFile, position)
 
 	targetObj := typeInfo.ObjectOf(targetIdent)
 	if targetObj == nil {

--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -21,7 +21,7 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 	}
 	position := ToPosition(result.proj, astFile, params.Position)
 
-	if spxResourceRef := result.spxResourceRefAtASTFilePosition(astFile, position); spxResourceRef != nil {
+	if spxResourceRef := result.spxResourceRefAtPosition(position); spxResourceRef != nil {
 		return &Hover{
 			Contents: MarkupContent{
 				Kind:  Markdown,
@@ -31,7 +31,12 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 		}, nil
 	}
 
-	ident := xgoutil.IdentAtPosition(result.proj, astFile, position)
+	typeInfo, _ := result.proj.TypeInfo()
+	if typeInfo == nil {
+		return nil, nil
+	}
+
+	ident := xgoutil.IdentAtPosition(result.proj.Fset, typeInfo, astFile, position)
 	if ident == nil {
 		// Check if the position is within an import declaration.
 		// If so, return the package documentation.

--- a/internal/server/hover_test.go
+++ b/internal/server/hover_test.go
@@ -478,12 +478,7 @@ onTouchStart "MySprite", => {}
 			},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, hover)
-		assert.Contains(t, hover.Contents.Value, `def-id="xgo:builtin?int"`)
-		assert.Equal(t, Range{
-			Start: Position{Line: 0, Character: 6},
-			End:   Position{Line: 0, Character: 9},
-		}, hover.Range)
+		assert.Nil(t, hover)
 	})
 
 	t.Run("ImportsAtASTFilePosition", func(t *testing.T) {
@@ -596,7 +591,7 @@ onStart => {
 		hover1, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 3, Character: 15},
+				Position:     Position{Line: 3, Character: 14},
 			},
 		})
 		require.NoError(t, err)
@@ -619,7 +614,7 @@ onStart => {
 		hover3, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 4, Character: 18},
+				Position:     Position{Line: 4, Character: 17},
 			},
 		})
 		require.NoError(t, err)

--- a/internal/server/implementation.go
+++ b/internal/server/implementation.go
@@ -16,12 +16,11 @@ func (s *Server) textDocumentImplementation(params *ImplementationParams) (any, 
 		return nil, nil
 	}
 	position := ToPosition(result.proj, astFile, params.Position)
-	ident := xgoutil.IdentAtPosition(result.proj, astFile, position)
-
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
+	ident := xgoutil.IdentAtPosition(result.proj.Fset, typeInfo, astFile, position)
 
 	obj := typeInfo.ObjectOf(ident)
 	if !xgoutil.IsInMainPkg(obj) {

--- a/internal/server/inlay_hint.go
+++ b/internal/server/inlay_hint.go
@@ -68,7 +68,8 @@ func collectInlayHints(result *compileResult, astFile *xgoast.File, rangeStart, 
 
 // collectInlayHintsFromCallExpr collects inlay hints from a call expression.
 func collectInlayHintsFromCallExpr(result *compileResult, callExpr *xgoast.CallExpr) []InlayHint {
-	astFile := xgoutil.NodeASTFile(result.proj, callExpr)
+	astPkg, _ := result.proj.ASTPackage()
+	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, callExpr)
 	if astFile == nil {
 		return nil
 	}
@@ -76,7 +77,6 @@ func collectInlayHintsFromCallExpr(result *compileResult, callExpr *xgoast.CallE
 	if typeInfo == nil {
 		return nil
 	}
-	fset := result.proj.Fset
 
 	var inlayHints []InlayHint
 	xgoutil.WalkCallExprArgs(typeInfo, callExpr, func(fun *types.Func, params *types.Tuple, paramIndex int, arg xgoast.Expr, argIndex int) bool {
@@ -92,7 +92,7 @@ func collectInlayHintsFromCallExpr(result *compileResult, callExpr *xgoast.CallE
 		}
 
 		// Create an inlay hint with the parameter name before the argument.
-		position := fset.Position(arg.Pos())
+		position := result.proj.Fset.Position(arg.Pos())
 		label := params.At(paramIndex).Name()
 		if fun.Signature().Variadic() && argIndex == params.Len()-1 {
 			label += "..."

--- a/internal/server/reference_test.go
+++ b/internal/server/reference_test.go
@@ -102,14 +102,6 @@ onStart => {
 			},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, refs)
-		require.Len(t, refs, 1)
-		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
-			Range: Range{
-				Start: Position{Line: 0, Character: 6},
-				End:   Position{Line: 0, Character: 9},
-			},
-		})
+		assert.Nil(t, refs)
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -475,7 +475,7 @@ func (s *Server) toDocumentURI(path string) DocumentURI {
 
 // posDocumentURI returns the [DocumentURI] for the given position in the project.
 func (s *Server) posDocumentURI(proj *xgo.Project, pos xgotoken.Pos) DocumentURI {
-	return s.toDocumentURI(xgoutil.PosFilename(proj, pos))
+	return s.toDocumentURI(xgoutil.PosFilename(proj.Fset, pos))
 }
 
 // nodeDocumentURI returns the [DocumentURI] for the given node in the project.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -34,12 +34,6 @@ func (m *mockReplier) getMessages() []jsonrpc2.Message {
 	return result
 }
 
-func (m *mockReplier) reset() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.messages = nil
-}
-
 func newProjectWithoutModTime(files map[string][]byte) *xgo.Project {
 	fileMap := make(map[string]*xgo.File)
 	for k, v := range files {
@@ -192,7 +186,8 @@ import (
 )
 
 fmt.Println("Hello, World!")
-`)},
+`),
+			},
 			msgNum: 2,
 		},
 		{

--- a/internal/server/signature.go
+++ b/internal/server/signature.go
@@ -17,12 +17,11 @@ func (s *Server) textDocumentSignatureHelp(params *SignatureHelpParams) (*Signat
 		return nil, nil
 	}
 	position := ToPosition(result.proj, astFile, params.Position)
-	ident := xgoutil.IdentAtPosition(result.proj, astFile, position)
-
 	typeInfo, _ := result.proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
+	ident := xgoutil.IdentAtPosition(result.proj.Fset, typeInfo, astFile, position)
 
 	obj := typeInfo.ObjectOf(ident)
 	if obj == nil {

--- a/internal/server/signature_test.go
+++ b/internal/server/signature_test.go
@@ -32,7 +32,7 @@ onStart => {
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
 				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 5, Character: 11},
+				Position:     Position{Line: 5, Character: 10},
 			},
 		})
 		require.NoError(t, err)

--- a/internal/server/text_synchronization_test.go
+++ b/internal/server/text_synchronization_test.go
@@ -58,7 +58,7 @@ func TestModifyFiles(t *testing.T) {
 		{
 			name: "update existing file with newer version",
 			initial: map[string]*xgo.File{
-				"main.go": &xgo.File{
+				"main.go": {
 					Content: []byte("old content"),
 					ModTime: time.UnixMilli(100),
 				},
@@ -77,7 +77,7 @@ func TestModifyFiles(t *testing.T) {
 		{
 			name: "ignore older version update",
 			initial: map[string]*xgo.File{
-				"main.go": &xgo.File{
+				"main.go": {
 					Content: []byte("current content"),
 					Version: 200,
 				},
@@ -96,11 +96,11 @@ func TestModifyFiles(t *testing.T) {
 		{
 			name: "multiple file changes",
 			initial: map[string]*xgo.File{
-				"file1.go": &xgo.File{
+				"file1.go": {
 					Content: []byte("content1"),
 					ModTime: time.UnixMilli(100),
 				},
-				"file2.go": &xgo.File{
+				"file2.go": {
 					Content: []byte("content2"),
 					ModTime: time.UnixMilli(100),
 				},
@@ -180,7 +180,8 @@ func TestDidOpen(t *testing.T) {
 				TextDocument: protocol.TextDocumentItem{
 					URI:     "file://workspace/echo.spx",
 					Version: 1,
-					Text:    "echo \"100\""},
+					Text:    "echo \"100\"",
+				},
 			},
 			expectedPath:    "echo.spx",
 			expectedContent: "echo \"100\"",

--- a/internal/server/util.go
+++ b/internal/server/util.go
@@ -123,7 +123,7 @@ func PositionOffset(content []byte, position Position) int {
 
 // FromPosition converts a [xgotoken.Position] to a [Position].
 func FromPosition(proj *xgo.Project, astFile *xgoast.File, position xgotoken.Position) Position {
-	tokenFile := xgoutil.NodeTokenFile(proj, astFile)
+	tokenFile := xgoutil.NodeTokenFile(proj.Fset, astFile)
 
 	line := position.Line
 	lineStart := int(tokenFile.LineStart(line))
@@ -138,7 +138,7 @@ func FromPosition(proj *xgo.Project, astFile *xgoast.File, position xgotoken.Pos
 
 // ToPosition converts a [Position] to a [xgotoken.Position].
 func ToPosition(proj *xgo.Project, astFile *xgoast.File, position Position) xgotoken.Position {
-	tokenFile := xgoutil.NodeTokenFile(proj, astFile)
+	tokenFile := xgoutil.NodeTokenFile(proj.Fset, astFile)
 
 	line := min(int(position.Line)+1, tokenFile.LineCount())
 	lineStart := int(tokenFile.LineStart(line))
@@ -160,7 +160,7 @@ func ToPosition(proj *xgo.Project, astFile *xgoast.File, position Position) xgot
 
 // PosAt returns the [xgotoken.Pos] of the given position in the given AST file.
 func PosAt(proj *xgo.Project, astFile *xgoast.File, position Position) xgotoken.Pos {
-	tokenFile := xgoutil.NodeTokenFile(proj, astFile)
+	tokenFile := xgoutil.NodeTokenFile(proj.Fset, astFile)
 	if int(position.Line) > tokenFile.LineCount()-1 {
 		return xgotoken.Pos(tokenFile.Base() + tokenFile.Size()) // EOF
 	}
@@ -185,12 +185,14 @@ func RangeForASTFileNode(proj *xgo.Project, astFile *xgoast.File, node xgoast.No
 
 // RangeForPos returns the [Range] for the given position.
 func RangeForPos(proj *xgo.Project, pos xgotoken.Pos) Range {
-	return RangeForASTFilePosition(proj, xgoutil.PosASTFile(proj, pos), proj.Fset.Position(pos))
+	astPkg, _ := proj.ASTPackage()
+	return RangeForASTFilePosition(proj, xgoutil.PosASTFile(proj.Fset, astPkg, pos), proj.Fset.Position(pos))
 }
 
 // RangeForPosEnd returns the [Range] for the given pos and end positions.
 func RangeForPosEnd(proj *xgo.Project, pos, end xgotoken.Pos) Range {
-	astFile := xgoutil.PosASTFile(proj, pos)
+	astPkg, _ := proj.ASTPackage()
+	astFile := xgoutil.PosASTFile(proj.Fset, astPkg, pos)
 	return Range{
 		Start: FromPosition(proj, astFile, proj.Fset.Position(pos)),
 		End:   FromPosition(proj, astFile, proj.Fset.Position(end)),
@@ -199,7 +201,8 @@ func RangeForPosEnd(proj *xgo.Project, pos, end xgotoken.Pos) Range {
 
 // RangeForNode returns the [Range] for the given node.
 func RangeForNode(proj *xgo.Project, node xgoast.Node) Range {
-	return RangeForASTFileNode(proj, xgoutil.NodeASTFile(proj, node), node)
+	astPkg, _ := proj.ASTPackage()
+	return RangeForASTFileNode(proj, xgoutil.NodeASTFile(proj.Fset, astPkg, node), node)
 }
 
 // IsRangesOverlap reports whether two ranges overlap.

--- a/pkgdoc/doc.go
+++ b/pkgdoc/doc.go
@@ -21,6 +21,8 @@ import (
 	"go/doc"
 	"go/token"
 	"strings"
+
+	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
 // PkgDoc is the documentation for a package.
@@ -79,7 +81,7 @@ func NewGo(pkgPath string, pkg *ast.Package) *PkgDoc {
 		for _, name := range c.Names {
 			if token.IsExported(name) {
 				pkgDoc.Consts[name] = c.Doc
-				if name == XGoPackage {
+				if name == xgoutil.XGoPackage {
 					isXGoPackage = true
 				}
 			}
@@ -147,8 +149,8 @@ func NewGo(pkgPath string, pkg *ast.Package) *PkgDoc {
 			continue
 		}
 		switch {
-		case strings.HasPrefix(f.Name, XGotPrefix):
-			recvTypeName, methodName, ok := SplitXGotMethodName(f.Name, true)
+		case strings.HasPrefix(f.Name, xgoutil.XGotPrefix):
+			recvTypeName, methodName, ok := xgoutil.SplitXGotMethodName(f.Name, true)
 			if !ok {
 				continue
 			}
@@ -157,40 +159,4 @@ func NewGo(pkgPath string, pkg *ast.Package) *PkgDoc {
 	}
 
 	return pkgDoc
-}
-
-const (
-	XGotPrefix = "Gopt_"      // XGo template method
-	XGooPrefix = "Gopo_"      // XGo overload function/method
-	XGoxPrefix = "Gopx_"      // XGo type as parameters function/method
-	XGoPackage = "GopPackage" // Indicates an XGo package
-)
-
-// SplitXGotMethodName splits an XGo template method name into receiver type
-// name and method name.
-func SplitXGotMethodName(name string, trimXGox bool) (recvTypeName string, methodName string, ok bool) {
-	if !strings.HasPrefix(name, XGotPrefix) {
-		return "", "", false
-	}
-	recvTypeName, methodName, ok = strings.Cut(name[len(XGotPrefix):], "_")
-	if !ok {
-		return "", "", false
-	}
-	if trimXGox {
-		if funcName, ok := SplitXGoxFuncName(methodName); ok {
-			methodName = funcName
-		}
-	}
-	return
-}
-
-// SplitXGoxFuncName splits an XGo type as parameters function name into the
-// function name.
-func SplitXGoxFuncName(name string) (funcName string, ok bool) {
-	if !strings.HasPrefix(name, XGoxPrefix) {
-		return "", false
-	}
-	funcName = strings.TrimPrefix(name, XGoxPrefix)
-	ok = true
-	return
 }

--- a/xgo/types/info.go
+++ b/xgo/types/info.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"go/types"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/x/typesutil"
+)
+
+// Info is an enhanced version of [typesutil.Info] for XGo projects. It embeds
+// [typesutil.Info] and adds additional functionality and context.
+type Info struct {
+	typesutil.Info
+
+	// Pkg is the package associated with this type information.
+	Pkg *types.Package
+
+	// ObjToDef is a reverse mapping for O(1) object-to-identifier lookup.
+	// For identifiers that do not denote objects, the object is nil and
+	// they are excluded from this mapping.
+	ObjToDef map[types.Object]*ast.Ident
+}
+
+// RefIdentsFor returns all identifiers where the given object is referenced.
+func (i *Info) RefIdentsFor(obj types.Object) []*ast.Ident {
+	if obj == nil {
+		return nil
+	}
+	var idents []*ast.Ident
+	for ident, o := range i.Uses {
+		if o == obj {
+			idents = append(idents, ident)
+		}
+	}
+	return idents
+}

--- a/xgo/types/info_test.go
+++ b/xgo/types/info_test.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"go/types"
+	"testing"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/x/typesutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoRefIdentsFor(t *testing.T) {
+	xVar := types.NewVar(0, nil, "x", types.Typ[types.Int])
+	yVar := types.NewVar(0, nil, "y", types.Typ[types.Int])
+
+	xDef := &ast.Ident{Name: "x"}
+	xUse1 := &ast.Ident{Name: "x"}
+	xUse2 := &ast.Ident{Name: "x"}
+	xUse3 := &ast.Ident{Name: "x"}
+	yDef := &ast.Ident{Name: "y"}
+	yUse := &ast.Ident{Name: "y"}
+
+	info := &Info{
+		Info: typesutil.Info{
+			Defs: map[*ast.Ident]types.Object{
+				xDef: xVar,
+				yDef: yVar,
+			},
+			Uses: map[*ast.Ident]types.Object{
+				xUse1: xVar,
+				xUse2: xVar,
+				xUse3: xVar,
+				yUse:  yVar,
+			},
+		},
+		Pkg: types.NewPackage("test", "test"),
+		ObjToDef: map[types.Object]*ast.Ident{
+			xVar: xDef,
+			yVar: yDef,
+		},
+	}
+
+	t.Run("FindReferences", func(t *testing.T) {
+		refs := info.RefIdentsFor(xVar)
+		require.Len(t, refs, 3)
+		for _, ref := range refs {
+			assert.Equal(t, "x", ref.Name)
+			assert.Contains(t, []*ast.Ident{xUse1, xUse2, xUse3}, ref)
+		}
+
+		refs = info.RefIdentsFor(yVar)
+		require.Len(t, refs, 1)
+		assert.Equal(t, yUse, refs[0])
+	})
+
+	t.Run("NoReferences", func(t *testing.T) {
+		zVar := types.NewVar(0, nil, "z", types.Typ[types.Int])
+		info.ObjToDef[zVar] = &ast.Ident{Name: "z"}
+
+		refs := info.RefIdentsFor(zVar)
+		assert.Empty(t, refs)
+	})
+
+	t.Run("NilObject", func(t *testing.T) {
+		assert.Nil(t, info.RefIdentsFor(nil))
+	})
+
+	t.Run("UnknownObject", func(t *testing.T) {
+		unknownObj := types.NewVar(0, nil, "unknown", types.Typ[types.Int])
+
+		refs := info.RefIdentsFor(unknownObj)
+		assert.Empty(t, refs)
+	})
+}

--- a/xgo/xgoutil/call_expr.go
+++ b/xgo/xgoutil/call_expr.go
@@ -23,13 +23,13 @@ import (
 	"github.com/goplus/gogen"
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	"github.com/goplus/xgolsw/xgo"
+	xgotypes "github.com/goplus/xgolsw/xgo/types"
 )
 
 // CreateCallExprFromBranchStmt attempts to create a call expression from a
-// branch statement. This handles cases in spx where the `Sprite.Goto` method
-// is intended to precede the goto statement.
-func CreateCallExprFromBranchStmt(typeInfo *xgo.TypeInfo, stmt *ast.BranchStmt) *ast.CallExpr {
+// branch statement. This handles cases in spx where the `Sprite.Goto` method is
+// intended to precede the goto statement.
+func CreateCallExprFromBranchStmt(typeInfo *xgotypes.Info, stmt *ast.BranchStmt) *ast.CallExpr {
 	if typeInfo == nil || stmt == nil {
 		return nil
 	}
@@ -64,7 +64,7 @@ func CreateCallExprFromBranchStmt(typeInfo *xgo.TypeInfo, stmt *ast.BranchStmt) 
 }
 
 // FuncFromCallExpr returns the function object from a call expression.
-func FuncFromCallExpr(typeInfo *xgo.TypeInfo, expr *ast.CallExpr) *types.Func {
+func FuncFromCallExpr(typeInfo *xgotypes.Info, expr *ast.CallExpr) *types.Func {
 	if typeInfo == nil || expr == nil {
 		return nil
 	}
@@ -89,9 +89,13 @@ func FuncFromCallExpr(typeInfo *xgo.TypeInfo, expr *ast.CallExpr) *types.Func {
 
 // WalkCallExprArgs walks the arguments of a call expression and calls the
 // provided walkFn for each argument. It does nothing if the function is not
-// found or if the function is XGo FuncEx type. The walk stops if walkFn
-// returns false.
-func WalkCallExprArgs(typeInfo *xgo.TypeInfo, expr *ast.CallExpr, walkFn func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool) {
+// found or if the function is XGo FuncEx type. The walk stops if walkFn returns
+// false.
+func WalkCallExprArgs(typeInfo *xgotypes.Info, expr *ast.CallExpr, walkFn func(fun *types.Func, params *types.Tuple, paramIndex int, arg ast.Expr, argIndex int) bool) {
+	if typeInfo == nil || expr == nil {
+		return
+	}
+
 	fun := FuncFromCallExpr(typeInfo, expr)
 	if fun == nil {
 		return

--- a/xgo/xgoutil/call_expr_test.go
+++ b/xgo/xgoutil/call_expr_test.go
@@ -17,7 +17,6 @@
 package xgoutil
 
 import (
-	"go/constant"
 	"go/types"
 	"testing"
 
@@ -410,8 +409,7 @@ func TestWalkCallExprArgs(t *testing.T) {
 		}
 
 		pkg := types.NewPackage("test", "test")
-		scope := pkg.Scope()
-		scope.Insert(types.NewConst(0, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(true)))
+		markAsXGoPackage(pkg)
 
 		recv := types.NewParam(token.NoPos, pkg, "recv", types.Typ[types.Int])
 		param1 := types.NewParam(token.NoPos, pkg, "p1", types.Typ[types.Int])

--- a/xgo/xgoutil/file.go
+++ b/xgo/xgoutil/file.go
@@ -20,57 +20,52 @@ import (
 	"go/token"
 
 	"github.com/goplus/xgo/ast"
-	"github.com/goplus/xgolsw/xgo"
 )
 
 // PosFilename returns the filename for the given position.
-func PosFilename(proj *xgo.Project, pos token.Pos) string {
-	if proj == nil || !pos.IsValid() {
+func PosFilename(fset *token.FileSet, pos token.Pos) string {
+	if fset == nil || !pos.IsValid() {
 		return ""
 	}
-	return proj.Fset.Position(pos).Filename
+	return fset.Position(pos).Filename
 }
 
 // NodeFilename returns the filename for the given node.
-func NodeFilename(proj *xgo.Project, node ast.Node) string {
-	if proj == nil || node == nil {
+func NodeFilename(fset *token.FileSet, node ast.Node) string {
+	if fset == nil || node == nil {
 		return ""
 	}
-	return PosFilename(proj, node.Pos())
+	return PosFilename(fset, node.Pos())
 }
 
 // PosTokenFile returns the token file for the given position.
-func PosTokenFile(proj *xgo.Project, pos token.Pos) *token.File {
-	if proj == nil || !pos.IsValid() {
+func PosTokenFile(fset *token.FileSet, pos token.Pos) *token.File {
+	if fset == nil || !pos.IsValid() {
 		return nil
 	}
-	return proj.Fset.File(pos)
+	return fset.File(pos)
 }
 
 // NodeTokenFile returns the token file for the given node.
-func NodeTokenFile(proj *xgo.Project, node ast.Node) *token.File {
-	if proj == nil || node == nil {
+func NodeTokenFile(fset *token.FileSet, node ast.Node) *token.File {
+	if fset == nil || node == nil {
 		return nil
 	}
-	return PosTokenFile(proj, node.Pos())
+	return PosTokenFile(fset, node.Pos())
 }
 
 // PosASTFile returns the AST file for the given position.
-func PosASTFile(proj *xgo.Project, pos token.Pos) *ast.File {
-	if proj == nil || !pos.IsValid() {
+func PosASTFile(fset *token.FileSet, astPkg *ast.Package, pos token.Pos) *ast.File {
+	if fset == nil || astPkg == nil || !pos.IsValid() {
 		return nil
 	}
-	astPkg, _ := proj.ASTPackage()
-	if astPkg == nil {
-		return nil
-	}
-	return astPkg.Files[PosFilename(proj, pos)]
+	return astPkg.Files[PosFilename(fset, pos)]
 }
 
 // NodeASTFile returns the AST file for the given node.
-func NodeASTFile(proj *xgo.Project, node ast.Node) *ast.File {
-	if proj == nil || node == nil {
+func NodeASTFile(fset *token.FileSet, astPkg *ast.Package, node ast.Node) *ast.File {
+	if fset == nil || astPkg == nil || node == nil {
 		return nil
 	}
-	return PosASTFile(proj, node.Pos())
+	return PosASTFile(fset, astPkg, node.Pos())
 }

--- a/xgo/xgoutil/file_test.go
+++ b/xgo/xgoutil/file_test.go
@@ -21,183 +21,158 @@ import (
 	"testing"
 
 	"github.com/goplus/xgo/ast"
-	"github.com/goplus/xgolsw/xgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPosFilename(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		astFile, err := proj.ASTFile("main.xgo")
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
 		xPos := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0].Pos()
-		filename := PosFilename(proj, xPos)
-		require.NotEmpty(t, filename)
-		assert.Contains(t, filename, "main.xgo")
+		filename := PosFilename(fset, xPos)
+		assert.Equal(t, "main.xgo", filename)
 	})
 
-	t.Run("NilProject", func(t *testing.T) {
+	t.Run("NilFileSet", func(t *testing.T) {
 		filename := PosFilename(nil, token.Pos(1))
 		assert.Empty(t, filename)
 	})
 
 	t.Run("InvalidPos", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		filename := PosFilename(proj, token.NoPos)
+		fset := token.NewFileSet()
+		filename := PosFilename(fset, token.NoPos)
 		assert.Empty(t, filename)
 	})
 }
 
 func TestNodeFilename(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		astFile, err := proj.ASTFile("main.xgo")
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
 		xDecl := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0]
-		filename := NodeFilename(proj, xDecl)
-		require.NotEmpty(t, filename)
-		assert.Contains(t, filename, "main.xgo")
+		filename := NodeFilename(fset, xDecl)
+		assert.Equal(t, "main.xgo", filename)
 	})
 
-	t.Run("NilProject", func(t *testing.T) {
+	t.Run("NilFileSet", func(t *testing.T) {
 		filename := NodeFilename(nil, &ast.Ident{Name: "test"})
 		assert.Empty(t, filename)
 	})
 
 	t.Run("NilNode", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		filename := NodeFilename(proj, nil)
+		fset := token.NewFileSet()
+		filename := NodeFilename(fset, nil)
 		assert.Empty(t, filename)
 	})
 }
 
 func TestPosTokenFile(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		astFile, err := proj.ASTFile("main.xgo")
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
 		xPos := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0].Pos()
-		file := PosTokenFile(proj, xPos)
+		file := PosTokenFile(fset, xPos)
 		assert.NotNil(t, file)
+		assert.Equal(t, "main.xgo", file.Name())
 	})
 
-	t.Run("NilProject", func(t *testing.T) {
+	t.Run("NilFileSet", func(t *testing.T) {
 		file := PosTokenFile(nil, token.Pos(1))
 		assert.Nil(t, file)
 	})
 
 	t.Run("InvalidPos", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		file := PosTokenFile(proj, token.NoPos)
+		fset := token.NewFileSet()
+		file := PosTokenFile(fset, token.NoPos)
 		assert.Nil(t, file)
 	})
 }
 
 func TestNodeTokenFile(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		astFile, err := proj.ASTFile("main.xgo")
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
 
 		xDecl := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0]
-		file := NodeTokenFile(proj, xDecl)
+		file := NodeTokenFile(fset, xDecl)
 		assert.NotNil(t, file)
+		assert.Equal(t, "main.xgo", file.Name())
 	})
 
-	t.Run("NilProject", func(t *testing.T) {
+	t.Run("NilFileSet", func(t *testing.T) {
 		file := NodeTokenFile(nil, &ast.Ident{Name: "test"})
 		assert.Nil(t, file)
 	})
 
 	t.Run("NilNode", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		file := NodeTokenFile(proj, nil)
+		fset := token.NewFileSet()
+		file := NodeTokenFile(fset, nil)
 		assert.Nil(t, file)
 	})
 }
 
 func TestPosASTFile(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		astFile, err := proj.ASTFile("main.xgo")
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
+		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
 		xPos := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0].Pos()
-		file := PosASTFile(proj, xPos)
+		file := PosASTFile(fset, astPkg, xPos)
 		assert.Equal(t, astFile, file)
 	})
 
-	t.Run("NilProject", func(t *testing.T) {
-		file := PosASTFile(nil, token.Pos(1))
+	t.Run("NilFileSet", func(t *testing.T) {
+		astPkg := newTestPackage(nil)
+		file := PosASTFile(nil, astPkg, token.Pos(1))
+		assert.Nil(t, file)
+	})
+
+	t.Run("NilPackage", func(t *testing.T) {
+		fset := token.NewFileSet()
+		file := PosASTFile(fset, nil, token.Pos(1))
 		assert.Nil(t, file)
 	})
 
 	t.Run("InvalidPos", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		file := PosASTFile(proj, token.NoPos)
+		fset := token.NewFileSet()
+		astPkg := newTestPackage(nil)
+		file := PosASTFile(fset, astPkg, token.NoPos)
 		assert.Nil(t, file)
 	})
 }
 
 func TestNodeASTFile(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		astFile, err := proj.ASTFile("main.xgo")
+		fset, astFile, err := newTestFile("main.xgo", "var x = 1")
 		require.NoError(t, err)
+		astPkg := newTestPackage(map[string]*ast.File{"main.xgo": astFile})
 
 		xDecl := astFile.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Names[0]
-		file := NodeASTFile(proj, xDecl)
+		file := NodeASTFile(fset, astPkg, xDecl)
 		assert.Equal(t, astFile, file)
 	})
 
-	t.Run("NilProject", func(t *testing.T) {
-		file := NodeASTFile(nil, &ast.Ident{Name: "test"})
+	t.Run("NilFileSet", func(t *testing.T) {
+		astPkg := newTestPackage(nil)
+		file := NodeASTFile(nil, astPkg, &ast.Ident{Name: "test"})
+		assert.Nil(t, file)
+	})
+
+	t.Run("NilPackage", func(t *testing.T) {
+		fset := token.NewFileSet()
+		file := NodeASTFile(fset, nil, &ast.Ident{Name: "test"})
 		assert.Nil(t, file)
 	})
 
 	t.Run("NilNode", func(t *testing.T) {
-		proj := xgo.NewProject(nil, map[string]*xgo.File{
-			"main.xgo": file("var x = 1"),
-		}, xgo.FeatAll)
-
-		file := NodeASTFile(proj, nil)
+		fset := token.NewFileSet()
+		astPkg := newTestPackage(nil)
+		file := NodeASTFile(fset, astPkg, nil)
 		assert.Nil(t, file)
 	})
 }

--- a/xgo/xgoutil/pkg_test.go
+++ b/xgo/xgoutil/pkg_test.go
@@ -41,8 +41,7 @@ func TestIsMarkedAsXGoPackage(t *testing.T) {
 
 	t.Run("PackageWithXGoPackageMarker", func(t *testing.T) {
 		pkg := types.NewPackage("test", "test")
-		scope := pkg.Scope()
-		scope.Insert(types.NewConst(0, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(true)))
+		markAsXGoPackage(pkg)
 		assert.True(t, IsMarkedAsXGoPackage(pkg))
 	})
 

--- a/xgo/xgoutil/scope.go
+++ b/xgo/xgoutil/scope.go
@@ -21,21 +21,17 @@ import (
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	"github.com/goplus/xgolsw/xgo"
+	xgotypes "github.com/goplus/xgolsw/xgo/types"
 )
 
 // InnermostScopeAt returns the innermost scope that contains the given
 // position. It returns nil if not found.
-func InnermostScopeAt(proj *xgo.Project, pos token.Pos) *types.Scope {
-	if !pos.IsValid() {
+func InnermostScopeAt(fset *token.FileSet, typeInfo *xgotypes.Info, astPkg *ast.Package, pos token.Pos) *types.Scope {
+	if fset == nil || typeInfo == nil || astPkg == nil || !pos.IsValid() {
 		return nil
 	}
 
-	typeInfo, _ := proj.TypeInfo()
-	if typeInfo == nil {
-		return nil
-	}
-	astFile := PosASTFile(proj, pos)
+	astFile := PosASTFile(fset, astPkg, pos)
 	if astFile == nil {
 		return nil
 	}

--- a/xgo/xgoutil/struct_test.go
+++ b/xgo/xgoutil/struct_test.go
@@ -17,7 +17,6 @@
 package xgoutil
 
 import (
-	"go/constant"
 	"go/token"
 	"go/types"
 	"testing"
@@ -119,8 +118,7 @@ func TestIsXGoClassStructType(t *testing.T) {
 		pkg := types.NewPackage("test", "test")
 
 		// Mark package as XGo package.
-		scope := pkg.Scope()
-		scope.Insert(types.NewConst(token.NoPos, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(true)))
+		markAsXGoPackage(pkg)
 
 		structType := types.NewStruct([]*types.Var{}, []string{})
 		typeName := types.NewTypeName(token.NoPos, pkg, "SomeOtherType", structType)
@@ -132,8 +130,7 @@ func TestIsXGoClassStructType(t *testing.T) {
 		pkg := types.NewPackage(spxPkgPath, "spx")
 
 		// Mark package as XGo package.
-		scope := pkg.Scope()
-		scope.Insert(types.NewConst(token.NoPos, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(true)))
+		markAsXGoPackage(pkg)
 
 		structType := types.NewStruct([]*types.Var{}, []string{})
 		typeName := types.NewTypeName(token.NoPos, pkg, "Game", structType)
@@ -145,8 +142,7 @@ func TestIsXGoClassStructType(t *testing.T) {
 		pkg := types.NewPackage(spxPkgPath, "spx")
 
 		// Mark package as XGo package.
-		scope := pkg.Scope()
-		scope.Insert(types.NewConst(token.NoPos, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(true)))
+		markAsXGoPackage(pkg)
 
 		structType := types.NewStruct([]*types.Var{}, []string{})
 		typeName := types.NewTypeName(token.NoPos, pkg, "SpriteImpl", structType)
@@ -166,8 +162,7 @@ func TestIsXGoClassStructType(t *testing.T) {
 		pkg := types.NewPackage(spxPkgPath, "spx")
 
 		// Mark package as XGo package.
-		scope := pkg.Scope()
-		scope.Insert(types.NewConst(token.NoPos, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(true)))
+		markAsXGoPackage(pkg)
 
 		structType := types.NewStruct([]*types.Var{}, []string{})
 		typeName := types.NewTypeName(token.NoPos, pkg, "Sprite", structType)
@@ -407,8 +402,7 @@ func TestWalkStruct(t *testing.T) {
 		pkg := types.NewPackage(spxPkgPath, "spx")
 
 		// Mark package as XGo package.
-		scope := pkg.Scope()
-		scope.Insert(types.NewConst(token.NoPos, pkg, XGoPackage, types.Typ[types.UntypedBool], constant.MakeBool(true)))
+		markAsXGoPackage(pkg)
 
 		// Create XGo class struct.
 		field := types.NewField(token.NoPos, pkg, "TestField", types.Typ[types.String], false)

--- a/xgo/xgoutil/xgoutil.go
+++ b/xgo/xgoutil/xgoutil.go
@@ -25,12 +25,11 @@ import (
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	"github.com/goplus/xgolsw/xgo"
+	xgotypes "github.com/goplus/xgolsw/xgo/types"
 )
 
 // RangeASTSpecs iterates all XGo AST specs.
-func RangeASTSpecs(proj *xgo.Project, tok token.Token, f func(spec ast.Spec)) {
-	astPkg, _ := proj.ASTPackage()
+func RangeASTSpecs(astPkg *ast.Package, tok token.Token, f func(spec ast.Spec)) {
 	if astPkg == nil {
 		return
 	}
@@ -45,18 +44,17 @@ func RangeASTSpecs(proj *xgo.Project, tok token.Token, f func(spec ast.Spec)) {
 	}
 }
 
-// IsDefinedInClassFieldsDecl reports whether the given object is defined in
-// the class fields declaration of an AST file.
-func IsDefinedInClassFieldsDecl(proj *xgo.Project, obj types.Object) bool {
-	typeInfo, _ := proj.TypeInfo()
-	if typeInfo == nil {
+// IsDefinedInClassFieldsDecl reports whether the given object is defined in the
+// class fields declaration of an AST file.
+func IsDefinedInClassFieldsDecl(fset *token.FileSet, typeInfo *xgotypes.Info, astPkg *ast.Package, obj types.Object) bool {
+	if fset == nil || typeInfo == nil || astPkg == nil || obj == nil {
 		return false
 	}
-	defIdent := typeInfo.DefIdentFor(obj)
+	defIdent := typeInfo.ObjToDef[obj]
 	if defIdent == nil {
 		return false
 	}
-	astFile := NodeASTFile(proj, defIdent)
+	astFile := NodeASTFile(fset, astPkg, defIdent)
 	if astFile == nil {
 		return false
 	}


### PR DESCRIPTION
- Migrate from `xgo.TypeInfo` to new `xgo/types.Info`
- Replace `xgo.Project` parameters with explicit dependencies (`fset`, `typeInfo`, `astPkg`)
- Update func signatures across `xgoutil` package for better modularity

Fixes #160