### PR TITLE
feat: add spx resource reference inspection for return statements

### DIFF
--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -762,14 +762,10 @@ func inferSpxInputTypeFromType(typ types.Type) SpxInputType {
 		return SpxInputTypeUnknown
 	}
 
-	switch typ {
-	case GetSpxBackdropNameType(),
-		GetSpxSoundNameType(),
-		GetSpxSpriteNameType(),
-		GetSpxSpriteCostumeNameType(),
-		GetSpxSpriteAnimationNameType(),
-		GetSpxWidgetNameType():
+	if IsSpxResourceNameType(typ) {
 		return SpxInputTypeResourceName
+	}
+	switch typ {
 	case GetSpxDirectionType():
 		return SpxInputTypeDirection
 	case GetSpxLayerActionType():

--- a/internal/server/spx_definition.go
+++ b/internal/server/spx_definition.go
@@ -989,15 +989,23 @@ func HasSpxResourceNameTypeParams(fun *types.Func) (has bool) {
 		if slice, ok := paramType.(*types.Slice); ok {
 			paramType = slice.Elem()
 		}
-		switch paramType {
-		case GetSpxBackdropNameType(),
-			GetSpxSpriteNameType(),
-			GetSpxSpriteCostumeNameType(),
-			GetSpxSpriteAnimationNameType(),
-			GetSpxSoundNameType(),
-			GetSpxWidgetNameType():
+		if IsSpxResourceNameType(paramType) {
 			return true
 		}
+	}
+	return false
+}
+
+// IsSpxResourceNameType reports whether the given type is a spx resource name type.
+func IsSpxResourceNameType(typ types.Type) bool {
+	switch typ {
+	case GetSpxBackdropNameType(),
+		GetSpxSpriteNameType(),
+		GetSpxSpriteCostumeNameType(),
+		GetSpxSpriteAnimationNameType(),
+		GetSpxSoundNameType(),
+		GetSpxWidgetNameType():
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
- Enhance spx resource reference inspection to detect resource references in return statements
- Add `resolveReturnTypeForExpr` to analyze function return types and identify resource name types
- Add `IsSpxResourceNameType` helper function to centralize spx resource type checking
- Add utility functions for AST traversal: `EnclosingNode`, `EnclosingFuncSignature`, `EnclosingReturnStmt`, and `ReturnValueIndex`