### PR TITLE
feat(server): support source-facing autoclosure parameters

### DIFF
--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -1420,7 +1420,7 @@ func (ctx *completionContext) collectCall() error {
 	}
 
 	if argIndex < sig.Params().Len() {
-		ctx.expectedTypes = []gotypes.Type{sig.Params().At(argIndex).Type()}
+		ctx.expectedTypes = []gotypes.Type{xgoutil.SourceParamType(sig.Params().At(argIndex))}
 	} else if sig.Variadic() && argIndex >= sig.Params().Len()-1 {
 		ctx.expectedTypes = []gotypes.Type{sig.Params().At(sig.Params().Len() - 1).Type().(*gotypes.Slice).Elem()}
 	}
@@ -1441,7 +1441,7 @@ func (ctx *completionContext) collectFuncDecoratorCall(callExpr *ast.CallExpr) e
 	}
 	argIndex := ctx.getCurrentArgIndex(callExpr)
 	if argIndex >= 0 && argIndex < params.Len() {
-		ctx.expectedTypes = []gotypes.Type{params.At(argIndex).Type()}
+		ctx.expectedTypes = []gotypes.Type{xgoutil.SourceParamType(params.At(argIndex))}
 	}
 	return ctx.collectGeneral()
 }

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -130,6 +130,48 @@ onStart => {
 		}))
 	})
 
+	t.Run("Autoclosure", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`const (
+	enabled = true
+	entry = "text"
+)
+
+onStart => {
+
+	repeatUntil e, => {}
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		signatureItemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 6, Character: 1},
+			},
+		})
+		require.NoError(t, err)
+		signatureItems := requireValueAs[[]CompletionItem](t, signatureItemsResult)
+		repeatUntilItem := completionItemByLabel(signatureItems, "repeatUntil")
+		require.NotNilf(t, repeatUntilItem, "%v", completionItemLabels(signatureItems))
+		require.NotNil(t, repeatUntilItem.Documentation)
+		documentation := requireValueAs[MarkupContent](t, repeatUntilItem.Documentation.Value)
+		assert.Contains(t, documentation.Value, `overview="func repeatUntil(condition bool, call func())"`)
+
+		argumentItemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 7, Character: 14},
+			},
+		})
+		require.NoError(t, err)
+		argumentItems := requireValueAs[[]CompletionItem](t, argumentItemsResult)
+		assert.Truef(t, containsCompletionItemLabel(argumentItems, "enabled"), "%v", completionItemLabels(argumentItems))
+		assert.Falsef(t, containsCompletionItemLabel(argumentItems, "entry"), "%v", completionItemLabels(argumentItems))
+	})
+
 	t.Run("FuncDecoratorArgument", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`const (

--- a/internal/server/format.go
+++ b/internal/server/format.go
@@ -760,7 +760,7 @@ func callExprArgType(sig *gotypes.Signature, params *gotypes.Tuple, paramIndex i
 		}
 		return nil
 	}
-	return param.Type()
+	return xgoutil.SourceParamType(param)
 }
 
 // callExprParam returns the positional parameter at paramIndex and normalizes

