### PR TITLE
test(xgo): decouple AST and type checking tests from spx

### DIFF
--- a/xgo/ast_test.go
+++ b/xgo/ast_test.go
@@ -17,6 +17,7 @@
 package xgo
 
 import (
+	"io/fs"
 	"testing"
 
 	"github.com/goplus/xgo/scanner"
@@ -26,18 +27,18 @@ import (
 
 func TestBuildASTFileCache(t *testing.T) {
 	t.Run("ValidFile", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.spx": file(`
-// Package documentation.  
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`
+// Package documentation.
 var x int
 
 func Test() {
 	println("test")
 }
 `),
-		}, FeatAll)
+		}, FeatASTCache)
 
-		cache, err := buildASTFileCache(proj, "main.spx", proj.files["main.spx"])
+		cache, err := buildASTFileCache(proj, "main.xgo", proj.files["main.xgo"])
 		require.NoError(t, err)
 		require.NotNil(t, cache)
 
@@ -54,52 +55,59 @@ func Test() {
 	})
 
 	t.Run("InvalidFile", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"invalid.spx": file(`invalid syntax {{{`),
-		}, FeatAll)
+		proj := newTestProject(t, map[string]*File{
+			"invalid.xgo": file(`invalid syntax {{{`),
+		}, FeatASTCache)
 
-		cache, err := buildASTFileCache(proj, "invalid.spx", proj.files["invalid.spx"])
+		cache, err := buildASTFileCache(proj, "invalid.xgo", proj.files["invalid.xgo"])
 		require.NoError(t, err)
 		require.NotNil(t, cache)
 
 		astFileCache, ok := cache.(*astFileCache)
 		require.True(t, ok)
 
-		// Should have parser error.
-		assert.Error(t, astFileCache.parserErr)
-
-		// Check if it's a scanner error list.
-		if el, ok := astFileCache.parserErr.(scanner.ErrorList); ok {
-			assert.NotEmpty(t, el)
-		}
+		var parserErrs scanner.ErrorList
+		require.ErrorAs(t, astFileCache.parserErr, &parserErrs)
+		assert.NotEmpty(t, parserErrs)
 	})
 
 	t.Run("DifferentFileTypes", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"test.gop": file(`var x int`),
-			"test.xgo": file(`var y string`),
-		}, FeatAll)
-
-		// Test .gop file.
-		cache1, err1 := buildASTFileCache(proj, "test.gop", proj.files["test.gop"])
-		require.NoError(t, err1)
-		require.NotNil(t, cache1)
-
-		// Test .xgo file.
-		cache2, err2 := buildASTFileCache(proj, "test.xgo", proj.files["test.xgo"])
-		require.NoError(t, err2)
-		require.NotNil(t, cache2)
-
-		astFileCache1, ok := cache1.(*astFileCache)
-		require.True(t, ok)
-		astFileCache2, ok := cache2.(*astFileCache)
-		require.True(t, ok)
-		assert.NotNil(t, astFileCache1.astFile)
-		assert.NotNil(t, astFileCache2.astFile)
+		for _, tt := range []struct {
+			name        string
+			filename    string
+			isClass     bool
+			isProj      bool
+			isNormalGox bool
+		}{
+			{name: "XGo", filename: "main.xgo"},
+			{name: "Gop", filename: "main.gop"},
+			{name: "NormalClass", filename: "Record.gox", isClass: true, isNormalGox: true},
+			{name: "ProjectClass", filename: "main_fixture.gox", isClass: true, isProj: true},
+			{name: "WorkClass", filename: "Worker_fixture.gox", isClass: true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				proj := newTestProject(t, map[string]*File{tt.filename: file(`var value int`)}, FeatASTCache)
+				cache, err := buildASTFileCache(proj, tt.filename, proj.files[tt.filename])
+				require.NoError(t, err)
+				astCache, ok := cache.(*astFileCache)
+				require.True(t, ok)
+				require.NoError(t, astCache.parserErr)
+				astFile := astCache.astFile
+				require.NotNil(t, astFile)
+				assert.Equal(t, tt.isClass, astFile.IsClass)
+				assert.Equal(t, tt.isProj, astFile.IsProj)
+				assert.Equal(t, tt.isNormalGox, astFile.IsNormalGox)
+				if tt.isClass {
+					assert.NotNil(t, astFile.ClassFields)
+				} else {
+					assert.Nil(t, astFile.ClassFields)
+				}
+			})
+		}
 	})
 
 	t.Run("RecoverFromPanic", func(t *testing.T) {
-		cache, err := buildASTFileCache(nil, "main.spx", file(`var x int`))
+		cache, err := buildASTFileCache(nil, "main.xgo", file(`var x int`))
 		assert.Nil(t, cache)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parser panic")
@@ -108,8 +116,8 @@ func Test() {
 
 func TestProjectASTFile(t *testing.T) {
 	t.Run("ValidFile", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.spx": file(`
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`
 // Package documentation.
 var x int
 
@@ -117,9 +125,9 @@ func Test() {
 	println("test")
 }
 `),
-		}, FeatAll)
+		}, FeatASTCache)
 
