### PR TITLE
fix(server): use project data for references and highlights

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -1,4 +1,5 @@
 ignore:
+  - internal/testframework
   - jsonrpc2
   - pkgdoc
   - protocol

--- a/internal/server/definition.go
+++ b/internal/server/definition.go
@@ -20,10 +20,6 @@ func (s *Server) textDocumentDeclaration(params *DeclarationParams) (any, error)
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_definition
 func (s *Server) textDocumentDefinition(params *DefinitionParams) (any, error) {
 	proj := s.getProjWithFile()
-	if proj == nil {
-		return nil, nil
-	}
-
 	spxFile, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file path from document URI %q: %w", params.TextDocument.URI, err)
@@ -57,9 +53,6 @@ func (s *Server) textDocumentDefinition(params *DefinitionParams) (any, error) {
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_typeDefinition
 func (s *Server) textDocumentTypeDefinition(params *TypeDefinitionParams) (any, error) {
 	proj := s.getProjWithFile()
-	if proj == nil {
-		return nil, nil
-	}
 	spxFile, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file path from document URI %q: %w", params.TextDocument.URI, err)

--- a/internal/server/highlight.go
+++ b/internal/server/highlight.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/goplus/xgo/ast"
@@ -10,19 +11,25 @@ import (
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_documentHighlight
 func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) (*[]DocumentHighlight, error) {
-	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
+	filename, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get file path from document URI %q: %w", params.TextDocument.URI, err)
 	}
+	proj := s.getProjWithFile()
+	astPkg, _ := proj.ASTPackage()
+	if astPkg == nil {
+		return nil, nil
+	}
+	astFile := astPkg.Files[filename]
 	if astFile == nil {
 		return nil, nil
 	}
-	position := ToPosition(result.proj, astFile, params.Position)
-	typeInfo, _ := result.proj.TypeInfo()
+	position := ToPosition(proj, astFile, params.Position)
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
-	_, targetObj, _ := objectAtPosition(result.proj, typeInfo, astFile, position)
+	_, targetObj, _ := objectAtPosition(proj, typeInfo, astFile, position)
 	if targetObj == nil {
 		return nil, nil
 	}
@@ -35,9 +42,6 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 		highlights = append(highlights, highlight)
 	}
 	ast.Inspect(astFile, func(node ast.Node) bool {
-		if node == nil {
-			return true
-		}
 		ident, ok := node.(*ast.Ident)
 		if !ok {
 			return true
@@ -60,20 +64,12 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 					kind = Read
 				}
 			case *ast.ValueSpec:
-				for _, name := range p.Names {
-					if name == ident {
-						kind = Write
-						break
-					}
+				if slices.Contains(p.Names, ident) {
+					kind = Write
 				}
 			case *ast.Field:
-				if p.Names != nil {
-					for _, name := range p.Names {
-						if name == ident {
-							kind = Write
-							break
-						}
-					}
+				if slices.Contains(p.Names, ident) {
+					kind = Write
 				}
 			case *ast.FuncDecl:
 				if p.Name == ident {
@@ -90,26 +86,14 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 			case *ast.AssignStmt:
 				switch p.Tok {
 				case token.ASSIGN:
-					for _, lhs := range p.Lhs {
-						if lhs == ident {
-							kind = Write
-							break
-						}
-					}
-					if kind != Write {
-						for _, rhs := range p.Rhs {
-							if rhs == ident {
-								kind = Read
-								break
-							}
-						}
+					if slices.Contains(p.Lhs, ast.Expr(ident)) {
+						kind = Write
+					} else if slices.Contains(p.Rhs, ast.Expr(ident)) {
+						kind = Read
 					}
 				case token.DEFINE:
-					for _, lhs := range p.Lhs {
-						if lhs == ident {
-							kind = Write
-							break
-						}
+					if slices.Contains(p.Lhs, ast.Expr(ident)) {
+						kind = Write
 					}
 				default:
 					kind = Write
@@ -125,15 +109,8 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 					kind = Write
 				}
 			case *ast.TypeSwitchStmt:
-				if p.Assign != nil {
-					if assign, ok := p.Assign.(*ast.AssignStmt); ok {
-						for _, lhs := range assign.Lhs {
-							if lhs == ident {
-								kind = Write
-								break
-							}
-						}
-					}
+				if assign, ok := p.Assign.(*ast.AssignStmt); ok && slices.Contains(assign.Lhs, ast.Expr(ident)) {
+					kind = Write
 				}
 			case *ast.BinaryExpr,
 				*ast.UnaryExpr,
@@ -159,12 +136,15 @@ func (s *Server) textDocumentDocumentHighlight(params *DocumentHighlightParams) 
 		}
 
 		appendHighlight(DocumentHighlight{
-			Range: RangeForNode(result.proj, ident),
+			Range: RangeForNode(proj, ident),
 			Kind:  kind,
 		})
 		return true
 	})
-	for _, loc := range s.kwargReferenceLocations(result, targetObj) {
+	for _, loc := range s.kwargReferenceLocations(proj, targetObj) {
+		if loc.URI != params.TextDocument.URI {
+			continue
+		}
 		appendHighlight(DocumentHighlight{
 			Range: loc.Range,
 			Kind:  Read,

--- a/internal/server/highlight_test.go
+++ b/internal/server/highlight_test.go
@@ -8,84 +8,268 @@ import (
 )
 
 func TestServerTextDocumentDocumentHighlight(t *testing.T) {
-	t.Run("Normal", func(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		filename string
+	}{
+		{name: "XGo", filename: "main.xgo"},
+		{name: "Gop", filename: "main.gop"},
+		{name: "NormalClass", filename: "Record.gox"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{
+				tt.filename: []byte("var value int\nfunc use() { println(value) }\n"),
+			})
+			highlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
+					Position:     Position{Line: 1, Character: 21},
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, highlights)
+			assert.ElementsMatch(t, []DocumentHighlight{
+				{
+					Range: Range{
+						Start: Position{Line: 0, Character: 4},
+						End:   Position{Line: 0, Character: 9},
+					},
+					Kind: Write,
+				},
+				{
+					Range: Range{
+						Start: Position{Line: 1, Character: 21},
+						End:   Position{Line: 1, Character: 26},
+					},
+					Kind: Read,
+				},
+			}, *highlights)
+		})
+	}
+
+	for _, tt := range []struct {
+		name    string
+		uri     DocumentURI
+		wantErr bool
+	}{
+		{name: "MissingFile", uri: "file:///missing.xgo"},
+		{name: "NonSourceFile", uri: "file:///notes.txt"},
+		{name: "InvalidURI", uri: "https://example.com/main.xgo", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{"notes.txt": []byte("var value int")})
+			highlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: tt.uri},
+				},
+			})
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "workspace root URI")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Nil(t, highlights)
+		})
+	}
+
+	for _, tt := range []struct {
+		name     string
+		source   string
+		position Position
+		want     []DocumentHighlight
+	}{
+		{
+			name: "Assignments",
+			source: `value := 1
+value = value
+value += 2
+value++
+println value
+`,
+			position: Position{Line: 0, Character: 0},
+			want: []DocumentHighlight{
+				{Kind: Write, Range: Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 0, Character: 5}}},
+				{Kind: Write, Range: Range{Start: Position{Line: 1, Character: 0}, End: Position{Line: 1, Character: 5}}},
+				{Kind: Read, Range: Range{Start: Position{Line: 1, Character: 8}, End: Position{Line: 1, Character: 13}}},
+				{Kind: Write, Range: Range{Start: Position{Line: 2, Character: 0}, End: Position{Line: 2, Character: 5}}},
+				{Kind: Write, Range: Range{Start: Position{Line: 3, Character: 0}, End: Position{Line: 3, Character: 5}}},
+				{Kind: Read, Range: Range{Start: Position{Line: 4, Character: 8}, End: Position{Line: 4, Character: 13}}},
+			},
+		},
+		{
+			name: "RangeVariable",
+			source: `for value := range [1, 2] {
+    println value
+}
+`,
+			position: Position{Line: 1, Character: 12},
+			want: []DocumentHighlight{
+				{Kind: Write, Range: Range{Start: Position{Line: 0, Character: 4}, End: Position{Line: 0, Character: 9}}},
+				{Kind: Read, Range: Range{Start: Position{Line: 1, Character: 12}, End: Position{Line: 1, Character: 17}}},
+			},
+		},
+		{
+			name: "RangeSource",
+			source: `values := [1, 2]
+for _, value := range values {
+    println value
+}
+`,
+			position: Position{Line: 0, Character: 0},
+			want: []DocumentHighlight{
+				{Kind: Write, Range: Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 0, Character: 6}}},
+				{Kind: Read, Range: Range{Start: Position{Line: 1, Character: 22}, End: Position{Line: 1, Character: 28}}},
+			},
+		},
+		{
+			name: "FunctionDeclaration",
+			source: `func run() {}
+run()
+`,
+			position: Position{Line: 0, Character: 5},
+			want: []DocumentHighlight{
+				{Kind: Write, Range: Range{Start: Position{Line: 0, Character: 5}, End: Position{Line: 0, Character: 8}}},
+				{Kind: Read, Range: Range{Start: Position{Line: 1, Character: 0}, End: Position{Line: 1, Character: 3}}},
+			},
+		},
+		{
+			name:     "InvalidPosition",
+			source:   "var value int\n",
+			position: Position{Line: 99, Character: 99},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+			highlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     tt.position,
+				},
+			})
+			require.NoError(t, err)
+			if tt.want == nil {
+				assert.Nil(t, highlights)
+			} else {
+				require.NotNil(t, highlights)
+				assert.ElementsMatch(t, tt.want, *highlights)
+			}
+			_, err = s.workspaceRootFS.TypeInfo()
+			assert.NoError(t, err)
+		})
+	}
+
+	t.Run("FileUpdatesWithTypeErrors", func(t *testing.T) {
+		files := map[string][]byte{
+			"main.xgo": []byte("var value int\nfunc use() { println(value) }\n"),
+		}
+		s := newTestServer(t, files)
+		params := &DocumentHighlightParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+				Position:     Position{Line: 0, Character: 4},
+			},
+		}
+		highlights, err := s.textDocumentDocumentHighlight(params)
+		require.NoError(t, err)
+		require.NotNil(t, highlights)
+		require.Len(t, *highlights, 2)
+
+		s.ModifyFiles([]FileChange{{
+			Path:    "main.xgo",
+			Content: append(files["main.xgo"], []byte("func again() { println(value); missing() }\n")...),
+			Version: 1,
+		}})
+		highlights, err = s.textDocumentDocumentHighlight(params)
+		require.NoError(t, err)
+		require.NotNil(t, highlights)
+		assert.ElementsMatch(t, []DocumentHighlight{
+			{Kind: Write, Range: Range{Start: Position{Line: 0, Character: 4}, End: Position{Line: 0, Character: 9}}},
+			{Kind: Read, Range: Range{Start: Position{Line: 1, Character: 21}, End: Position{Line: 1, Character: 26}}},
+			{Kind: Read, Range: Range{Start: Position{Line: 2, Character: 23}, End: Position{Line: 2, Character: 28}}},
+		}, *highlights)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.ErrorContains(t, err, "undefined: missing")
+	})
+
+	t.Run("FrameworkClasses", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
-MySprite.turn Left
-MySprite.turn Right
+			"main_fixture.gox": []byte(`
+Worker.apply Low
+Worker.apply High
 `),
-			"MySprite.spx": []byte(`
-onStart => {
-	MySprite.turn Right
+			"Worker_fixture.gox": []byte(`
+onValue amount => {
+	Worker.apply High
 }
 `),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
-		mySpriteHighlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
+		workerHighlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 1, Character: 0},
 			},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, mySpriteHighlights)
-		assert.Len(t, *mySpriteHighlights, 2)
-		assert.Contains(t, *mySpriteHighlights, DocumentHighlight{
+		require.NotNil(t, workerHighlights)
+		assert.Len(t, *workerHighlights, 2)
+		assert.Contains(t, *workerHighlights, DocumentHighlight{
 			Range: Range{
 				Start: Position{Line: 1, Character: 0},
-				End:   Position{Line: 1, Character: 8},
+				End:   Position{Line: 1, Character: 6},
 			},
 			Kind: Read,
 		})
-		assert.Contains(t, *mySpriteHighlights, DocumentHighlight{
+		assert.Contains(t, *workerHighlights, DocumentHighlight{
 			Range: Range{
 				Start: Position{Line: 2, Character: 0},
-				End:   Position{Line: 2, Character: 8},
+				End:   Position{Line: 2, Character: 6},
 			},
 			Kind: Read,
 		})
 
-		leftHighlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
+		highHighlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 14},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
+				Position:     Position{Line: 2, Character: 13},
 			},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, leftHighlights)
-		assert.Len(t, *leftHighlights, 1)
-		assert.Contains(t, *leftHighlights, DocumentHighlight{
+		require.NotNil(t, highHighlights)
+		assert.Len(t, *highHighlights, 1)
+		assert.Contains(t, *highHighlights, DocumentHighlight{
 			Range: Range{
-				Start: Position{Line: 2, Character: 14},
-				End:   Position{Line: 2, Character: 19},
+				Start: Position{Line: 2, Character: 13},
+				End:   Position{Line: 2, Character: 17},
 			},
 			Kind: Read,
 		})
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("KwargField", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 type Options struct {
 	Count int
 }
 
 func configure(opts Options?) {}
 
-onStart => {
+func main() {
 	configure count = 1
 	configure count = 2
 }
 `),
+			"other.xgo": []byte("func other() { configure count = 3 }\n"),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		highlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 8, Character: 12},
 			},
 		})