--- a/internal/server/format_test.go
+++ b/internal/server/format_test.go
@@ -961,23 +961,52 @@ func TestOverloadMatchesCallExpr(t *testing.T) {
 }
 
 func TestCallExprArgType(t *testing.T) {
-	pkg := gotypes.NewPackage("main", "main")
-	handlerType := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
-	sig := gotypes.NewSignatureType(
-		nil,
-		nil,
-		nil,
-		gotypes.NewTuple(
-			gotypes.NewParam(token.NoPos, pkg, "name", gotypes.Typ[gotypes.String]),
-			gotypes.NewParam(token.NoPos, pkg, "handlers", gotypes.NewSlice(handlerType)),
-		),
-		nil,
-		true,
-	)
-	params := sig.Params()
+	t.Run("Variadic", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		handlerType := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+		sig := gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(
+				gotypes.NewParam(token.NoPos, pkg, "name", gotypes.Typ[gotypes.String]),
+				gotypes.NewParam(token.NoPos, pkg, "handlers", gotypes.NewSlice(handlerType)),
+			),
+			nil,
+			true,
+		)
+		params := sig.Params()
 
-	assert.Equal(t, gotypes.Typ[gotypes.String], callExprArgType(sig, params, 0))
-	assert.True(t, gotypes.Identical(handlerType, callExprArgType(sig, params, 1)))
-	assert.True(t, gotypes.Identical(handlerType, callExprArgType(sig, params, 2)))
-	assert.Nil(t, callExprArgType(sig, params, -1))
+		assert.Equal(t, gotypes.Typ[gotypes.String], callExprArgType(sig, params, 0))
+		assert.True(t, gotypes.Identical(handlerType, callExprArgType(sig, params, 1)))
+		assert.True(t, gotypes.Identical(handlerType, callExprArgType(sig, params, 2)))
+		assert.Nil(t, callExprArgType(sig, params, -1))
+	})
+
+	t.Run("Autoclosure", func(t *testing.T) {
+		pkg := gotypes.NewPackage("main", "main")
+		autoclosureType := gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", gotypes.Typ[gotypes.Bool])),
+			false,
+		)
+		sig := gotypes.NewSignatureType(
+			nil,
+			nil,
+			nil,
+			gotypes.NewTuple(gotypes.NewParam(
+				token.NoPos,
+				pkg,
+				"__xgo_autoclosure_condition",
+				autoclosureType,
+			)),
+			nil,
+			false,
+		)
+
+		assert.Equal(t, gotypes.Typ[gotypes.Bool], callExprArgType(sig, sig.Params(), 0))
+	})
 }

--- a/internal/server/hover_test.go
+++ b/internal/server/hover_test.go
@@ -423,6 +423,28 @@ onTouchStart "MySprite", => {}
 		}, onTouchStartFirstArgHover)
 	})
 
+	t.Run("Autoclosure", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	repeatUntil true, => {}
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		hover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 2, Character: 2},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Contains(t, hover.Contents.Value, `overview="func repeatUntil(condition bool, call func())"`)
+	})
+
 	t.Run("InvalidPosition", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`var x int`),

--- a/internal/server/inlay_hint.go
+++ b/internal/server/inlay_hint.go
@@ -127,6 +127,9 @@ func collectInlayHintsFromCallExpr(result *compileResult, callExpr *ast.CallExpr
 			Label:    label,
 			Kind:     Parameter,
 		}
+		if _, ok := xgoutil.AutoclosureParamResultType(resolvedArg.Param); ok {
+			hint.Tooltip = &InlayHintTooltip{Value: autoclosureParamDocumentation}
+		}
 		key := hintKeyFor(hint)
 		if existingHint, ok := hintsByKey[key]; ok {
 			if existingHint.Label != hint.Label {

--- a/internal/server/inlay_hint_test.go
+++ b/internal/server/inlay_hint_test.go
@@ -96,6 +96,35 @@ func run() {
 		})
 	})
 