-		astFile, err := proj.ASTFile("main.spx")
+		astFile, err := proj.ASTFile("main.xgo")
 		require.NoError(t, err)
 		require.NotNil(t, astFile)
 
@@ -129,46 +137,39 @@ func Test() {
 	})
 
 	t.Run("InvalidFile", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"invalid.spx": file(`invalid syntax {{{`),
-		}, FeatAll)
+		proj := newTestProject(t, map[string]*File{
+			"invalid.xgo": file(`invalid syntax {{{`),
+		}, FeatASTCache)
 
-		astFile, err := proj.ASTFile("invalid.spx")
-		// Should have error but may still return partial AST.
-		assert.Error(t, err)
-
-		// May or may not have partial AST depending on how severe the error is.
-		_ = astFile
-
-		// Check if it's a scanner error list.
-		if el, ok := err.(scanner.ErrorList); ok {
-			assert.NotEmpty(t, el)
-		}
+		_, err := proj.ASTFile("invalid.xgo")
+		var parserErrs scanner.ErrorList
+		require.ErrorAs(t, err, &parserErrs)
+		assert.NotEmpty(t, parserErrs)
 	})
 
 	t.Run("NonExistentFile", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.spx": file(`var x int`),
-		}, FeatAll)
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`var x int`),
+		}, FeatASTCache)
 
-		astFile, err := proj.ASTFile("nonexistent.spx")
-		assert.Error(t, err)
+		astFile, err := proj.ASTFile("nonexistent.xgo")
+		assert.ErrorIs(t, err, fs.ErrNotExist)
 		assert.Nil(t, astFile)
 	})
 }
 
 func TestBuildASTPackageCache(t *testing.T) {
 	t.Run("ValidPackage", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.spx": file(`
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`
 var mainVar int
 func MainFunc() {}
 `),
-			"sprite.spx": file(`
-var spriteVar string  
-func SpriteFunc() {}
+			"Worker.gox": file(`
+var workVar string
+func WorkFunc() {}
 `),
-		}, FeatAll)
+		}, FeatASTCache)
 
 		cache, err := buildASTPackageCache(proj)
 		require.NoError(t, err)
@@ -183,18 +184,18 @@ func SpriteFunc() {}
 		astPkg := astPackageCache.astPkg
 		assert.Equal(t, "main", astPkg.Name)
 		assert.Len(t, astPkg.Files, 2)
-		assert.Contains(t, astPkg.Files, "main.spx")
-		assert.Contains(t, astPkg.Files, "sprite.spx")
+		assert.Contains(t, astPkg.Files, "main.xgo")
+		assert.Contains(t, astPkg.Files, "Worker.gox")
 	})
 
 	t.Run("PartiallyValidPackage", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"valid.spx": file(`
+		proj := newTestProject(t, map[string]*File{
+			"valid.xgo": file(`
 var validVar int
 func ValidFunc() {}
 `),
-			"invalid.spx": file(`invalid syntax {{{`),
-		}, FeatAll)
+			"invalid.xgo": file(`invalid syntax {{{`),
+		}, FeatASTCache)
 
 		cache, err := buildASTPackageCache(proj)
 		require.NoError(t, err)
@@ -210,13 +211,13 @@ func ValidFunc() {}
 		// Should still contain the valid file.
 		astPkg := astPackageCache.astPkg
 		assert.Equal(t, "main", astPkg.Name)
-		assert.Contains(t, astPkg.Files, "valid.spx")
-		assert.NotNil(t, astPkg.Files["valid.spx"])
+		assert.Contains(t, astPkg.Files, "valid.xgo")
+		assert.NotNil(t, astPkg.Files["valid.xgo"])
 	})
 
 	t.Run("ASTFileNonScannerError", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.spx": file(`var x int`),
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`var x int`),
 		}, 0)
 
 		cache, err := buildASTPackageCache(proj)