@@ -117,7 +301,7 @@ onStart => {
 
 	t.Run("FuncDecoratorArgument", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`func retry(times int, fn func()) {
+			"main.xgo": []byte(`func retry(times int, fn func()) {
 	fn()
 }
 
@@ -127,11 +311,11 @@ func run(times int) {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		highlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 4, Character: 8},
 			},
 		})

--- a/internal/server/kwarg.go
+++ b/internal/server/kwarg.go
@@ -310,6 +310,9 @@ func callExprFuncOverloads(proj *xgo.Project, typeInfo *types.Info, callExpr *as
 // objectDefinitionLocation returns the declaration location of obj when it is
 // available in the current project.
 func (s *Server) objectDefinitionLocation(proj *xgo.Project, typeInfo *types.Info, obj gotypes.Object) *Location {
+	if obj.Pkg() != typeInfo.Pkg {
+		return nil
+	}
 	defIdent := typeInfo.ObjToDef[obj]
 	if defIdent != nil {
 		if xgoutil.NodeTokenFile(proj.Fset, defIdent) == nil {
@@ -327,12 +330,12 @@ func (s *Server) objectDefinitionLocation(proj *xgo.Project, typeInfo *types.Inf
 }
 
 // kwargReferenceLocations returns all kwarg-name locations that resolve to obj.
-func (s *Server) kwargReferenceLocations(result *compileResult, obj gotypes.Object) []Location {
-	typeInfo, _ := result.proj.TypeInfo()
+func (s *Server) kwargReferenceLocations(proj *xgo.Project, obj gotypes.Object) []Location {
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
-	astPkg, _ := result.proj.ASTPackage()
+	astPkg, _ := proj.ASTPackage()
 	if astPkg == nil {
 		return nil
 	}
@@ -346,11 +349,11 @@ func (s *Server) kwargReferenceLocations(result *compileResult, obj gotypes.Obje
 			}
 
 			for _, kwarg := range callExpr.Kwargs {
-				for _, target := range lookupCallExprKwargTargets(result.proj, typeInfo, callExpr, kwarg.Name.Name) {
+				for _, target := range lookupCallExprKwargTargets(proj, typeInfo, callExpr, kwarg.Name.Name) {
 					if !kwargTargetMatchesObject(target, obj) {
 						continue
 					}
-					locations = append(locations, s.locationForNode(result.proj, kwarg.Name))
+					locations = append(locations, s.locationForNode(proj, kwarg.Name))
 				}
 			}
 			return true

--- a/internal/server/reference.go
+++ b/internal/server/reference.go
@@ -1,45 +1,53 @@
 package server
 
 import (
+	"fmt"
 	gotypes "go/types"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/xgo"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_references
 func (s *Server) textDocumentReferences(params *ReferenceParams) ([]Location, error) {
-	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
+	filename, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get file path from document URI %q: %w", params.TextDocument.URI, err)
 	}
+	proj := s.getProjWithFile()
+	astPkg, _ := proj.ASTPackage()
+	if astPkg == nil {
+		return nil, nil
+	}
+	astFile := astPkg.Files[filename]
 	if astFile == nil {
 		return nil, nil
 	}
-	position := ToPosition(result.proj, astFile, params.Position)
+	position := ToPosition(proj, astFile, params.Position)
 
-	typeInfo, _ := result.proj.TypeInfo()
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
-	_, obj, _ := objectAtPosition(result.proj, typeInfo, astFile, position)
+	_, obj, _ := objectAtPosition(proj, typeInfo, astFile, position)
 	if obj == nil {
 		return nil, nil
 	}
 
 	var locations []Location
 
-	locations = append(locations, s.findReferenceLocations(result, obj)...)
-	locations = append(locations, s.kwargReferenceLocations(result, obj)...)
+	locations = append(locations, s.findReferenceLocations(proj, obj)...)
+	locations = append(locations, s.kwargReferenceLocations(proj, obj)...)
 
 	if fn, ok := obj.(*gotypes.Func); ok && fn.Signature().Recv() != nil {
-		locations = append(locations, s.handleMethodReferences(result, fn)...)
-		locations = append(locations, s.handleEmbeddedFieldReferences(result, obj)...)
+		locations = append(locations, s.handleMethodReferences(proj, fn)...)
+		locations = append(locations, s.handleEmbeddedFieldReferences(proj, fn)...)
 	}
 
 	if params.Context.IncludeDeclaration {
-		if loc := s.objectDefinitionLocation(result.proj, typeInfo, obj); loc != nil {
+		if loc := s.objectDefinitionLocation(proj, typeInfo, obj); loc != nil {
 			locations = append(locations, *loc)
 		}
 	}
@@ -48,8 +56,8 @@ func (s *Server) textDocumentReferences(params *ReferenceParams) ([]Location, er
 }
 
 // findReferenceLocations returns all locations where the given object is referenced.
-func (s *Server) findReferenceLocations(result *compileResult, obj gotypes.Object) []Location {
-	typeInfo, _ := result.proj.TypeInfo()
+func (s *Server) findReferenceLocations(proj *xgo.Project, obj gotypes.Object) []Location {
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
@@ -62,41 +70,39 @@ func (s *Server) findReferenceLocations(result *compileResult, obj gotypes.Objec
 		if refIdent.Implicit() {
 			continue
 		}
-		locations = append(locations, s.locationForNode(result.proj, refIdent))
+		locations = append(locations, s.locationForNode(proj, refIdent))
 	}
 	return locations
 }
 
 // handleMethodReferences finds all references to a method, including interface
 // implementations and interface method references.
-func (s *Server) handleMethodReferences(result *compileResult, fn *gotypes.Func) []Location {
-	var locations []Location
+func (s *Server) handleMethodReferences(proj *xgo.Project, fn *gotypes.Func) []Location {
 	recvType := fn.Signature().Recv().Type()
-	if gotypes.IsInterface(recvType) {
-		iface, ok := recvType.(*gotypes.Interface)
-		if !ok {
-			return nil
-		}
-		methodName := fn.Name()
-		locations = append(locations, s.findEmbeddedInterfaceReferences(result, iface, methodName)...)
-		locations = append(locations, s.findImplementingMethodReferences(result, iface, methodName)...)
-	} else {
-		locations = append(locations, s.findInterfaceMethodReferences(result, fn)...)
+	if !gotypes.IsInterface(recvType) {
+		return s.findInterfaceMethodReferences(proj, fn)
 	}
+	iface, ok := recvType.(*gotypes.Interface)
+	if !ok {
+		return nil
+	}
+	methodName := fn.Name()
+	locations := s.findEmbeddedInterfaceReferences(proj, iface, methodName)
+	locations = append(locations, s.findImplementingMethodReferences(proj, iface, methodName)...)
 	return locations
 }
 
 // findEmbeddedInterfaceReferences finds references to methods in interfaces
 // that embed the given interface.
-func (s *Server) findEmbeddedInterfaceReferences(result *compileResult, iface *gotypes.Interface, methodName string) []Location {
-	var locations []Location
-	seenIfaces := make(map[*gotypes.Interface]bool)
-	typeInfo, _ := result.proj.TypeInfo()
+func (s *Server) findEmbeddedInterfaceReferences(proj *xgo.Project, iface *gotypes.Interface, methodName string) []Location {
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
-		return locations
+		return nil
 	}
 
-	astPkg, _ := result.proj.ASTPackage()
+	var locations []Location
+	seenIfaces := make(map[*gotypes.Interface]bool)
+	astPkg, _ := proj.ASTPackage()
 	var find func(*gotypes.Interface)
 	find = func(current *gotypes.Interface) {
 		if seenIfaces[current] {
@@ -116,16 +122,15 @@ func (s *Server) findEmbeddedInterfaceReferences(result *compileResult, iface *g
 			}
 
 			for typ := range embedIface.EmbeddedTypes() {
-				if gotypes.Identical(typ, current) {
-					selection, ok := gotypes.LookupSelection(embedIface, false, typeName.Pkg(), methodName)
-					if ok {
-						method, ok := selection.Obj().(*gotypes.Func)
-						if ok {
-							locations = append(locations, s.findReferenceLocations(result, method)...)
-						}
-					}
-					find(embedIface)
+				if !gotypes.Identical(typ, current) {
+					continue
 				}
+				if selection, ok := gotypes.LookupSelection(embedIface, false, typeName.Pkg(), methodName); ok {
+					if method, ok := selection.Obj().(*gotypes.Func); ok {
+						locations = append(locations, s.findReferenceLocations(proj, method)...)
+					}
+				}
+				find(embedIface)
 			}
 		}
 	}
@@ -135,13 +140,13 @@ func (s *Server) findEmbeddedInterfaceReferences(result *compileResult, iface *g
 
 // findImplementingMethodReferences finds references to all methods that
 // implement the given interface method.
-func (s *Server) findImplementingMethodReferences(result *compileResult, iface *gotypes.Interface, methodName string) []Location {
-	typeInfo, _ := result.proj.TypeInfo()
+func (s *Server) findImplementingMethodReferences(proj *xgo.Project, iface *gotypes.Interface, methodName string) []Location {
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
 	var locations []Location
-	astPkg, _ := result.proj.ASTPackage()
+	astPkg, _ := proj.ASTPackage()
 	for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
 		typeSpec := spec.(*ast.TypeSpec)
 		typeName := typeInfo.ObjectOf(typeSpec.Name)
@@ -161,22 +166,22 @@ func (s *Server) findImplementingMethodReferences(result *compileResult, iface *
 		if !ok {
 			continue
 		}
-		locations = append(locations, s.findReferenceLocations(result, method)...)
+		locations = append(locations, s.findReferenceLocations(proj, method)...)
 	}
 	return locations
 }
 
 // findInterfaceMethodReferences finds references to interface methods that this
 // method implements, including methods from embedded interfaces.
-func (s *Server) findInterfaceMethodReferences(result *compileResult, fn *gotypes.Func) []Location {
-	typeInfo, _ := result.proj.TypeInfo()
+func (s *Server) findInterfaceMethodReferences(proj *xgo.Project, fn *gotypes.Func) []Location {
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
 	var locations []Location
 	recvType := fn.Signature().Recv().Type()
 	seenIfaces := make(map[*gotypes.Interface]bool)
-	astPkg, _ := result.proj.ASTPackage()
+	astPkg, _ := proj.ASTPackage()
 
 	for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
 		typeSpec := spec.(*ast.TypeSpec)
@@ -198,47 +203,41 @@ func (s *Server) findInterfaceMethodReferences(result *compileResult, fn *gotype
 		if !ok {
 			continue
 		}
-		locations = append(locations, s.findReferenceLocations(result, method)...)
-		locations = append(locations, s.findEmbeddedInterfaceReferences(result, ifaceType, fn.Name())...)
+		locations = append(locations, s.findReferenceLocations(proj, method)...)
+		locations = append(locations, s.findEmbeddedInterfaceReferences(proj, ifaceType, fn.Name())...)
 	}
 	return locations
 }
 
 // handleEmbeddedFieldReferences finds all references through embedded fields.
-func (s *Server) handleEmbeddedFieldReferences(result *compileResult, obj gotypes.Object) []Location {
-	typeInfo, _ := result.proj.TypeInfo()
+func (s *Server) handleEmbeddedFieldReferences(proj *xgo.Project, fn *gotypes.Func) []Location {
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
 	var locations []Location
-	if fn, ok := obj.(*gotypes.Func); ok {
-		recv := fn.Signature().Recv()
-		if recv == nil {
-			return nil
+	recvType := fn.Signature().Recv().Type()
+	seenTypes := make(map[gotypes.Type]bool)
+	astPkg, _ := proj.ASTPackage()
+	for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
+		typeSpec := spec.(*ast.TypeSpec)
+		typeName := typeInfo.ObjectOf(typeSpec.Name)
+		if typeName == nil {
+			continue
+		}
+		named, ok := typeName.Type().(*gotypes.Named)
+		if !ok {
+			continue
 		}
 
-		seenTypes := make(map[gotypes.Type]bool)
-		astPkg, _ := result.proj.ASTPackage()
-		for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
-			typeSpec := spec.(*ast.TypeSpec)
-			typeName := typeInfo.ObjectOf(typeSpec.Name)
-			if typeName == nil {
-				continue
-			}
-			named, ok := typeName.Type().(*gotypes.Named)
-			if !ok {
-				continue
-			}
-
-			locations = append(locations, s.findEmbeddedMethodReferences(result, fn, named, recv.Type(), seenTypes)...)
-		}
+		locations = append(locations, s.findEmbeddedMethodReferences(proj, fn, named, recvType, seenTypes)...)
 	}
 	return locations
 }
 
 // findEmbeddedMethodReferences recursively finds all references to a method
 // through embedded fields.
-func (s *Server) findEmbeddedMethodReferences(result *compileResult, fn *gotypes.Func, named *gotypes.Named, targetType gotypes.Type, seenTypes map[gotypes.Type]bool) []Location {
+func (s *Server) findEmbeddedMethodReferences(proj *xgo.Project, fn *gotypes.Func, named *gotypes.Named, targetType gotypes.Type, seenTypes map[gotypes.Type]bool) []Location {
 	if seenTypes[named] {
 		return nil
 	}
@@ -267,19 +266,19 @@ func (s *Server) findEmbeddedMethodReferences(result *compileResult, fn *gotypes
 			if !ok {
 				continue
 			}
-			locations = append(locations, s.findReferenceLocations(result, method)...)
+			locations = append(locations, s.findReferenceLocations(proj, method)...)
 		}
 
 		if fieldNamed, ok := field.Type().(*gotypes.Named); ok {
-			locations = append(locations, s.findEmbeddedMethodReferences(result, fn, fieldNamed, targetType, seenTypes)...)
+			locations = append(locations, s.findEmbeddedMethodReferences(proj, fn, fieldNamed, targetType, seenTypes)...)
 		}
 	}
 	if hasEmbed {
-		typeInfo, _ := result.proj.TypeInfo()
+		typeInfo, _ := proj.TypeInfo()
 		if typeInfo == nil {
 			return nil
 		}
-		astPkg, _ := result.proj.ASTPackage()
+		astPkg, _ := proj.ASTPackage()
 		for spec := range xgoutil.ASTSpecs(astPkg, token.TYPE) {
 			typeSpec := spec.(*ast.TypeSpec)
 			typeName := typeInfo.ObjectOf(typeSpec.Name)
@@ -291,7 +290,7 @@ func (s *Server) findEmbeddedMethodReferences(result *compileResult, fn *gotypes
 				continue
 			}
 
-			locations = append(locations, s.findEmbeddedMethodReferences(result, fn, named, named, seenTypes)...)
+			locations = append(locations, s.findEmbeddedMethodReferences(proj, fn, named, named, seenTypes)...)
 		}
 	}
 	return locations

--- a/internal/server/reference_test.go
+++ b/internal/server/reference_test.go
@@ -8,25 +8,123 @@ import (
 )
 
 func TestServerTextDocumentReferences(t *testing.T) {
-	t.Run("Normal", func(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		filename           string
+		includeDeclaration bool
+	}{
+		{name: "XGo", filename: "main.xgo", includeDeclaration: true},
+		{name: "Gop", filename: "main.gop", includeDeclaration: true},
+		{name: "NormalClass", filename: "Record.gox", includeDeclaration: true},
+		{name: "ExcludeDeclaration", filename: "main.xgo"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{
+				tt.filename: []byte("var value int\nfunc use() { println(value) }\n"),
+			})
+			uri := s.toDocumentURI(tt.filename)
+			refs, err := s.textDocumentReferences(&ReferenceParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: uri},
+					Position:     Position{Line: 1, Character: 21},
+				},
+				Context: ReferenceContext{IncludeDeclaration: tt.includeDeclaration},
+			})
+			require.NoError(t, err)
+			want := []Location{{
+				URI: uri,
+				Range: Range{
+					Start: Position{Line: 1, Character: 21},
+					End:   Position{Line: 1, Character: 26},
+				},
+			}}
+			if tt.includeDeclaration {
+				want = append(want, Location{
+					URI: uri,
+					Range: Range{
+						Start: Position{Line: 0, Character: 4},
+						End:   Position{Line: 0, Character: 9},
+					},
+				})
+			}
+			assert.ElementsMatch(t, want, refs)
+		})
+	}
+
+	for _, tt := range []struct {
+		name    string
+		uri     DocumentURI
+		wantErr bool
+	}{
+		{name: "MissingFile", uri: "file:///missing.xgo"},
+		{name: "NonSourceFile", uri: "file:///notes.txt"},
+		{name: "InvalidURI", uri: "https://example.com/main.xgo", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{"notes.txt": []byte("var value int")})
+			refs, err := s.textDocumentReferences(&ReferenceParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: tt.uri},
+				},
+			})
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "workspace root URI")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Nil(t, refs)
+		})
+	}
+
+	t.Run("FileUpdatesWithTypeErrors", func(t *testing.T) {
+		files := map[string][]byte{
+			"main.xgo": []byte("var value int\nfunc use() { println(value) }\n"),
+		}
+		s := newTestServer(t, files)
+		params := &ReferenceParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+				Position:     Position{Line: 0, Character: 4},
+			},
+			Context: ReferenceContext{IncludeDeclaration: true},
+		}
+		refs, err := s.textDocumentReferences(params)
+		require.NoError(t, err)
+		require.Len(t, refs, 2)
+
+		s.ModifyFiles([]FileChange{{
+			Path:    "main.xgo",
+			Content: append(files["main.xgo"], []byte("func again() { println(value); missing() }\n")...),
+			Version: 1,
+		}})
+		refs, err = s.textDocumentReferences(params)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []Location{
+			{URI: "file:///main.xgo", Range: Range{Start: Position{Line: 0, Character: 4}, End: Position{Line: 0, Character: 9}}},
+			{URI: "file:///main.xgo", Range: Range{Start: Position{Line: 1, Character: 21}, End: Position{Line: 1, Character: 26}}},
+			{URI: "file:///main.xgo", Range: Range{Start: Position{Line: 2, Character: 23}, End: Position{Line: 2, Character: 28}}},
+		}, refs)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.ErrorContains(t, err, "undefined: missing")
+	})
+
+	t.Run("FrameworkClasses", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
-MySprite.turn Left
-MySprite.turn Right
+			"main_fixture.gox": []byte(`
+Worker.apply Low
+Worker.apply High
 `),
-			"MySprite.spx": []byte(`
-onStart => {
-	MySprite.turn Right
+			"Worker_fixture.gox": []byte(`
+onValue amount => {
+	Worker.apply High
 }
 `),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
-		mainSpxMySpriteRef, err := s.textDocumentReferences(&ReferenceParams{
+		workerRefs, err := s.textDocumentReferences(&ReferenceParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 1, Character: 0},
 			},
 			Context: ReferenceContext{
@@ -34,74 +132,74 @@ onStart => {
 			},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, mainSpxMySpriteRef)
-		require.Len(t, mainSpxMySpriteRef, 3)
-		assert.Contains(t, mainSpxMySpriteRef, Location{
-			URI: "file:///main.spx",
+		require.Len(t, workerRefs, 3)
+		assert.Contains(t, workerRefs, Location{
+			URI: "file:///main_fixture.gox",
 			Range: Range{
 				Start: Position{Line: 1, Character: 0},
-				End:   Position{Line: 1, Character: 8},
+				End:   Position{Line: 1, Character: 6},
 			},
 		})
-		assert.Contains(t, mainSpxMySpriteRef, Location{
-			URI: "file:///main.spx",
+		assert.Contains(t, workerRefs, Location{
+			URI: "file:///main_fixture.gox",
 			Range: Range{
 				Start: Position{Line: 2, Character: 0},
-				End:   Position{Line: 2, Character: 8},
+				End:   Position{Line: 2, Character: 6},
 			},
 		})
-		assert.Contains(t, mainSpxMySpriteRef, Location{
-			URI: "file:///MySprite.spx",
+		assert.Contains(t, workerRefs, Location{
+			URI: "file:///Worker_fixture.gox",
 			Range: Range{
 				Start: Position{Line: 2, Character: 1},
-				End:   Position{Line: 2, Character: 9},
+				End:   Position{Line: 2, Character: 7},
 			},
 		})
 
-		mainSpxTurnRef, err := s.textDocumentReferences(&ReferenceParams{
+		applyRefs, err := s.textDocumentReferences(&ReferenceParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 9},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
+				Position:     Position{Line: 1, Character: 7},
 			},
 			Context: ReferenceContext{
 				IncludeDeclaration: true,
 			},
 		})
 		require.NoError(t, err)
-		require.NotNil(t, mainSpxTurnRef)
-		require.Len(t, mainSpxTurnRef, 3)
-		assert.Contains(t, mainSpxTurnRef, Location{
-			URI: "file:///main.spx",
+		require.Len(t, applyRefs, 3)
+		assert.Contains(t, applyRefs, Location{
+			URI: "file:///main_fixture.gox",
 			Range: Range{
-				Start: Position{Line: 1, Character: 9},
-				End:   Position{Line: 1, Character: 13},
+				Start: Position{Line: 1, Character: 7},
+				End:   Position{Line: 1, Character: 12},
 			},
 		})
-		assert.Contains(t, mainSpxTurnRef, Location{
-			URI: "file:///main.spx",
+		assert.Contains(t, applyRefs, Location{
+			URI: "file:///main_fixture.gox",
 			Range: Range{
-				Start: Position{Line: 2, Character: 9},
+				Start: Position{Line: 2, Character: 7},
+				End:   Position{Line: 2, Character: 12},
+			},
+		})
+		assert.Contains(t, applyRefs, Location{
+			URI: "file:///Worker_fixture.gox",
+			Range: Range{
+				Start: Position{Line: 2, Character: 8},
 				End:   Position{Line: 2, Character: 13},
 			},
 		})
-		assert.Contains(t, mainSpxTurnRef, Location{
-			URI: "file:///MySprite.spx",
-			Range: Range{
-				Start: Position{Line: 2, Character: 10},
-				End:   Position{Line: 2, Character: 14},
-			},
-		})
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("InvalidPosition", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`var x int`),
+			"main.xgo": []byte(`var x int`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		refs, err := s.textDocumentReferences(&ReferenceParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 99, Character: 99},
 			},
 		})
@@ -109,26 +207,80 @@ onStart => {
 		assert.Nil(t, refs)
 	})
 
+	t.Run("MethodsAcrossFiles", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			position Position
+		}{
+			{name: "ConcreteMethod", position: Position{Line: 1, Character: 11}},
+			{name: "EmbeddedMethod", position: Position{Line: 4, Character: 12}},
+			{name: "NestedEmbeddedMethod", position: Position{Line: 5, Character: 10}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{
+					"types.xgo": []byte(`type Runner interface { Run() }
+type Extended interface { Runner }
+type Unrelated interface { Stop() }
+type Worker struct{}
+func (Worker) Run() {}
+type Wrapper struct { Worker }
+type Outer struct { Wrapper }
+type Different struct{}
+func (Different) Run(int) {}
+`),
+					"main.xgo": []byte(`func use(worker Worker, runner Runner, extended Extended, wrapper Wrapper, outer Outer, different Different) {
+    worker.run()
+    runner.run()
+    extended.run()
+    wrapper.run()
+    outer.run()
+    different.run 1
+}
+`),
+				})
+				refs, err := s.textDocumentReferences(&ReferenceParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+						Position:     tt.position,
+					},
+					Context: ReferenceContext{IncludeDeclaration: true},
+				})
+				require.NoError(t, err)
+				assert.ElementsMatch(t, []Location{
+					{URI: "file:///types.xgo", Range: Range{Start: Position{Line: 4, Character: 14}, End: Position{Line: 4, Character: 17}}},
+					{URI: "file:///main.xgo", Range: Range{Start: Position{Line: 1, Character: 11}, End: Position{Line: 1, Character: 14}}},
+					{URI: "file:///main.xgo", Range: Range{Start: Position{Line: 2, Character: 11}, End: Position{Line: 2, Character: 14}}},
+					{URI: "file:///main.xgo", Range: Range{Start: Position{Line: 3, Character: 13}, End: Position{Line: 3, Character: 16}}},
+					{URI: "file:///main.xgo", Range: Range{Start: Position{Line: 4, Character: 12}, End: Position{Line: 4, Character: 15}}},
+					{URI: "file:///main.xgo", Range: Range{Start: Position{Line: 5, Character: 10}, End: Position{Line: 5, Character: 13}}},
+				}, refs)
+				_, err = s.workspaceRootFS.TypeInfo()
+				assert.NoError(t, err)
+			})
+		}
+	})
+
 	t.Run("KwargField", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 type Options struct {
 	Count int
 }
 
 func configure(opts Options?) {}
 
-onStart => {
+func main() {
 	configure count = 1
 	configure count = 2
 }
 `),
+			"other.xgo": []byte("func other() { configure count = 3 }\n"),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		refs, err := s.textDocumentReferences(&ReferenceParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 2, Character: 4},
 			},
 			Context: ReferenceContext{
@@ -137,33 +289,40 @@ onStart => {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, refs)
-		require.Len(t, refs, 3)
+		require.Len(t, refs, 4)
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 2, Character: 1},
 				End:   Position{Line: 2, Character: 6},
 			},
 		})
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 8, Character: 11},
 				End:   Position{Line: 8, Character: 16},
 			},
 		})
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 9, Character: 11},
 				End:   Position{Line: 9, Character: 16},