+	t.Run("Autoclosure", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	repeatUntil true, => {}
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		inlayHints, err := s.textDocumentInlayHint(&InlayHintParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			Range: Range{
+				Start: Position{Line: 0, Character: 0},
+				End:   Position{Line: 4, Character: 0},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []InlayHint{
+			{
+				Position: Position{Line: 2, Character: 13},
+				Label:    "condition",
+				Kind:     Parameter,
+				Tooltip:  &InlayHintTooltip{Value: autoclosureParamDocumentation},
+			},
+		}, inlayHints)
+	})
+
 	t.Run("PartialXGoxFunction", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`import "example.com/typeargs"

--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -97,9 +97,10 @@ type (
 	DidCloseTextDocumentParams  = protocol.DidCloseTextDocumentParams
 	DidSaveTextDocumentParams   = protocol.DidSaveTextDocumentParams
 
-	InlayHintParams = protocol.InlayHintParams
-	InlayHint       = protocol.InlayHint
-	InlayHintKind   = protocol.InlayHintKind
+	InlayHintParams  = protocol.InlayHintParams
+	InlayHint        = protocol.InlayHint
+	InlayHintKind    = protocol.InlayHintKind
+	InlayHintTooltip = protocol.OrPTooltip_textDocument_inlayHint
 )
 
 const (

--- a/internal/server/signature.go
+++ b/internal/server/signature.go
@@ -12,6 +12,8 @@ import (
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
+const autoclosureParamDocumentation = "Deferred expression. The callee controls when and how often it is evaluated."
+
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_signatureHelp
 func (s *Server) textDocumentSignatureHelp(params *SignatureHelpParams) (*SignatureHelp, error) {
 	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
@@ -153,10 +155,11 @@ func signatureHelpInformation(fun *gotypes.Func, sig *gotypes.Signature, params 
 	for i := range params.Len() {
 		paramLabel := signatureHelpParameterLabel(fun, sig, params, i)
 		paramLabels = append(paramLabels, paramLabel)
-		paramInfos = append(paramInfos, ParameterInformation{
-			Label: paramLabel,
-			// TODO: Add documentation.
-		})
+		paramInfo := ParameterInformation{Label: paramLabel}
+		if _, ok := xgoutil.AutoclosureParamResultType(params.At(i)); ok {
+			paramInfo.Documentation = autoclosureParamDocumentation
+		}
+		paramInfos = append(paramInfos, paramInfo)
 	}
 
 	labelName := displayedName
@@ -273,14 +276,7 @@ func signatureHelpParameterLabel(fun *gotypes.Func, sig *gotypes.Signature, para
 	if paramIndex < xgoutil.NormalizedCallExprTypeArgCount(fun, params) {
 		return xgoutil.SourceParamName(param) + " Type"
 	}
-	paramType := param.Type()
-	typeLabel := GetSimplifiedTypeString(paramType)
-	if sig.Variadic() && paramIndex == params.Len()-1 {
-		if slice, ok := paramType.(*gotypes.Slice); ok {
-			typeLabel = "..." + GetSimplifiedTypeString(slice.Elem())
-		}
-	}
-	return xgoutil.SourceParamName(param) + " " + typeLabel
+	return sourceParamLabel(sig, params, paramIndex)
 }
 
 // overloadSignatureHelpActiveParameter resolves the active parameter for one

--- a/internal/server/signature_test.go
+++ b/internal/server/signature_test.go
@@ -62,6 +62,41 @@ onStart => {
 		}, turnHelp.Signatures[0])
 	})
 
+	t.Run("Autoclosure", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	repeatUntil true, => {}
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 2, Character: 17},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, help)
+		require.Len(t, help.Signatures, 1)
+		assert.Equal(t, uint32(0), help.ActiveParameter)
+		assert.Equal(t, SignatureInformation{
+			Label: "repeatUntil(condition bool, call func())",
+			Parameters: []ParameterInformation{
+				{
+					Label:         "condition bool",
+					Documentation: autoclosureParamDocumentation,
+				},
+				{
+					Label: "call func()",
+				},
+			},
+		}, help.Signatures[0])
+	})
+
 	t.Run("FuncDecorator", func(t *testing.T) {
 		m := map[string][]byte{
 			"main.spx": []byte(`func retry(times int, fn func()) {

--- a/internal/server/spx_definition.go
+++ b/internal/server/spx_definition.go
@@ -925,32 +925,18 @@ func displayedFuncResults(results *gotypes.Tuple) string {
 // displayedFuncParamLabels formats the source-facing parameter list for
 // function signatures shown in spx UI surfaces.
 func displayedFuncParamLabels(sig *gotypes.Signature, isXGotMethod bool) []string {
-	params := make([]string, 0, sig.TypeParams().Len()+sig.Params().Len())
+	labels := make([]string, 0, sig.TypeParams().Len()+sig.Params().Len())
 	for typeParam := range sig.TypeParams().TypeParams() {
-		params = append(params, typeParam.Obj().Name()+" Type")
+		labels = append(labels, typeParam.Obj().Name()+" Type")
 	}
-	for i := range sig.Params().Len() {
+	params := sig.Params()
+	for i := range params.Len() {
 		if isXGotMethod && i == 0 {
 			continue
 		}
-		params = append(params, displayedFuncParamLabel(sig, i))
+		labels = append(labels, sourceParamLabel(sig, params, i))
 	}
-	return params
-}
-
-// displayedFuncParamLabel formats one source-facing function parameter label.
-func displayedFuncParamLabel(sig *gotypes.Signature, paramIndex int) string {
-	param := sig.Params().At(paramIndex)
-	paramType := param.Type()
-	paramTypeName := GetSimplifiedTypeString(paramType)
-
-	if sig.Variadic() && paramIndex == sig.Params().Len()-1 {
-		if slice, ok := paramType.(*gotypes.Slice); ok {
-			paramTypeName = "..." + GetSimplifiedTypeString(slice.Elem())
-		}
-	}
-
-	return param.Name() + " " + paramTypeName
+	return labels
 }
 
 // makeSpxDefinitionOverviewForFunc makes an overview string for a function that

--- a/internal/server/spx_util.go
+++ b/internal/server/spx_util.go
@@ -38,6 +38,19 @@ func GetSimplifiedTypeString(typ gotypes.Type) string {
 	})
 }
 
+// sourceParamLabel formats a source-facing function parameter label.
+func sourceParamLabel(sig *gotypes.Signature, params *gotypes.Tuple, paramIndex int) string {
+	param := params.At(paramIndex)
+	paramType := xgoutil.SourceParamType(param)
+	typeName := GetSimplifiedTypeString(paramType)
+	if sig.Variadic() && paramIndex == params.Len()-1 {
+		if slice, ok := paramType.(*gotypes.Slice); ok {
+			typeName = "..." + GetSimplifiedTypeString(slice.Elem())
+		}
+	}
+	return xgoutil.SourceParamName(param) + " " + typeName
+}
+
 // resolvedNamedType resolves aliases and pointer indirections until it reaches
 // a named type. It returns nil if typ does not resolve to a named type.
 func resolvedNamedType(typ gotypes.Type) *gotypes.Named {

--- a/xgo/xgoutil/call_expr.go
+++ b/xgo/xgoutil/call_expr.go
@@ -31,6 +31,9 @@ import (
 )
 
 const (
+	// xgoAutoclosureParamPrefix prefixes generated names for XGo autoclosure parameters.
+	xgoAutoclosureParamPrefix = "__xgo_autoclosure_"
+
 	// xgoOptionalParamPrefix prefixes generated names for current XGo optional parameters.
 	xgoOptionalParamPrefix = "__xgo_optional_"
 
@@ -342,7 +345,7 @@ func resolvedCallExprArgType(sig *gotypes.Signature, params *gotypes.Tuple, para
 	if sig.Variadic() && paramIndex == params.Len()-1 && !ellipsis {
 		return variadicValueType(param.Type())
 	}
-	return param.Type()
+	return SourceParamType(param)
 }
 
 // variadicValueType returns the per-argument type for a variadic parameter.
@@ -355,8 +358,33 @@ func variadicValueType(typ gotypes.Type) gotypes.Type {
 
 // SourceParamName returns the source-facing spelling of param.
 func SourceParamName(param *gotypes.Var) string {
+	if name, ok := strings.CutPrefix(param.Name(), xgoAutoclosureParamPrefix); ok {
+		return name
+	}
 	name, _ := trimOptionalParamPrefix(param.Name())
 	return name
+}
+
+// SourceParamType returns the source-facing type of param.
+func SourceParamType(param *gotypes.Var) gotypes.Type {
+	if resultType, ok := AutoclosureParamResultType(param); ok {
+		return resultType
+	}
+	return param.Type()
+}
+
+// AutoclosureParamResultType returns the result type of param and reports
+// whether param is an XGo autoclosure parameter with an underlying `func() T`
+// type.
+func AutoclosureParamResultType(param *gotypes.Var) (gotypes.Type, bool) {
+	if !strings.HasPrefix(param.Name(), xgoAutoclosureParamPrefix) {
+		return nil, false
+	}
+	sig, ok := param.Type().Underlying().(*gotypes.Signature)
+	if !ok || sig.Params().Len() != 0 || sig.Results().Len() != 1 {
+		return nil, false
+	}
+	return sig.Results().At(0).Type(), true
 }
 
 // isOptionalParam reports whether param is an XGo optional parameter.

--- a/xgo/xgoutil/call_expr_test.go
+++ b/xgo/xgoutil/call_expr_test.go
@@ -60,6 +60,17 @@ func newTestFunc(pkg *gotypes.Package, name string, variadic bool, params ...*go
 	))
 }
 
+func newTestAutoclosureType(pkg *gotypes.Package, resultType gotypes.Type) *gotypes.Signature {
+	return gotypes.NewSignatureType(
+		nil,
+		nil,
+		nil,
+		nil,
+		gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", resultType)),
+		false,
+	)
+}
+
 func newTestKwarg(name, value string) *ast.KwargExpr {
 	return &ast.KwargExpr{
 		Name:  &ast.Ident{Name: name},
@@ -433,13 +444,139 @@ func TestSourceParamName(t *testing.T) {
 		name string
 		want string
 	}{
+		{name: "__xgo_autoclosure_condition", want: "condition"},
 		{name: "__xgo_optional_opts", want: "opts"},
 		{name: "__gop_optional_opts", want: "opts"},
+		{name: "__xgo_internal_condition", want: "__xgo_internal_condition"},
 		{name: "opts", want: "opts"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			param := gotypes.NewParam(token.NoPos, pkg, tt.name, gotypes.Typ[gotypes.Int])
 			assert.Equal(t, tt.want, SourceParamName(param))
+		})
+	}
+}
+
+func TestSourceParamType(t *testing.T) {
+	pkg := gotypes.NewPackage("main", "main")
+	callbackType := gotypes.NewSignatureType(nil, nil, nil, nil, nil, false)
+	typeParam := gotypes.NewTypeParam(
+		gotypes.NewTypeName(token.NoPos, pkg, "T", nil),
+		newTestEmptyInterface(),
+	)
+	namedAutoclosureType := gotypes.NewNamed(
+		gotypes.NewTypeName(token.NoPos, pkg, "Condition", nil),
+		newTestAutoclosureType(pkg, gotypes.Typ[gotypes.Bool]),
+		nil,
+	)
+	namedResultType := gotypes.NewNamed(
+		gotypes.NewTypeName(token.NoPos, pkg, "Flag", nil),
+		gotypes.Typ[gotypes.Bool],
+		nil,
+	)
+	withParamType := gotypes.NewSignatureType(
+		nil,
+		nil,
+		nil,
+		gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "value", gotypes.Typ[gotypes.Int])),
+		gotypes.NewTuple(gotypes.NewParam(token.NoPos, pkg, "", gotypes.Typ[gotypes.Bool])),
+		false,
+	)
+	multipleResultType := gotypes.NewSignatureType(
+		nil,
+		nil,
+		nil,
+		nil,
+		gotypes.NewTuple(
+			gotypes.NewParam(token.NoPos, pkg, "", gotypes.Typ[gotypes.Bool]),
+			gotypes.NewParam(token.NoPos, pkg, "", gotypes.Typ[gotypes.String]),
+		),
+		false,
+	)
+
+	for _, tt := range []struct {
+		name            string
+		paramName       string
+		paramType       gotypes.Type
+		want            gotypes.Type
+		wantAutoclosure bool
+	}{
+		{
+			name:            "Autoclosure",
+			paramName:       "__xgo_autoclosure_condition",
+			paramType:       newTestAutoclosureType(pkg, gotypes.Typ[gotypes.Bool]),
+			want:            gotypes.Typ[gotypes.Bool],
+			wantAutoclosure: true,
+		},
+		{
+			name:            "NamedAutoclosureType",
+			paramName:       "__xgo_autoclosure_condition",
+			paramType:       namedAutoclosureType,
+			want:            gotypes.Typ[gotypes.Bool],
+			wantAutoclosure: true,
+		},
+		{
+			name:            "FunctionResult",
+			paramName:       "__xgo_autoclosure_callback",
+			paramType:       newTestAutoclosureType(pkg, callbackType),
+			want:            callbackType,
+			wantAutoclosure: true,
+		},
+		{
+			name:            "NamedResult",
+			paramName:       "__xgo_autoclosure_value",
+			paramType:       newTestAutoclosureType(pkg, namedResultType),
+			want:            namedResultType,
+			wantAutoclosure: true,
+		},
+		{
+			name:            "GenericResult",
+			paramName:       "__xgo_autoclosure_value",
+			paramType:       newTestAutoclosureType(pkg, typeParam),
+			want:            typeParam,
+			wantAutoclosure: true,
+		},
+		{
+			name:      "OrdinaryCallback",
+			paramName: "condition",
+			paramType: newTestAutoclosureType(pkg, gotypes.Typ[gotypes.Bool]),
+		},
+		{
+			name:      "NonFunctionAutoclosureType",
+			paramName: "__xgo_autoclosure_condition",
+			paramType: gotypes.Typ[gotypes.Bool],
+		},
+		{
+			name:      "AutoclosureWithParameter",
+			paramName: "__xgo_autoclosure_condition",
+			paramType: withParamType,
+		},
+		{
+			name:      "AutoclosureWithoutResult",
+			paramName: "__xgo_autoclosure_condition",
+			paramType: callbackType,
+		},
+		{
+			name:      "AutoclosureWithMultipleResults",
+			paramName: "__xgo_autoclosure_condition",
+			paramType: multipleResultType,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			param := gotypes.NewParam(token.NoPos, pkg, tt.paramName, tt.paramType)
+			want := tt.want
+			if want == nil {
+				want = tt.paramType
+			}
+
+			resultType, ok := AutoclosureParamResultType(param)
+			assert.Equal(t, tt.wantAutoclosure, ok)
+			if tt.wantAutoclosure {
+				assert.True(t, gotypes.Identical(want, resultType))
+			} else {
+				assert.Nil(t, resultType)
+			}
+			assert.True(t, gotypes.Identical(want, SourceParamType(param)))
 		})
 	}
 }