@@ -234,8 +235,8 @@ func ValidFunc() {}
 
 func TestProjectASTPackage(t *testing.T) {
 	t.Run("ValidPackage", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.spx": file(`
+		proj := newTestProject(t, map[string]*File{
+			"main_fixture.gox": file(`
 // Main file.
 var mainVar int
 
@@ -243,34 +244,36 @@ func MainFunc() {
 	println("main")
 }
 `),
-			"sprite.spx": file(`
-// Sprite file.
-var spriteVar string
+			"Worker_fixture.gox": file(`
+// Work file.
+var workVar string
 
-func SpriteFunc() {
-	println("sprite")
+func WorkFunc() {
+	println("work")
 }
 `),
-		}, FeatAll)
+		}, FeatASTCache)
 
 		astPkg, err := proj.ASTPackage()
 		require.NoError(t, err)
 		require.NotNil(t, astPkg)
 
 		assert.Equal(t, "main", astPkg.Name)
-		assert.Len(t, astPkg.Files, 2)
-		assert.Contains(t, astPkg.Files, "main.spx")
-		assert.Contains(t, astPkg.Files, "sprite.spx")
-
-		// Check that both files are parsed.
-		assert.NotNil(t, astPkg.Files["main.spx"])
-		assert.NotNil(t, astPkg.Files["sprite.spx"])
+		require.Len(t, astPkg.Files, 2)
+		projectFile := astPkg.Files["main_fixture.gox"]
+		require.NotNil(t, projectFile)
+		assert.True(t, projectFile.IsClass)
+		assert.True(t, projectFile.IsProj)
+		workFile := astPkg.Files["Worker_fixture.gox"]
+		require.NotNil(t, workFile)
+		assert.True(t, workFile.IsClass)
+		assert.False(t, workFile.IsProj)
 	})
 
 	t.Run("Cache", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.spx": file(`var x int`),
-		}, FeatAll)
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`var x int`),
+		}, FeatASTCache)
 
 		// First call.
 		astPkg1, err1 := proj.ASTPackage()

--- a/xgo/testdata/framework/framework.go
+++ b/xgo/testdata/framework/framework.go
@@ -1,0 +1,33 @@
+// Package framework provides a minimal classfile framework for Project tests.
+package framework
+
+const XGoPackage = true
+
+// App is the project base class.
+type App struct{}
+
+func (a *App) initApp() {}
+
+// OnStart accepts a project callback.
+func (a *App) OnStart(callback func()) {}
+
+// Measure__0 is the integer overload of Measure.
+func (a *App) Measure__0(value int) int { return value }
+
+// Measure__1 is the string overload of Measure.
+func (a *App) Measure__1(value string) int { return len(value) }
+
+// Item is the work base class.
+type Item struct{}
+
+// Main is the work entry point.
+func (i *Item) Main() {}
+
+// OnValue accepts a callback with an inferred integer parameter.
+func (i *Item) OnValue(callback func(int)) {}
+
+// Label is exposed as a property in XGo source.
+func (i *Item) Label() string { return "item" }
+
+// XGot_App_Main receives the generated project and work classes.
+func XGot_App_Main(app interface{ initApp() }, items ...interface{ Main() }) {}

--- a/xgo/testutil_test.go
+++ b/xgo/testutil_test.go
@@ -1,0 +1,65 @@
+package xgo
+
+import (
+	_ "embed"
+	goast "go/ast"
+	goparser "go/parser"
+	gotypes "go/types"
+	"strings"
+	"testing"
+
+	"github.com/goplus/gogen/packages"
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/mod/modload"
+	"github.com/goplus/mod/xgomod"
+	"github.com/stretchr/testify/require"
+)
+
+const testFrameworkPkgPath = "example.com/framework"
+
+//go:embed testdata/framework/framework.go
+var testFrameworkSource string
+
+func newTestProject(t *testing.T, files map[string]*File, feats uint) *Project {
+	t.Helper()
+
+	proj := NewProject(nil, files, feats)
+	proj.Mod = xgomod.New(modload.Module{
+		Opt: &modfile.File{Projects: []*modfile.Project{{
+			Ext:      "_fixture.gox",
+			FullExt:  "main_fixture.gox",
+			Class:    "App",
+			PkgPaths: []string{testFrameworkPkgPath},
+			Works:    []*modfile.Class{{Ext: "_fixture.gox", Class: "Item", Embedded: true}},
+		}}},
+	})
+	require.NoError(t, proj.Mod.ImportClasses())
+
+	astFile, err := goparser.ParseFile(proj.Fset, "testdata/framework/framework.go", testFrameworkSource, 0)
+	require.NoError(t, err)
+	framework, err := new(gotypes.Config).Check(testFrameworkPkgPath, proj.Fset, []*goast.File{astFile}, nil)
+	require.NoError(t, err)
+	proj.Importer = &testImporter{
+		t:         t,
+		framework: framework,
+		fallback:  packages.NewImporter(proj.Fset),
+	}
+	return proj
+}
+
+type testImporter struct {
+	t         *testing.T
+	framework *gotypes.Package
+	fallback  gotypes.Importer
+}
+
+func (i *testImporter) Import(pkgPath string) (*gotypes.Package, error) {
+	i.t.Helper()
+
+	require.False(i.t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
+		"unexpected spx import: %s", pkgPath)
+	if pkgPath == testFrameworkPkgPath {
+		return i.framework, nil
+	}
+	return i.fallback.Import(pkgPath)
+}

--- a/xgo/typeinfo_test.go
+++ b/xgo/typeinfo_test.go
@@ -20,15 +20,15 @@ import (
 	gotypes "go/types"
 	"testing"
 
+	"github.com/goplus/mod/xgomod"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuildTypeInfoCache(t *testing.T) {
 	t.Run("ValidProject", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.xgo": {
-				Content: []byte(`
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`
 var x int = 42
 var y string = "hello"
 
@@ -41,8 +41,7 @@ func main() {
 	println(result, y)
 }
 `),
-			},
-		}, FeatAll)
+		}, FeatASTCache|FeatTypeInfoCache)
 
 		cache, err := buildTypeInfoCache(proj)
 		require.NoError(t, err)