+			},
+		})
+		assert.Contains(t, refs, Location{
+			URI: "file:///other.xgo",
+			Range: Range{
+				Start: Position{Line: 0, Character: 25},
+				End:   Position{Line: 0, Character: 30},
 			},
 		})
 	})
 
 	t.Run("OverloadKwargField", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 type Worker struct{}
 
 type CountOptions struct {
@@ -184,17 +343,17 @@ func (Worker).handle = (
     (Worker).handleName
 )
 
-onStart => {
+func main() {
     worker.handle count = 1
     worker.handle count = 2
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		refs, err := s.textDocumentReferences(&ReferenceParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 4, Character: 5},
 			},
 			Context: ReferenceContext{
@@ -205,21 +364,21 @@ onStart => {
 		require.NotNil(t, refs)
 		require.Len(t, refs, 3)
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 4, Character: 4},
 				End:   Position{Line: 4, Character: 9},
 			},
 		})
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 22, Character: 18},
 				End:   Position{Line: 22, Character: 23},
 			},
 		})
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 23, Character: 18},
 				End:   Position{Line: 23, Character: 23},
@@ -229,7 +388,7 @@ onStart => {
 
 	t.Run("KwargInterfaceMethod", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 type Client struct{}
 
 type Params interface {
@@ -242,17 +401,17 @@ func (c Client) Params() Params { return nil }
 
 func (c Client) complete(prompt string, params Params?) {}
 
-onStart => {
+func main() {
 	client.complete "hi", maxTokens = 1
 	client.complete "bye", maxTokens = 2
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		refs, err := s.textDocumentReferences(&ReferenceParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 14, Character: 25},
 			},
 			Context: ReferenceContext{
@@ -263,21 +422,21 @@ onStart => {
 		require.NotNil(t, refs)
 		require.Len(t, refs, 3)
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 4, Character: 1},
 				End:   Position{Line: 4, Character: 10},
 			},
 		})
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 14, Character: 23},
 				End:   Position{Line: 14, Character: 32},
 			},
 		})
 		assert.Contains(t, refs, Location{
-			URI: "file:///main.spx",
+			URI: "file:///main.xgo",
 			Range: Range{
 				Start: Position{Line: 15, Character: 24},
 				End:   Position{Line: 15, Character: 33},

--- a/internal/server/rename.go
+++ b/internal/server/rename.go
@@ -13,9 +13,6 @@ import (
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_prepareRename
 func (s *Server) textDocumentPrepareRename(params *PrepareRenameParams) (*Range, error) {
 	proj := s.getProjWithFile()
-	if proj == nil {
-		return nil, nil
-	}
 	spxFile, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file path from document URI %q: %w", params.TextDocument.URI, err)
@@ -102,8 +99,8 @@ func (s *Server) renameObjectAtPosition(result *compileResult, params *RenamePar
 			},
 		},
 	}
-	refLocs := s.findReferenceLocations(result, obj)
-	kwargRefLocs := s.kwargReferenceLocations(result, obj)
+	refLocs := s.findReferenceLocations(result.proj, obj)
+	kwargRefLocs := s.kwargReferenceLocations(result.proj, obj)
 	kwargNewName := kwargRenameText(obj, params.NewName)
 	kwargRefSet := make(map[Location]struct{}, len(kwargRefLocs))
 	for _, refLoc := range kwargRefLocs {

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/goplus/xgolsw/internal/testframework"
+)
+
+func newTestServer(t *testing.T, files map[string][]byte) *Server {
+	t.Helper()
+
+	proj := newProjectWithoutModTime(files)
+	s := New(proj, nil, fileMapGetter(files), &MockScheduler{})
+	proj.Mod = testframework.NewModule(t)
+	proj.Importer = testframework.NewImporter(t, proj.Fset)
+	return s
+}

--- a/internal/testframework/framework.go
+++ b/internal/testframework/framework.go
@@ -1,0 +1,77 @@
+// Package testframework provides an isolated classfile framework for tests.
+package testframework
+
+import (
+	_ "embed"
+	goast "go/ast"
+	goparser "go/parser"
+	gotypes "go/types"
+	"strings"
+	"testing"
+
+	"github.com/goplus/gogen/packages"
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/mod/modload"
+	"github.com/goplus/mod/xgomod"
+	"github.com/goplus/xgo/token"
+	"github.com/stretchr/testify/require"
+)
+
+// PkgPath is the import path of the test framework.
+const PkgPath = "example.com/framework"
+
+// source defines the framework's base classes and methods.
+//
+//go:embed testdata/framework.go
+var source string
+
+// NewModule returns a fresh module with the test framework registered.
+func NewModule(t *testing.T) *xgomod.Module {
+	t.Helper()
+
+	mod := xgomod.New(modload.Module{
+		Opt: &modfile.File{Projects: []*modfile.Project{{
+			Ext:      "_fixture.gox",
+			FullExt:  "main_fixture.gox",
+			Class:    "App",
+			PkgPaths: []string{PkgPath},
+			Works:    []*modfile.Class{{Ext: "_fixture.gox", Class: "Item", Embedded: true}},
+		}}},
+	})
+	require.NoError(t, mod.ImportClasses())
+	return mod
+}
+
+// NewImporter type checks the framework and returns an importer that rejects spx.
+func NewImporter(t *testing.T, fset *token.FileSet) gotypes.Importer {
+	t.Helper()
+
+	astFile, err := goparser.ParseFile(fset, "testdata/framework.go", source, 0)
+	require.NoError(t, err)
+	framework, err := new(gotypes.Config).Check(PkgPath, fset, []*goast.File{astFile}, nil)
+	require.NoError(t, err)
+	return &importer{
+		t:         t,
+		framework: framework,
+		fallback:  packages.NewImporter(fset),
+	}
+}
+
+// importer supplies the test framework and delegates other imports.
+type importer struct {
+	t         *testing.T
+	framework *gotypes.Package
+	fallback  gotypes.Importer
+}
+
+// Import implements [go/types.Importer].
+func (i *importer) Import(pkgPath string) (*gotypes.Package, error) {
+	i.t.Helper()
+
+	require.False(i.t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
+		"unexpected spx import: %s", pkgPath)
+	if pkgPath == PkgPath {
+		return i.framework, nil
+	}
+	return i.fallback.Import(pkgPath)
+}

--- a/internal/testframework/testdata/framework.go
+++ b/internal/testframework/testdata/framework.go
@@ -1,7 +1,13 @@
-// Package framework provides a minimal classfile framework for Project tests.
+// Package framework provides a minimal classfile framework for language tests.
 package framework
 
 const XGoPackage = true
+
+// Low and High are values used by framework methods.
+const (
+	Low = iota
+	High
+)
 
 // App is the project base class.
 type App struct{}
@@ -28,6 +34,9 @@ func (i *Item) OnValue(callback func(int)) {}
 
 // Label is exposed as a property in XGo source.
 func (i *Item) Label() string { return "item" }
+
+// Apply accepts a value on a work instance.
+func (i *Item) Apply(value int) {}
 
 // XGot_App_Main receives the generated project and work classes.
 func XGot_App_Main(app interface{ initApp() }, items ...interface{ Main() }) {}

--- a/xgo/testutil_test.go
+++ b/xgo/testutil_test.go
@@ -1,65 +1,16 @@
 package xgo
 
 import (
-	_ "embed"
-	goast "go/ast"
-	goparser "go/parser"
-	gotypes "go/types"
-	"strings"
 	"testing"
 
-	"github.com/goplus/gogen/packages"
-	"github.com/goplus/mod/modfile"
-	"github.com/goplus/mod/modload"
-	"github.com/goplus/mod/xgomod"
-	"github.com/stretchr/testify/require"
+	"github.com/goplus/xgolsw/internal/testframework"
 )
-
-const testFrameworkPkgPath = "example.com/framework"
-
-//go:embed testdata/framework/framework.go
-var testFrameworkSource string
 
 func newTestProject(t *testing.T, files map[string]*File, feats uint) *Project {
 	t.Helper()
 
 	proj := NewProject(nil, files, feats)
-	proj.Mod = xgomod.New(modload.Module{
-		Opt: &modfile.File{Projects: []*modfile.Project{{
-			Ext:      "_fixture.gox",
-			FullExt:  "main_fixture.gox",
-			Class:    "App",
-			PkgPaths: []string{testFrameworkPkgPath},
-			Works:    []*modfile.Class{{Ext: "_fixture.gox", Class: "Item", Embedded: true}},
-		}}},
-	})
-	require.NoError(t, proj.Mod.ImportClasses())
-
-	astFile, err := goparser.ParseFile(proj.Fset, "testdata/framework/framework.go", testFrameworkSource, 0)
-	require.NoError(t, err)
-	framework, err := new(gotypes.Config).Check(testFrameworkPkgPath, proj.Fset, []*goast.File{astFile}, nil)
-	require.NoError(t, err)
-	proj.Importer = &testImporter{
-		t:         t,
-		framework: framework,
-		fallback:  packages.NewImporter(proj.Fset),
-	}
+	proj.Mod = testframework.NewModule(t)
+	proj.Importer = testframework.NewImporter(t, proj.Fset)
 	return proj
-}
-
-type testImporter struct {
-	t         *testing.T
-	framework *gotypes.Package
-	fallback  gotypes.Importer
-}
-
-func (i *testImporter) Import(pkgPath string) (*gotypes.Package, error) {
-	i.t.Helper()
-
-	require.False(i.t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
-		"unexpected spx import: %s", pkgPath)
-	if pkgPath == testFrameworkPkgPath {
-		return i.framework, nil
-	}
-	return i.fallback.Import(pkgPath)
 }

--- a/xgo/typeinfo_test.go
+++ b/xgo/typeinfo_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/goplus/mod/xgomod"
+	"github.com/goplus/xgolsw/internal/testframework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -139,7 +140,7 @@ func Double() int {
 		require.True(t, ok)
 		assert.True(t, gotypes.Identical(gotypes.NewPointer(record.Type()), double.Signature().Recv().Type()))
 		for _, pkg := range typeInfo.Pkg.Imports() {
-			assert.NotEqual(t, testFrameworkPkgPath, pkg.Path())
+			assert.NotEqual(t, testframework.PkgPath, pkg.Path())
 		}
 	})
 
@@ -182,7 +183,7 @@ echo label
 		require.True(t, ok)
 		require.Equal(t, 3, workerStruct.NumFields())
 
-		framework, err := proj.Importer.Import(testFrameworkPkgPath)
+		framework, err := proj.Importer.Import(testframework.PkgPath)
 		require.NoError(t, err)
 		require.NotNil(t, framework)
 		frameworkApp := framework.Scope().Lookup("App")


### PR DESCRIPTION
Resolve references and document highlights from the project's AST and type information so these features can be tested without spx compilation. Share an isolated classfile fixture between the XGo and server tests, and exclude this test support from production coverage statistics.

Keep imported declarations out of project locations and limit kwarg highlights to the requested document.

Cover source file kinds, cross-file and embedded method references, interface references, read/write highlights, document updates, and partial type information.