@@ -491,6 +628,28 @@ func TestResolvedCallExprArgs(t *testing.T) {
 		assert.Equal(t, arg2, resolved[1].Arg)
 		assert.Equal(t, 1, resolved[1].ArgIndex)
 		assert.Equal(t, gotypes.Typ[gotypes.String], resolved[1].ExpectedType)
+	})
+
+	t.Run("Autoclosure", func(t *testing.T) {
+		ident := &ast.Ident{Name: "waitUntil"}
+		arg := &ast.Ident{Name: "condition"}
+		expr := &ast.CallExpr{Fun: ident, Args: []ast.Expr{arg}}
+
+		pkg := gotypes.NewPackage("test", "test")
+		param := gotypes.NewParam(
+			token.NoPos,
+			pkg,
+			"__xgo_autoclosure_condition",
+			newTestAutoclosureType(pkg, gotypes.Typ[gotypes.Bool]),
+		)
+		fun := newTestFunc(pkg, "waitUntil", false, param)
+		typeInfo := newTestTypeInfo(nil, map[*ast.Ident]gotypes.Object{ident: fun})
+
+		resolved := slices.Collect(ResolvedCallExprArgs(typeInfo, expr))
+
+		require.Len(t, resolved, 1)
+		assert.Equal(t, param, resolved[0].Param)
+		assert.Equal(t, gotypes.Typ[gotypes.Bool], resolved[0].ExpectedType)
 	})
 
 	t.Run("VariadicFunction", func(t *testing.T) {


### PR DESCRIPTION
Normalize generated autoclosure names and closure types to the parameter names and expression types written in source.

Use the source-facing form for completion, formatting, hover, inlay hints, and signature help. Describe deferred evaluation through standard LSP documentation fields.

Updates goplus/xgo#2818
Updates goplus/builder#3450