@@ -63,25 +62,18 @@ func main() {
 	})
 
 	t.Run("ASTPackageError", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"invalid.xgo": {
-				Content: []byte(`invalid syntax {{{`),
-			},
-		}, 0) // Use minimal features to potentially cause issues
+		proj := newTestProject(t, map[string]*File{
+			"invalid.xgo": file(`invalid syntax {{{`),
+		}, 0)
 
 		cache, err := buildTypeInfoCache(proj)
-		// Should handle AST package errors gracefully.
-		if err != nil {
-			assert.Error(t, err)
-			assert.Nil(t, cache)
-		}
+		assert.ErrorIs(t, err, ErrUnknownCacheKind)
+		assert.Nil(t, cache)
 	})
 
 	t.Run("ASTCacheUnavailable", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.xgo": {
-				Content: []byte(`var x int`),
-			},
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`var x int`),
 		}, FeatTypeInfoCache)
 
 		cache, err := buildTypeInfoCache(proj)
@@ -92,9 +84,8 @@ func main() {
 	})
 
 	t.Run("TypeCheckingError", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.xgo": {
-				Content: []byte(`
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`
 var x int = "string" // Type error
 var y = undefinedVar // Undefined variable
 
@@ -102,8 +93,7 @@ func test() {
 	z := x + y
 }
 `),
-			},
-		}, FeatAll)
+		}, FeatASTCache|FeatTypeInfoCache)
 
 		cache, err := buildTypeInfoCache(proj)
 		require.NoError(t, err)
@@ -123,10 +113,175 @@ func test() {
 }
 
 func TestProjectTypeInfo(t *testing.T) {
+	t.Run("NormalClass", func(t *testing.T) {
+		proj := newTestProject(t, map[string]*File{
+			"Record.gox": file(`var value int
+
+func Double() int {
+	return value * 2
+}
+`),
+		}, FeatASTCache|FeatTypeInfoCache)
+
+		typeInfo, err := proj.TypeInfo()
+		require.NoError(t, err)
+		require.NotNil(t, typeInfo)
+		require.NotNil(t, typeInfo.Pkg)
+		record := typeInfo.Pkg.Scope().Lookup("Record")
+		require.NotNil(t, record)
+		recordStruct, ok := record.Type().Underlying().(*gotypes.Struct)
+		require.True(t, ok)
+		require.Equal(t, 1, recordStruct.NumFields())
+		assert.Equal(t, "value", recordStruct.Field(0).Name())
+		assert.Equal(t, gotypes.Typ[gotypes.Int], recordStruct.Field(0).Type())
+		method, _, _ := gotypes.LookupFieldOrMethod(record.Type(), true, typeInfo.Pkg, "Double")
+		double, ok := method.(*gotypes.Func)
+		require.True(t, ok)
+		assert.True(t, gotypes.Identical(gotypes.NewPointer(record.Type()), double.Signature().Recv().Type()))
+		for _, pkg := range typeInfo.Pkg.Imports() {
+			assert.NotEqual(t, testFrameworkPkgPath, pkg.Path())
+		}
+	})
+
+	t.Run("FrameworkClasses", func(t *testing.T) {
+		proj := newTestProject(t, map[string]*File{
+			"main_fixture.gox": file(`var total int
+
+onStart => {
+	total = measure(1)
+	total = measure("sample")
+}
+`),
+			"Worker_fixture.gox": file(`var value int
+
+onValue amount => {
+	value = amount
+	total = value
+}
+echo label
+`),
+		}, FeatASTCache|FeatTypeInfoCache)
+
+		_, registeredByDefault := xgomod.Default.LookupClass("_fixture.gox")
+		assert.False(t, registeredByDefault)
+		_, hasSpx := proj.Mod.LookupClass(".spx")
+		assert.False(t, hasSpx)
+
+		typeInfo, err := proj.TypeInfo()
+		require.NoError(t, err)
+		require.NotNil(t, typeInfo)
+		require.NotNil(t, typeInfo.Pkg)
+		app := typeInfo.Pkg.Scope().Lookup("App")
+		require.NotNil(t, app)
+		appStruct, ok := app.Type().Underlying().(*gotypes.Struct)
+		require.True(t, ok)
+		require.Equal(t, 3, appStruct.NumFields())
+		worker := typeInfo.Pkg.Scope().Lookup("Worker")
+		require.NotNil(t, worker)
+		workerStruct, ok := worker.Type().Underlying().(*gotypes.Struct)
+		require.True(t, ok)
+		require.Equal(t, 3, workerStruct.NumFields())
+
+		framework, err := proj.Importer.Import(testFrameworkPkgPath)
+		require.NoError(t, err)
+		require.NotNil(t, framework)
+		frameworkApp := framework.Scope().Lookup("App")
+		require.NotNil(t, frameworkApp)
+		frameworkItem := framework.Scope().Lookup("Item")
+		require.NotNil(t, frameworkItem)
+		assert.Same(t, frameworkApp.Type(), appStruct.Field(0).Type())
+		assert.True(t, appStruct.Field(0).Embedded())
+		assert.Equal(t, "Worker", appStruct.Field(1).Name())
+		assert.True(t, gotypes.Identical(gotypes.NewPointer(worker.Type()), appStruct.Field(1).Type()))
+		assert.Same(t, frameworkItem.Type(), workerStruct.Field(0).Type())
+		assert.True(t, workerStruct.Field(0).Embedded())
+		assert.True(t, gotypes.Identical(gotypes.NewPointer(app.Type()), workerStruct.Field(1).Type()))
+		assert.True(t, workerStruct.Field(1).Embedded())
+
+		total := appStruct.Field(2)
+		assert.Equal(t, "total", total.Name())
+		assert.Equal(t, gotypes.Typ[gotypes.Int], total.Type())
+		assert.Equal(t, "value", workerStruct.Field(2).Name())
+		assert.Equal(t, gotypes.Typ[gotypes.Int], workerStruct.Field(2).Type())
+
+		uses := make(map[string][]gotypes.Object)
+		for ident, obj := range typeInfo.Uses {
+			if !ident.Implicit() {
+				uses[ident.Name] = append(uses[ident.Name], obj)
+			}
+		}
+		require.Len(t, uses["total"], 3)
+		for _, obj := range uses["total"] {
+			assert.Same(t, total, obj)
+		}
+		require.Len(t, uses["measure"], 2)
+		assert.ElementsMatch(t, []string{"Measure__0", "Measure__1"}, []string{
+			uses["measure"][0].Name(), uses["measure"][1].Name(),
+		})
+		require.Len(t, uses["amount"], 1)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], uses["amount"][0].Type())
+		require.Len(t, uses["label"], 1)
+		assert.Equal(t, "Label", uses["label"][0].Name())
+		assert.Same(t, framework, uses["label"][0].Pkg())
+	})
+
+	t.Run("FrameworkTypeError", func(t *testing.T) {
+		proj := newTestProject(t, map[string]*File{
+			"main_fixture.gox": file(`var total int`),
+			"Worker_fixture.gox": file(`onValue amount => {
+	total = "invalid"
+}
+`),
+		}, FeatASTCache|FeatTypeInfoCache)
+
+		typeInfo, err := proj.TypeInfo()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Worker_fixture.gox")
+		assert.Contains(t, err.Error(), "cannot use")
+		require.NotNil(t, typeInfo)
+		require.NotNil(t, typeInfo.Pkg)
+		assert.NotNil(t, typeInfo.Pkg.Scope().Lookup("App"))
+		assert.NotNil(t, typeInfo.Pkg.Scope().Lookup("Worker"))
+	})
+
+	t.Run("FrameworkCacheInvalidation", func(t *testing.T) {
+		proj := newTestProject(t, map[string]*File{
+			"main_fixture.gox":   file(`var total int`),
+			"Worker_fixture.gox": file(`var value int`),
+		}, FeatASTCache|FeatTypeInfoCache)
+
+		before, err := proj.TypeInfo()
+		require.NoError(t, err)
+		require.NotNil(t, before)
+		require.NotNil(t, before.Pkg)
+		beforeWorker := before.Pkg.Scope().Lookup("Worker")
+		require.NotNil(t, beforeWorker)
+		beforeField, _, _ := gotypes.LookupFieldOrMethod(beforeWorker.Type(), true, before.Pkg, "value")
+		require.NotNil(t, beforeField)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], beforeField.Type())
+
+		proj.PutFile("Worker_fixture.gox", file(`var value string`))
+		after, err := proj.TypeInfo()
+		require.NoError(t, err)
+		require.NotNil(t, after)
+		require.NotNil(t, after.Pkg)
+		assert.NotSame(t, before, after)
+		afterWorker := after.Pkg.Scope().Lookup("Worker")
+		require.NotNil(t, afterWorker)
+		afterField, _, _ := gotypes.LookupFieldOrMethod(afterWorker.Type(), true, after.Pkg, "value")
+		require.NotNil(t, afterField)
+		assert.Equal(t, gotypes.Typ[gotypes.String], afterField.Type())
+
+		beforeBase, _, _ := gotypes.LookupFieldOrMethod(beforeWorker.Type(), true, before.Pkg, "Item")
+		require.NotNil(t, beforeBase)
+		afterBase, _, _ := gotypes.LookupFieldOrMethod(afterWorker.Type(), true, after.Pkg, "Item")
+		require.NotNil(t, afterBase)
+		assert.Same(t, beforeBase.Type(), afterBase.Type())
+	})
+
 	t.Run("Basic", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.xgo": {
-				Content: []byte(`
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`
 var counter int = 0
 
 func increment() {
@@ -137,8 +292,7 @@ func getCounter() int {
 	return counter
 }
 `),
-			},
-		}, FeatAll)
+		}, FeatASTCache|FeatTypeInfoCache)
 
 		typeInfo, err := proj.TypeInfo()
 		require.NoError(t, err)
