### PR TITLE
fix(completion): improve composite literal completion in return statements

### DIFF
--- a/xgo/xgoutil/type.go
+++ b/xgo/xgoutil/type.go
@@ -53,6 +53,25 @@ func IsTypesCompatible(got, want types.Type) bool {
 		gotCh, ok := got.(*types.Chan)
 		return ok && types.Identical(want.Elem(), gotCh.Elem()) &&
 			(want.Dir() == types.SendRecv || want.Dir() == gotCh.Dir())
+	case *types.Signature:
+		gotSig, ok := got.(*types.Signature)
+		if !ok {
+			return false
+		}
+		if want.Results().Len() != gotSig.Results().Len() {
+			return false
+		}
+		if want.Results().Len() == 0 {
+			return true
+		}
+		return IsTypesCompatible(gotSig.Results().At(0).Type(), want.Results().At(0).Type())
+	}
+
+	if gotSig, ok := got.(*types.Signature); ok {
+		if gotSig.Results().Len() != 1 {
+			return false
+		}
+		return IsTypesCompatible(gotSig.Results().At(0).Type(), want)
 	}
 
 	if _, ok := got.(*types.Named); ok {

--- a/xgo/xgoutil/type_test.go
+++ b/xgo/xgoutil/type_test.go
@@ -128,6 +128,7 @@ func TestIsTypesCompatible(t *testing.T) {
 		// Non-slice to slice.
 		assert.False(t, IsTypesCompatible(types.Typ[types.Int], intSlice))
 	})
+
 	t.Run("ChannelTypes", func(t *testing.T) {
 		intChanSendRecv := types.NewChan(types.SendRecv, types.Typ[types.Int])
 		intChanSend := types.NewChan(types.SendOnly, types.Typ[types.Int])
@@ -156,6 +157,39 @@ func TestIsTypesCompatible(t *testing.T) {
 
 		// Non-channel to channel.
 		assert.False(t, IsTypesCompatible(types.Typ[types.Int], intChanSendRecv))
+	})
+
+	t.Run("SignatureTypes", func(t *testing.T) {
+		noResultWant := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(), false)
+		noResultGot := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(), false)
+		assert.True(t, IsTypesCompatible(noResultGot, noResultWant))
+
+		intResultVar := types.NewVar(0, nil, "", types.Typ[types.Int])
+		intResultSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(intResultVar), false)
+		otherIntResultSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int])), false)
+		assert.True(t, IsTypesCompatible(otherIntResultSig, intResultSig))
+
+		stringResultSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.String])), false)
+		assert.False(t, IsTypesCompatible(otherIntResultSig, stringResultSig))
+
+		twoResultsSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(
+			types.NewVar(0, nil, "", types.Typ[types.Int]),
+			types.NewVar(0, nil, "", types.Typ[types.Int]),
+		), false)
+		assert.False(t, IsTypesCompatible(twoResultsSig, intResultSig))
+
+		ptrToInt := types.NewPointer(types.Typ[types.Int])
+		ptrResultSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", ptrToInt)), false)
+		ptrWantSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", ptrToInt)), false)
+		assert.True(t, IsTypesCompatible(ptrResultSig, ptrWantSig))
+
+		ptrToString := types.NewPointer(types.Typ[types.String])
+		ptrStringSig := types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(types.NewVar(0, nil, "", ptrToString)), false)
+		assert.False(t, IsTypesCompatible(ptrResultSig, ptrStringSig))
+
+		assert.True(t, IsTypesCompatible(otherIntResultSig, types.Typ[types.Int]))
+		assert.False(t, IsTypesCompatible(twoResultsSig, types.Typ[types.Int]))
+		assert.False(t, IsTypesCompatible(stringResultSig, types.Typ[types.Int]))
 	})
 
 	t.Run("NamedTypes", func(t *testing.T) {


### PR DESCRIPTION
Improve completion logic to provide variable suggestions when cursor is positioned in value expressions within composite literals (maps/structs) in return statements, instead of restricting to return type completion.

Updates goplus/builder#2219