@@ -165,11 +319,9 @@ func getCounter() int {
 	})
 
 	t.Run("Cache", func(t *testing.T) {
-		proj := NewProject(nil, map[string]*File{
-			"main.xgo": {
-				Content: []byte(`var x int`),
-			},
-		}, FeatAll)
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`var x int`),
+		}, FeatASTCache|FeatTypeInfoCache)
 
 		// First call.
 		typeInfo1, err1 := proj.TypeInfo()
@@ -186,17 +338,12 @@ func getCounter() int {
 	})
 
 	t.Run("CacheError", func(t *testing.T) {
-		// Create a project without the TypeInfoCache feature enabled.
-		// This will cause Cache() to return ErrUnknownCacheKind.
-		proj := NewProject(nil, map[string]*File{
-			"main.xgo": {
-				Content: []byte(`var x int`),
-			},
-		}, 0) // No features enabled, so typeInfoCacheKind is not registered.
+		proj := newTestProject(t, map[string]*File{
+			"main.xgo": file(`var x int`),
+		}, 0)
 
 		typeInfo, err := proj.TypeInfo()
-		assert.Error(t, err)
-		assert.Equal(t, ErrUnknownCacheKind, err)
+		assert.ErrorIs(t, err, ErrUnknownCacheKind)
 		assert.Nil(t, typeInfo)
 	})
 }


### PR DESCRIPTION
Use a local classfile framework with isolated module registration and package imports so AST and type checking tests do not depend on spx or production package data.

Cover classfile classification, generated class relationships, overload resolution, lambda inference, partial type information, and cache invalidation. Reject unexpected spx imports in the test importer.