### PR TITLE
fix(server): use project data for signature help and inlay hints

### DIFF
--- a/internal/server/inlay_hint.go
+++ b/internal/server/inlay_hint.go
@@ -2,36 +2,41 @@ package server
 
 import (
 	"cmp"
+	"fmt"
 	"slices"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/xgo"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_inlayHint
 func (s *Server) textDocumentInlayHint(params *InlayHintParams) ([]InlayHint, error) {
-	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
+	filename, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get file path from document URI %q: %w", params.TextDocument.URI, err)
 	}
-	if astFile == nil {
+	proj := s.getProjWithFile()
+	astPkg, _ := proj.ASTPackage()
+	if astPkg == nil {
 		return nil, nil
 	}
-	if !astFile.Pos().IsValid() {
+	astFile := astPkg.Files[filename]
+	if astFile == nil || !astFile.Pos().IsValid() {
 		return nil, nil
 	}
 
-	rangeStart := PosAt(result.proj, astFile, params.Range.Start)
-	rangeEnd := PosAt(result.proj, astFile, params.Range.End)
-	return collectInlayHints(result, astFile, rangeStart, rangeEnd), nil
+	rangeStart := PosAt(proj, astFile, params.Range.Start)
+	rangeEnd := PosAt(proj, astFile, params.Range.End)
+	return collectInlayHints(proj, astFile, rangeStart, rangeEnd), nil
 }
 
 // collectInlayHints collects inlay hints from the given AST file. If
 // rangeStart and rangeEnd positions are provided (non-zero), only hints within
 // the range are included.
-func collectInlayHints(result *compileResult, astFile *ast.File, rangeStart, rangeEnd token.Pos) []InlayHint {
-	typeInfo, _ := result.proj.TypeInfo()
+func collectInlayHints(proj *xgo.Project, astFile *ast.File, rangeStart, rangeEnd token.Pos) []InlayHint {
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
@@ -52,11 +57,11 @@ func collectInlayHints(result *compileResult, astFile *ast.File, rangeStart, ran
 		switch node := node.(type) {
 		case *ast.BranchStmt:
 			if callExpr := xgoutil.CreateCallExprFromBranchStmt(typeInfo, node); callExpr != nil {
-				hints := collectInlayHintsFromCallExpr(result, callExpr)
+				hints := collectInlayHintsFromCallExpr(proj, callExpr)
 				inlayHints = append(inlayHints, hints...)
 			}
 		case *ast.CallExpr, *ast.FuncDecorator:
-			hints := collectInlayHintsFromCallExpr(result, callExprFromNode(node))
+			hints := collectInlayHintsFromCallExpr(proj, callExprFromNode(node))
 			inlayHints = append(inlayHints, hints...)
 		}
 		return true
@@ -66,13 +71,13 @@ func collectInlayHints(result *compileResult, astFile *ast.File, rangeStart, ran
 }
 
 // collectInlayHintsFromCallExpr collects inlay hints from a call expression.
-func collectInlayHintsFromCallExpr(result *compileResult, callExpr *ast.CallExpr) []InlayHint {
-	astPkg, _ := result.proj.ASTPackage()
-	astFile := xgoutil.NodeASTFile(result.proj.Fset, astPkg, callExpr)
+func collectInlayHintsFromCallExpr(proj *xgo.Project, callExpr *ast.CallExpr) []InlayHint {
+	astPkg, _ := proj.ASTPackage()
+	astFile := xgoutil.NodeASTFile(proj.Fset, astPkg, callExpr)
 	if astFile == nil {
 		return nil
 	}
-	typeInfo, _ := result.proj.TypeInfo()
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil
 	}
@@ -80,22 +85,10 @@ func collectInlayHintsFromCallExpr(result *compileResult, callExpr *ast.CallExpr
 	hasResolvedSignature := resolvedParams != nil
 
 	var inlayHints []InlayHint
-	type hintKey struct {
-		line      uint32
-		character uint32
-		kind      InlayHintKind
-	}
-	hintKeyFor := func(hint InlayHint) hintKey {
-		return hintKey{
-			line:      hint.Position.Line,
-			character: hint.Position.Character,
-			kind:      hint.Kind,
-		}
-	}
-	hintsByKey := make(map[hintKey]InlayHint)
-	ambiguousHintKeys := make(map[hintKey]struct{})
+	labelsByPosition := make(map[Position]string)
+	ambiguousPositions := make(map[Position]struct{})
 	variadicParamSeen := false
-	for resolvedArg := range resolvedCallExprArgs(result.proj, typeInfo, callExpr) {
+	for resolvedArg := range resolvedCallExprArgs(proj, typeInfo, callExpr) {
 		if resolvedArg.Kind != xgoutil.ResolvedCallExprArgPositional {
 			continue
 		}
@@ -117,31 +110,30 @@ func collectInlayHintsFromCallExpr(result *compileResult, callExpr *ast.CallExpr
 		}
 
 		// Create an inlay hint with the parameter name before the argument.
-		position := result.proj.Fset.Position(resolvedArg.Arg.Pos())
+		position := proj.Fset.Position(resolvedArg.Arg.Pos())
 		label := xgoutil.SourceParamName(resolvedArg.Param)
 		if variadicArg {
 			label += "..."
 		}
 		hint := InlayHint{
-			Position: FromPosition(result.proj, astFile, position),
+			Position: FromPosition(proj, astFile, position),
 			Label:    label,
 			Kind:     Parameter,
 		}
 		if _, ok := xgoutil.AutoclosureParamResultType(resolvedArg.Param); ok {
 			hint.Tooltip = &InlayHintTooltip{Value: autoclosureParamDocumentation}
 		}
-		key := hintKeyFor(hint)
-		if existingHint, ok := hintsByKey[key]; ok {
-			if existingHint.Label != hint.Label {
-				ambiguousHintKeys[key] = struct{}{}
+		if existingLabel, ok := labelsByPosition[hint.Position]; ok {
+			if existingLabel != hint.Label {
+				ambiguousPositions[hint.Position] = struct{}{}
 			}
 			continue
 		}
-		hintsByKey[key] = hint
+		labelsByPosition[hint.Position] = hint.Label
 		inlayHints = append(inlayHints, hint)
 	}
 	return slices.DeleteFunc(inlayHints, func(hint InlayHint) bool {
-		_, ok := ambiguousHintKeys[hintKeyFor(hint)]
+		_, ok := ambiguousPositions[hint.Position]
 		return ok
 	})
 }

--- a/internal/server/inlay_hint_test.go
+++ b/internal/server/inlay_hint_test.go
@@ -9,68 +9,172 @@ import (
 )
 
 func TestServerTextDocumentInlayHint(t *testing.T) {
-	t.Run("Normal", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	// Function calls with named parameters.
-	println "Hello, World!"
-	MySprite.turn Left
+	for _, tt := range []struct {
+		name     string
+		filename string
+	}{
+		{name: "XGo", filename: "main.xgo"},
+		{name: "Gop", filename: "main.gop"},
+		{name: "NormalClass", filename: "Record.gox"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{
+				"functions.xgo": []byte("func combine(count int, label string) {}\n"),
+				tt.filename:     []byte("combine 1, \"value\"\n"),
+			})
+			hints, err := s.textDocumentInlayHint(&InlayHintParams{
+				TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
+				Range:        Range{End: Position{Line: 1}},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, []InlayHint{
+				{Position: Position{Line: 0, Character: 8}, Label: "count", Kind: Parameter},
+				{Position: Position{Line: 0, Character: 11}, Label: "label", Kind: Parameter},
+			}, hints)
+			_, err = s.workspaceRootFS.TypeInfo()
+			assert.NoError(t, err)
+		})
+	}
 
-	// Call with multiple parameters.
-	setGraphicEffect ColorEffect, 50
-
-	// Function with HSB color value.
-	color := HSB(255, 0, 0)
-}
-`),
-			"MySprite.spx":                       []byte(`{}`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		params := &InlayHintParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-			Range: Range{
-				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 100, Character: 0},
+	t.Run("FrameworkMethods", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox":   []byte("onStart => {\n    Worker.apply 3\n    _ = create(Item, \"sample\")\n}\n"),
+			"Worker_fixture.gox": []byte("onValue amount => {\n    apply amount\n}\n"),
+		})
+		for _, tt := range []struct {
+			filename string
+			want     []InlayHint
+		}{
+			{
+				filename: "main_fixture.gox",
+				want: []InlayHint{
+					{Position: Position{Line: 1, Character: 17}, Label: "value", Kind: Parameter},
+					{Position: Position{Line: 2, Character: 15}, Label: "T", Kind: Parameter},
+					{Position: Position{Line: 2, Character: 21}, Label: "name", Kind: Parameter},
+				},
 			},
+			{
+				filename: "Worker_fixture.gox",
+				want: []InlayHint{
+					{Position: Position{Line: 1, Character: 10}, Label: "value", Kind: Parameter},
+				},
+			},
+		} {
+			hints, err := s.textDocumentInlayHint(&InlayHintParams{
+				TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
+				Range:        Range{End: Position{Line: 10}},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, hints, tt.filename)
 		}
-
-		inlayHints, err := s.textDocumentInlayHint(params)
-		require.NoError(t, err)
-		require.NotNil(t, inlayHints)
-		assert.NotEmpty(t, inlayHints)
-
-		assert.True(t, slices.ContainsFunc(inlayHints, func(hint InlayHint) bool {
-			return hint.Position.Line == 3 && hint.Label != "" && hint.Kind == Parameter
-		}))
-
-		assert.True(t, slices.ContainsFunc(inlayHints, func(hint InlayHint) bool {
-			return hint.Position.Line == 4 && hint.Label != "" && hint.Kind == Parameter
-		}))
-
-		setGraphicEffectHintCount := 0
-		for _, hint := range inlayHints {
-			if hint.Position.Line == 7 && hint.Kind == Parameter {
-				setGraphicEffectHintCount++
-			}
-		}
-		assert.Equal(t, 2, setGraphicEffectHintCount)
-
-		hsbHintCount := 0
-		for _, hint := range inlayHints {
-			if hint.Position.Line == 10 && hint.Kind == Parameter {
-				hsbHintCount++
-			}
-		}
-		assert.Equal(t, 3, hsbHintCount)
+		_, err := s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
+	t.Run("SpecificRange", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte("func use(value int) {}\nuse 1\nuse 2\nuse 3\n"),
+		})
+		hints, err := s.textDocumentInlayHint(&InlayHintParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+			Range:        Range{Start: Position{Line: 2}, End: Position{Line: 2, Character: 5}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []InlayHint{
+			{Position: Position{Line: 2, Character: 4}, Label: "value", Kind: Parameter},
+		}, hints)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
+	})
+
+	t.Run("UTF16", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte("func combine(text string, count int) {}\ncombine \"\U0001F600\", 1\n"),
+		})
+		hints, err := s.textDocumentInlayHint(&InlayHintParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+			Range:        Range{Start: Position{Line: 1}, End: Position{Line: 1, Character: 15}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []InlayHint{
+			{Position: Position{Line: 1, Character: 8}, Label: "text", Kind: Parameter},
+			{Position: Position{Line: 1, Character: 14}, Label: "count", Kind: Parameter},
+		}, hints)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
+	})
+
+	t.Run("FileUpdatesWithTypeErrors", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"functions.xgo": []byte("func combine(count int) {}\n"),
+			"main.xgo":      []byte("combine 1\n"),
+		})
+		params := &InlayHintParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+			Range:        Range{End: Position{Line: 10}},
+		}
+		hints, err := s.textDocumentInlayHint(params)
+		require.NoError(t, err)
+		assert.Equal(t, []InlayHint{
+			{Position: Position{Character: 8}, Label: "count", Kind: Parameter},
+		}, hints)
+		_, err = s.workspaceRootFS.TypeInfo()
+		require.NoError(t, err)
+
+		s.ModifyFiles([]FileChange{
+			{Path: "functions.xgo", Content: []byte("func combine(value int, label string) {}\nfunc broken() { missing() }\n"), Version: 1},
+			{Path: "main.xgo", Content: []byte("\ncombine 1, \"x\"\n"), Version: 1},
+		})
+		hints, err = s.textDocumentInlayHint(params)
+		require.NoError(t, err)
+		assert.Equal(t, []InlayHint{
+			{Position: Position{Line: 1, Character: 8}, Label: "value", Kind: Parameter},
+			{Position: Position{Line: 1, Character: 11}, Label: "label", Kind: Parameter},
+		}, hints)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.ErrorContains(t, err, "undefined: missing")
+	})
+
+	for _, tt := range []struct {
+		name         string
+		uri          DocumentURI
+		source       string
+		wantError    bool
+		wantASTError bool
+	}{
+		{name: "EmptyFile", uri: "file:///main.xgo"},
+		{name: "MissingFile", uri: "file:///missing.xgo"},
+		{name: "NonSourceFile", uri: "file:///notes.txt"},
+		{name: "InvalidURI", uri: "https://example.com/main.xgo", wantError: true},
+		{name: "StartWithInvalidChar", uri: "file:///main.xgo", source: "\n\u201c\u201dvar (\n    maps []int\n)\n", wantASTError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{
+				"main.xgo":  []byte(tt.source),
+				"notes.txt": []byte("func use(value int) {}\nuse 1\n"),
+			})
+			hints, err := s.textDocumentInlayHint(&InlayHintParams{
+				TextDocument: TextDocumentIdentifier{URI: tt.uri},
+				Range:        Range{End: Position{Line: 10}},
+			})
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Empty(t, hints)
+			_, err = s.workspaceRootFS.ASTPackage()
+			if tt.wantASTError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+
 	t.Run("FuncDecorator", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`func retry(times int, fn func()) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`func retry(times int, fn func()) {
 	fn()
 }
 
@@ -78,11 +182,10 @@ onStart => {
 func run() {
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		inlayHints, err := s.textDocumentInlayHint(&InlayHintParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 7, Character: 0},
@@ -94,21 +197,21 @@ func run() {
 			Label:    "times",
 			Kind:     Parameter,
 		})
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("Autoclosure", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`
 onStart => {
-	repeatUntil true, => {}
+	runWhen true, => {}
 }
 `),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		inlayHints, err := s.textDocumentInlayHint(&InlayHintParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 4, Character: 0},
@@ -117,28 +220,29 @@ onStart => {
 		require.NoError(t, err)
 		assert.Equal(t, []InlayHint{
 			{
-				Position: Position{Line: 2, Character: 13},
+				Position: Position{Line: 2, Character: 9},
 				Label:    "condition",
 				Kind:     Parameter,
 				Tooltip:  &InlayHintTooltip{Value: autoclosureParamDocumentation},
 			},
 		}, inlayHints)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("PartialXGoxFunction", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`import "example.com/typeargs"
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`import "example.com/typeargs"
 
-onStart => {
+func main() {
 	typeargs.convert(string, 100)
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 		s.workspaceRootFS.Importer = xgoxTestImporter{fallback: s.workspaceRootFS.Importer}
 
 		inlayHints, err := s.textDocumentInlayHint(&InlayHintParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 5, Character: 0},
@@ -157,358 +261,145 @@ onStart => {
 				Kind:     Parameter,
 			},
 		}, inlayHints)
-	})
-
-	t.Run("EmptyFile", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(``),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		params := &InlayHintParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-			Range: Range{
-				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 1, Character: 0},
-			},
-		}
-
-		inlayHints, err := s.textDocumentInlayHint(params)
-		require.NoError(t, err)
-		assert.Empty(t, inlayHints)
-	})
-
-	t.Run("NonExistentFile", func(t *testing.T) {
-		s := New(newProjectWithoutModTime(map[string][]byte{}), nil, fileMapGetter(map[string][]byte{}), &MockScheduler{})
-
-		params := &InlayHintParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///nonexistent.spx"},
-			Range: Range{
-				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 10, Character: 0},
-			},
-		}
-
-		inlayHints, err := s.textDocumentInlayHint(params)
-		require.Error(t, err)
-		assert.Nil(t, inlayHints)
-	})
-
-	t.Run("SpecificRange", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-var (
-	MySprite Sprite
-)
-
-onStart => {
-	// Line 6
-	println "Hello"
-	// Line 8
-	MySprite.turn Left
-	// Line 10
-	setGraphicEffect ColorEffect, 50
-	// Line 12
-	color := HSB(255, 0, 0)
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		params := &InlayHintParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-			Range: Range{
-				Start: Position{Line: 7, Character: 0},
-				End:   Position{Line: 11, Character: 0},
-			},
-		}
-
-		inlayHints, err := s.textDocumentInlayHint(params)
-		require.NoError(t, err)
-		require.NotNil(t, inlayHints)
-		assert.Len(t, inlayHints, 2)
-
-		for _, hint := range inlayHints {
-			assert.True(t, hint.Position.Line >= 7 && hint.Position.Line <= 11)
-		}
-		assert.True(t, slices.ContainsFunc(inlayHints, func(hint InlayHint) bool {
-			return hint.Position.Line == 7 && hint.Kind == Parameter
-		}))
-		assert.True(t, slices.ContainsFunc(inlayHints, func(hint InlayHint) bool {
-			return hint.Position.Line == 9 && hint.Kind == Parameter
-		}))
-		assert.False(t, slices.ContainsFunc(inlayHints, func(hint InlayHint) bool {
-			return hint.Position.Line < 7 || hint.Position.Line > 11
-		}))
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 }
 
 func TestCollectInlayHints(t *testing.T) {
-	t.Run("FunctionCallsWithNamedParams", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	// Regular function calls with parameters.
-	println "Hello, World!"
-	MySprite.turn Left
-
-	// Function call with multiple parameters.
-	setGraphicEffect ColorEffect, 50
-	getWidget Monitor, "myWidget"
-
-	// Function call with lambda expression.
-	onKey [KeySpace], () => {
-		println "Space pressed"
+	for _, tt := range []struct {
+		name   string
+		source string
+		want   []InlayHint
+	}{
+		{
+			name:   "NamedParameters",
+			source: "func mix(count int, label string, enabled bool) {}\nfunc main() {\n    mix 1, \"text\", true\n}\n",
+			want: []InlayHint{
+				{Position: Position{Line: 2, Character: 8}, Label: "count", Kind: Parameter},
+				{Position: Position{Line: 2, Character: 11}, Label: "label", Kind: Parameter},
+				{Position: Position{Line: 2, Character: 19}, Label: "enabled", Kind: Parameter},
+			},
+		},
+		{
+			name:   "BuiltinAndImportedFunctions",
+			source: "import \"fmt\"\nfunc main() {\n    println \"hello\"\n    fmt.Println(\"world\")\n}\n",
+			want: []InlayHint{
+				{Position: Position{Line: 2, Character: 12}, Label: "a...", Kind: Parameter},
+				{Position: Position{Line: 3, Character: 16}, Label: "a...", Kind: Parameter},
+			},
+		},
+		{
+			name:   "LambdaExpressionsSkipped",
+			source: "func visit(count int, callback func()) {}\nfunc main() {\n    visit 1, => {}\n    visit 2, () => {}\n}\n",
+			want: []InlayHint{
+				{Position: Position{Line: 2, Character: 10}, Label: "count", Kind: Parameter},
+				{Position: Position{Line: 3, Character: 10}, Label: "count", Kind: Parameter},
+			},
+		},
+		{name: "NoInlayHints", source: "var value = 1\n_ = value\n"},
+		{name: "EmptyFile"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+			proj := s.getProjWithFile()
+			astFile, err := proj.ASTFile("main.xgo")
+			require.NoError(t, err)
+			require.NotNil(t, astFile)
+			assert.Equal(t, tt.want, collectInlayHints(proj, astFile, 0, 0))
+			_, err = proj.TypeInfo()
+			assert.NoError(t, err)
+		})
 	}
-
-	// Variables with function calls.
-	color := HSB(255, 0, 0)
-}
-`),
-			"MySprite.spx": []byte(`
-onStart => {
-	// Branch statement that converts to call expression.
-	stepTo "OtherSprite"
-}
-`),
-			"OtherSprite.spx":                       []byte(``),
-			"assets/index.json":                     []byte(`{"zorder":[{"name":"myWidget"}]}`),
-			"assets/sprites/MySprite/index.json":    []byte(`{}`),
-			"assets/sprites/OtherSprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
-		require.NoError(t, err)
-		require.NotNil(t, astFile)
-
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
-		require.NotNil(t, inlayHints)
-		assert.NotEmpty(t, inlayHints)
-
-		assert.True(t, slices.ContainsFunc(inlayHints, func(hint InlayHint) bool {
-			return hint.Position.Line == 3 && hint.Label != ""
-		}))
-
-		assert.True(t, slices.ContainsFunc(inlayHints, func(hint InlayHint) bool {
-			return hint.Position.Line == 4 && hint.Label != ""
-		}))
-
-		setGraphicEffectHintCount := 0
-		for _, hint := range inlayHints {
-			if hint.Position.Line == 7 {
-				setGraphicEffectHintCount++
-			}
-		}
-		assert.Equal(t, 2, setGraphicEffectHintCount)
-
-		var (
-			getWidgetHintCount  int
-			getWidgetHintLabels []string
-		)
-		for _, hint := range inlayHints {
-			if hint.Position.Line == 8 {
-				getWidgetHintCount++
-				getWidgetHintLabels = append(getWidgetHintLabels, hint.Label)
-			}
-		}
-		assert.Equal(t, 2, getWidgetHintCount)
-		assert.ElementsMatch(t, []string{"T", "name"}, getWidgetHintLabels)
-
-		hsbHintCount := 0
-		for _, hint := range inlayHints {
-			if hint.Position.Line == 16 {
-				hsbHintCount++
-			}
-		}
-		assert.Equal(t, 3, hsbHintCount)
-
-		spriteResult, _, spriteAstFile, err := s.compileAndGetASTFileForDocumentURI("file:///MySprite.spx")
-		require.NoError(t, err)
-		require.NotNil(t, spriteAstFile)
-
-		spriteInlayHints := collectInlayHints(spriteResult, spriteAstFile, 0, 0)
-		require.NotNil(t, spriteInlayHints)
-		assert.NotEmpty(t, spriteInlayHints)
-
-		hasStepToHint := false
-		for _, hint := range spriteInlayHints {
-			if hint.Position.Line == 3 {
-				hasStepToHint = true
-				break
-			}
-		}
-		assert.True(t, hasStepToHint)
-	})
-
-	t.Run("NoInlayHints", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	// No function calls with parameters.
-	a := 5
-	b := 10
-	c := a + b
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
-		require.NoError(t, err)
-		require.NotNil(t, astFile)
-
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
-		assert.Empty(t, inlayHints)
-	})
-
-	t.Run("LambdaExpressionSkipped", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	// Function with lambda argument (should be skipped).
-	onKey [KeySpace], () => {
-		println "Space pressed"
-	}
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
-		require.NoError(t, err)
-		require.NotNil(t, astFile)
-
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
-		require.NotNil(t, inlayHints)
-		assert.NotEmpty(t, inlayHints)
-
-		onKeyHintCount := 0
-		for _, hint := range inlayHints {
-			if hint.Position.Line == 4 {
-				onKeyHintCount++
-			}
-		}
-		assert.Equal(t, 1, onKeyHintCount)
-	})
-
-	t.Run("EmptyFile", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(``),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
-		require.NoError(t, err)
-		require.NotNil(t, astFile)
-
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
-		assert.Empty(t, inlayHints)
-	})
 
 	t.Run("RangeFiltering", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	// Line 2
-	println "Hello"
-	// Line 4
-	MySprite.turn Left
-	// Line 6
-	setGraphicEffect ColorEffect, 50
-	// Line 8
-	color := HSB(255, 0, 0)
-}
-`),
-			"MySprite.spx":                       []byte(``),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte("func use(value int) {}\nuse 1\nuse 2\nuse 3\n"),
+		})
+		proj := s.getProjWithFile()
+		astFile, err := proj.ASTFile("main.xgo")
 		require.NoError(t, err)
 		require.NotNil(t, astFile)
-
-		rangeStart := PosAt(result.proj, astFile, Position{Line: 3, Character: 0})
-		rangeEnd := PosAt(result.proj, astFile, Position{Line: 6, Character: 0})
-		filteredHints := collectInlayHints(result, astFile, rangeStart, rangeEnd)
-		require.NotNil(t, filteredHints)
-		assert.NotEmpty(t, filteredHints)
-
-		allHints := collectInlayHints(result, astFile, 0, 0)
-		require.NotNil(t, allHints)
-		assert.NotEmpty(t, allHints)
-
-		assert.Less(t, len(filteredHints), len(allHints))
-
-		for _, hint := range filteredHints {
-			assert.True(t, hint.Position.Line >= 3 && hint.Position.Line <= 6)
-		}
-		assert.True(t, slices.ContainsFunc(filteredHints, func(hint InlayHint) bool {
-			return hint.Position.Line == 3 && hint.Kind == Parameter
-		}))
-		assert.True(t, slices.ContainsFunc(filteredHints, func(hint InlayHint) bool {
-			return hint.Position.Line == 5 && hint.Kind == Parameter
-		}))
-
-		hsbHintCount := 0
-		for _, hint := range filteredHints {
-			if hint.Position.Line > 6 {
-				hsbHintCount++
-			}
-		}
-		assert.Zero(t, hsbHintCount)
+		assert.Equal(t, []InlayHint{
+			{Position: Position{Line: 1, Character: 4}, Label: "value", Kind: Parameter},
+			{Position: Position{Line: 2, Character: 4}, Label: "value", Kind: Parameter},
+			{Position: Position{Line: 3, Character: 4}, Label: "value", Kind: Parameter},
+		}, collectInlayHints(proj, astFile, 0, 0))
+		start := PosAt(proj, astFile, Position{Line: 2})
+		end := PosAt(proj, astFile, Position{Line: 2, Character: 5})
+		assert.Equal(t, []InlayHint{
+			{Position: Position{Line: 2, Character: 4}, Label: "value", Kind: Parameter},
+		}, collectInlayHints(proj, astFile, start, end))
+		_, err = proj.TypeInfo()
+		assert.NoError(t, err)
 	})
 
-	t.Run("UnresolvedOverloadFuncCall", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	onKey nonExistent
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
-		require.NoError(t, err)
-		require.NotNil(t, astFile)
-
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
-		require.Nil(t, inlayHints)
-	})
+	for _, tt := range []struct {
+		name       string
+		parameters string
+		argument   string
+		want       []InlayHint
+	}{
+		{name: "UnresolvedOverload", parameters: "other int, text string", argument: "unknown, unknown"},
+		{name: "AmbiguousParameter", parameters: "other int, text string", argument: "1, unknown"},
+		{
+			name: "SharedOverloadParameter", parameters: "value int, text string", argument: "1, unknown",
+			want: []InlayHint{{Position: Position{Line: 9, Character: 18}, Label: "value", Kind: Parameter}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			source := "type Worker struct{}\n" +
+				"var worker Worker\n" +
+				"func (w *Worker) handleFlag(value int, flag bool) {}\n" +
+				"func (w *Worker) handleText(" + tt.parameters + ") {}\n" +
+				"func (Worker).handle = (\n" +
+				"    (Worker).handleFlag\n" +
+				"    (Worker).handleText\n" +
+				")\n" +
+				"func main() {\n" +
+				"    worker.handle " + tt.argument + "\n" +
+				"}\n"
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte(source)})
+			proj := s.getProjWithFile()
+			astFile, err := proj.ASTFile("main.xgo")
+			require.NoError(t, err)
+			require.NotNil(t, astFile)
+			assert.Equal(t, tt.want, collectInlayHints(proj, astFile, 0, 0))
+			_, err = proj.TypeInfo()
+			assert.ErrorContains(t, err, "undefined: unknown")
+		})
+	}
 
 	t.Run("FunctionArgumentWithUnresolvedValue", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
 func handle(count int) {}
 
-onStart => {
+func main() {
 	handle unknown
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		proj := s.getProjWithFile()
+		astFile, err := proj.ASTFile("main.xgo")
 		require.NoError(t, err)
 		require.NotNil(t, astFile)
 
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
+		inlayHints := collectInlayHints(proj, astFile, 0, 0)
 		require.Len(t, inlayHints, 1)
 		assert.Equal(t, InlayHint{
 			Position: Position{Line: 4, Character: 8},
 			Label:    "count",
 			Kind:     Parameter,
 		}, inlayHints[0])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.ErrorContains(t, err, "undefined: unknown")
 	})
 
 	t.Run("OverloadFunctionArguments", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
 type Worker struct{}
 
 var worker Worker
@@ -519,123 +410,77 @@ func (Worker).handle = (
 	(Worker).handleCount
 )
 
-onStart => {
+func main() {
 	worker.handle 5
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		proj := s.getProjWithFile()
+		astFile, err := proj.ASTFile("main.xgo")
 		require.NoError(t, err)
 		require.NotNil(t, astFile)
 
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
+		inlayHints := collectInlayHints(proj, astFile, 0, 0)
 		require.Len(t, inlayHints, 1)
 		assert.Equal(t, InlayHint{
 			Position: Position{Line: 12, Character: 15},
 			Label:    "count",
 			Kind:     Parameter,
 		}, inlayHints[0])
-	})
-
-	t.Run("SpxStepToWithAmbiguousArgument", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(``),
-			"MySprite.spx": []byte(`
-onStart => {
-	stepToWith 1,
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///MySprite.spx")
-		require.NoError(t, err)
-		require.NotNil(t, astFile)
-
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
-		assert.Empty(t, inlayHints)
-	})
-
-	t.Run("SpxStepToWithPositionArguments", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(``),
-			"MySprite.spx": []byte(`
-onStart => {
-	stepToWith 1, 2
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///MySprite.spx")
-		require.NoError(t, err)
-		require.NotNil(t, astFile)
-
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
-		require.Len(t, inlayHints, 2)
-		assert.Equal(t, InlayHint{
-			Position: Position{Line: 2, Character: 12},
-			Label:    "x",
-			Kind:     Parameter,
-		}, inlayHints[0])
-		assert.Equal(t, InlayHint{
-			Position: Position{Line: 2, Character: 15},
-			Label:    "y",
-			Kind:     Parameter,
-		}, inlayHints[1])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("VariadicFunctionArguments", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+func main() {
 	echo 1
 	echo 1, 2, 3
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		proj := s.getProjWithFile()
+		astFile, err := proj.ASTFile("main.xgo")
 		require.NoError(t, err)
 		require.NotNil(t, astFile)
 
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
+		inlayHints := collectInlayHints(proj, astFile, 0, 0)
 		require.NotNil(t, inlayHints)
 		require.Len(t, inlayHints, 2)
 		assert.Equal(t, "a...", inlayHints[0].Label)
 		assert.Equal(t, "a...", inlayHints[1].Label)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("VariadicArgumentAfterKwargsParameter", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
 func process(opts map[string]string?, args ...int) {}
 
-onStart => {
+func main() {
 	process 1, name = "x"
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
-		result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
+		proj := s.getProjWithFile()
+		astFile, err := proj.ASTFile("main.xgo")
 		require.NoError(t, err)
 		require.NotNil(t, astFile)
 
-		inlayHints := collectInlayHints(result, astFile, 0, 0)
+		inlayHints := collectInlayHints(proj, astFile, 0, 0)
 		require.Len(t, inlayHints, 1)
 		assert.Equal(t, InlayHint{
 			Position: Position{Line: 4, Character: 9},
 			Label:    "args...",
 			Kind:     Parameter,
 		}, inlayHints[0])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 }
 
@@ -712,29 +557,5 @@ func TestSortInlayHints(t *testing.T) {
 		assert.Equal(t, "A", l5c10Hints[0].Label)
 		assert.Equal(t, "M", l5c10Hints[1].Label)
 		assert.Equal(t, "Z", l5c10Hints[2].Label)
-	})
-
-	t.Run("StartWithInvalidChar", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-“”var (
-	maps []int
-)
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		params := &InlayHintParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-			Range: Range{
-				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 4, Character: 0},
-			},
-		}
-
-		inlayHints, err := s.textDocumentInlayHint(params)
-		require.NoError(t, err)
-		require.Nil(t, inlayHints)
-		assert.Empty(t, inlayHints)
 	})
 }

--- a/internal/server/signature.go
+++ b/internal/server/signature.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"cmp"
+	"fmt"
 	gotypes "go/types"
 	"strings"
 
@@ -16,15 +17,21 @@ const autoclosureParamDocumentation = "Deferred expression. The callee controls 
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_signatureHelp
 func (s *Server) textDocumentSignatureHelp(params *SignatureHelpParams) (*SignatureHelp, error) {
-	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
+	filename, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get file path from document URI %q: %w", params.TextDocument.URI, err)
 	}
-	if astFile == nil {
+	proj := s.getProjWithFile()
+	astPkg, _ := proj.ASTPackage()
+	if astPkg == nil {
 		return nil, nil
 	}
-	pos := PosAt(result.proj, astFile, params.Position)
-	typeInfo, _ := result.proj.TypeInfo()
+	astFile := astPkg.Files[filename]
+	if astFile == nil || !astFile.Pos().IsValid() {
+		return nil, nil
+	}
+	pos := PosAt(proj, astFile, params.Position)
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
@@ -44,7 +51,7 @@ func (s *Server) textDocumentSignatureHelp(params *SignatureHelpParams) (*Signat
 	if callExpr != nil {
 		fun, sig, resolvedParams = xgoutil.ResolveCallExprSignature(typeInfo, callExpr)
 		if fun == nil || sig == nil || resolvedParams == nil {
-			return overloadSignatureHelp(result.proj, typeInfo, callExpr, pos), nil
+			return overloadSignatureHelp(proj, typeInfo, callExpr, pos), nil
 		}
 		activeParameter = signatureHelpActiveParameter(typeInfo, callExpr, pos, sig, resolvedParams)
 		if funcDecorator {
@@ -75,7 +82,7 @@ func (s *Server) textDocumentSignatureHelp(params *SignatureHelpParams) (*Signat
 
 	displayedName := ""
 	if callExpr != nil {
-		displayedName = signatureHelpResolvedCallName(result.proj, typeInfo, callExpr, fun)
+		displayedName = signatureHelpResolvedCallName(proj, typeInfo, callExpr, fun)
 	}
 	help := &SignatureHelp{
 		Signatures: []SignatureInformation{signatureHelpInformation(fun, sig, resolvedParams, displayedName)},

--- a/internal/server/signature_test.go
+++ b/internal/server/signature_test.go
@@ -7,76 +7,242 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTextDocumentSignatureHelp(t *testing.T) {
-	t.Run("Normal", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-import "fmt"
-fmt.Println 
-MySprite.turn Left
-`),
-			"MySprite.spx": []byte(`
-onStart => {
-	MySprite.turn Right
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
+func TestServerTextDocumentSignatureHelp(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		filename string
+	}{
+		{name: "XGo", filename: "main.xgo"},
+		{name: "Gop", filename: "main.gop"},
+		{name: "NormalClass", filename: "Record.gox"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{
+				"functions.xgo": []byte("func combine(count int, label string) {}\n"),
+				tt.filename:     []byte("combine 1, \"value\"\n"),
+			})
+			help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
+					Position:     Position{Line: 0, Character: 13},
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, &SignatureHelp{
+				Signatures: []SignatureInformation{{
+					Label:      "combine(count int, label string)",
+					Parameters: []ParameterInformation{{Label: "count int"}, {Label: "label string"}},
+				}},
+				ActiveParameter: 1,
+			}, help)
+			_, err = s.workspaceRootFS.TypeInfo()
+			assert.NoError(t, err)
+		})
+	}
+
+	t.Run("FrameworkMethods", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			filename string
+			source   string
+			position Position
+			label    string
+		}{
+			{
+				name: "ProjectOverload", filename: "main_fixture.gox",
+				source: "onStart => {\n    measure 1\n}\n", position: Position{Line: 1, Character: 12},
+				label: "measure(value int) int",
+			},
+			{
+				name: "WorkMethod", filename: "Worker_fixture.gox",
+				source: "onValue amount => {\n    apply amount\n}\n", position: Position{Line: 1, Character: 12},
+				label: "apply(value int)",
+			},
+			{
+				name: "BoundWorkMethod", filename: "main_fixture.gox",
+				source: "onStart => {\n    Worker.apply 1\n}\n", position: Position{Line: 1, Character: 17},
+				label: "apply(value int)",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				files := map[string][]byte{
+					"main_fixture.gox":   {},
+					"Worker_fixture.gox": {},
+				}
+				files[tt.filename] = []byte(tt.source)
+				s := newTestServer(t, files)
+				help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				assert.Equal(t, &SignatureHelp{
+					Signatures: []SignatureInformation{{
+						Label: tt.label, Parameters: []ParameterInformation{{Label: "value int"}},
+					}},
+				}, help)
+				_, err = s.workspaceRootFS.TypeInfo()
+				assert.NoError(t, err)
+			})
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		fmtHelp, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 10},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, fmtHelp)
-		require.Len(t, fmtHelp.Signatures, 1)
-		assert.Equal(t, SignatureInformation{
-			Label: "println(a ...any) (n int, err error)",
-			Parameters: []ParameterInformation{
-				{
-					Label: "a ...any",
-				},
-			},
-		}, fmtHelp.Signatures[0])
-
-		turnHelp, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 3, Character: 10},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, turnHelp)
-		require.Len(t, turnHelp.Signatures, 1)
-		assert.Equal(t, SignatureInformation{
-			Label: "turn(dir Direction)",
-			Parameters: []ParameterInformation{
-				{
-					Label: "dir Direction",
-				},
-			},
-		}, turnHelp.Signatures[0])
 	})
 
+	t.Run("ImportedFunction", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte("import \"fmt\"\nfmt.Println \"value\"\n"),
+		})
+		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+				Position:     Position{Line: 1, Character: 5},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, &SignatureHelp{
+			Signatures: []SignatureInformation{{
+				Label: "println(a ...any) (n int, err error)", Parameters: []ParameterInformation{{Label: "a ...any"}},
+			}},
+		}, help)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
+	})
+
+	t.Run("UTF16", func(t *testing.T) {
+		for _, tt := range []struct {
+			name            string
+			character       uint32
+			activeParameter uint32
+		}{
+			{name: "StringArgument", character: 11, activeParameter: 0},
+			{name: "FollowingArgument", character: 14, activeParameter: 1},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{
+					"main.xgo": []byte("func combine(text string, count int) {}\ncombine \"\U0001F600\", 1\n"),
+				})
+				help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+						Position:     Position{Line: 1, Character: tt.character},
+					},
+				})
+				require.NoError(t, err)
+				assert.Equal(t, &SignatureHelp{
+					Signatures: []SignatureInformation{{
+						Label:      "combine(text string, count int)",
+						Parameters: []ParameterInformation{{Label: "text string"}, {Label: "count int"}},
+					}},
+					ActiveParameter: tt.activeParameter,
+				}, help)
+				_, err = s.workspaceRootFS.TypeInfo()
+				assert.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("FileUpdatesWithTypeErrors", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"functions.xgo": []byte("func combine(count int) {}\n"),
+			"main.xgo":      []byte("combine 1\n"),
+		})
+		params := &SignatureHelpParams{TextDocumentPositionParams: TextDocumentPositionParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+			Position:     Position{Character: 8},
+		}}
+		help, err := s.textDocumentSignatureHelp(params)
+		require.NoError(t, err)
+		assert.Equal(t, &SignatureHelp{
+			Signatures: []SignatureInformation{{
+				Label: "combine(count int)", Parameters: []ParameterInformation{{Label: "count int"}},
+			}},
+		}, help)
+		_, err = s.workspaceRootFS.TypeInfo()
+		require.NoError(t, err)
+
+		s.ModifyFiles([]FileChange{
+			{Path: "functions.xgo", Content: []byte("func combine(value int, label string) {}\nfunc broken() { missing() }\n"), Version: 1},
+			{Path: "main.xgo", Content: []byte("\ncombine 1, \"x\"\n"), Version: 1},
+		})
+		params.Position = Position{Line: 1, Character: 12}
+		help, err = s.textDocumentSignatureHelp(params)
+		require.NoError(t, err)
+		assert.Equal(t, &SignatureHelp{
+			Signatures: []SignatureInformation{{
+				Label:      "combine(value int, label string)",
+				Parameters: []ParameterInformation{{Label: "value int"}, {Label: "label string"}},
+			}},
+			ActiveParameter: 1,
+		}, help)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.ErrorContains(t, err, "undefined: missing")
+	})
+
+	for _, tt := range []struct {
+		name         string
+		uri          DocumentURI
+		source       string
+		position     Position
+		wantError    bool
+		wantASTError bool
+		want         *SignatureHelp
+	}{
+		{name: "EmptyFile", uri: "file:///main.xgo"},
+		{name: "MissingFile", uri: "file:///missing.xgo"},
+		{name: "NonSourceFile", uri: "file:///notes.txt"},
+		{name: "InvalidURI", uri: "https://example.com/main.xgo", wantError: true},
+		{
+			name: "PositionBeyondEOF", uri: "file:///main.xgo",
+			source: "func use(value int) {}\nuse 1\n", position: Position{Line: 100, Character: 100},
+			want: &SignatureHelp{Signatures: []SignatureInformation{{
+				Label: "use(value int)", Parameters: []ParameterInformation{{Label: "value int"}},
+			}}},
+		},
+		{name: "NonFunction", uri: "file:///main.xgo", source: "var value int\n_ = value\n", position: Position{Line: 1, Character: 4}},
+		{name: "StartWithInvalidChar", uri: "file:///main.xgo", source: "\n\u201c\u201dvar (\n    maps []int\n)\n", wantASTError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{
+				"main.xgo":  []byte(tt.source),
+				"notes.txt": []byte("func use(value int) {}\nuse 1\n"),
+			})
+			help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: tt.uri},
+					Position:     tt.position,
+				},
+			})
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, help)
+			_, err = s.workspaceRootFS.ASTPackage()
+			if tt.wantASTError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				_, err = s.workspaceRootFS.TypeInfo()
+				assert.NoError(t, err)
+			}
+		})
+	}
+
 	t.Run("Autoclosure", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`
 onStart => {
-	repeatUntil true, => {}
+	runWhen true, => {}
 }
 `),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 17},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
+				Position:     Position{Line: 2, Character: 12},
 			},
 		})
 		require.NoError(t, err)
@@ -84,22 +250,24 @@ onStart => {
 		require.Len(t, help.Signatures, 1)
 		assert.Equal(t, uint32(0), help.ActiveParameter)
 		assert.Equal(t, SignatureInformation{
-			Label: "repeatUntil(condition bool, call func())",
+			Label: "runWhen(condition bool, callback func())",
 			Parameters: []ParameterInformation{
 				{
 					Label:         "condition bool",
 					Documentation: autoclosureParamDocumentation,
 				},
 				{
-					Label: "call func()",
+					Label: "callback func()",
 				},
 			},
 		}, help.Signatures[0])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("FuncDecorator", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`func retry(times int, fn func()) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`func retry(times int, fn func()) {
 	fn()
 }
 
@@ -107,12 +275,11 @@ onStart => {
 func run() {
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 4, Character: 8},
 			},
 		})
@@ -121,11 +288,13 @@ func run() {
 		require.Len(t, help.Signatures, 1)
 		assert.Equal(t, uint32(0), help.ActiveParameter)
 		assert.Equal(t, "retry(times int)", help.Signatures[0].Label)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("FuncDecoratorReturningError", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`func log(fn func() error) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`func log(fn func() error) {
 	_ = fn()
 }
 
@@ -134,12 +303,11 @@ func run() error {
 	return nil
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 4, Character: 3},
 			},
 		})
@@ -148,72 +316,50 @@ func run() error {
 		require.Len(t, help.Signatures, 1)
 		assert.Equal(t, "log()", help.Signatures[0].Label)
 		assert.Empty(t, help.Signatures[0].Parameters)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
-	t.Run("SingleResult", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-func answer() int { return 42 }
-
-onStart => {
-	answer
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 4, Character: 4},
-			},
+	for _, tt := range []struct {
+		name   string
+		result string
+		want   string
+	}{
+		{name: "SingleResult", result: "int", want: "answer() int"},
+		{name: "SingleNamedResult", result: "(n int)", want: "answer() (n int)"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{
+				"main.xgo": []byte("\nfunc answer() " + tt.result + " { return 42 }\n\nfunc main() {\n\tanswer\n}\n"),
+			})
+			help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 4, Character: 4},
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, help)
+			require.Len(t, help.Signatures, 1)
+			assert.Equal(t, tt.want, help.Signatures[0].Label)
+			assert.Empty(t, help.Signatures[0].Parameters)
+			_, err = s.workspaceRootFS.TypeInfo()
+			assert.NoError(t, err)
 		})
-		require.NoError(t, err)
-		require.NotNil(t, help)
-		require.Len(t, help.Signatures, 1)
-		assert.Equal(t, "answer() int", help.Signatures[0].Label)
-		assert.Empty(t, help.Signatures[0].Parameters)
-	})
-
-	t.Run("SingleNamedResult", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-func answer() (n int) { return 42 }
-
-onStart => {
-	answer
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 4, Character: 4},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, help)
-		require.Len(t, help.Signatures, 1)
-		assert.Equal(t, "answer() (n int)", help.Signatures[0].Label)
-		assert.Empty(t, help.Signatures[0].Parameters)
-	})
+	}
 
 	t.Run("XGoxMethod", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`
 onStart => {
-	getWidget Monitor, "myWidget"
+	create Item, "sample"
 }
 `),
-			"assets/index.json": []byte(`{"zorder":[{"name":"myWidget"}]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 2, Character: 1},
 			},
 		})
@@ -222,34 +368,34 @@ onStart => {
 		require.Len(t, help.Signatures, 1)
 		assert.Equal(t, uint32(0), help.ActiveParameter)
 		assert.Equal(t, SignatureInformation{
-			Label: "getWidget(T Type, name WidgetName) *T",
+			Label: "create(T Type, name string) *T",
 			Parameters: []ParameterInformation{
 				{
 					Label: "T Type",
 				},
 				{
-					Label: "name WidgetName",
+					Label: "name string",
 				},
 			},
 		}, help.Signatures[0])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("PartialXGoxFunction", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`import "example.com/typeargs"
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`import "example.com/typeargs"
 
-onStart => {
+func main() {
 	println typeargs.convert(string, 100)
 }
 `),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 		s.workspaceRootFS.Importer = xgoxTestImporter{fallback: s.workspaceRootFS.Importer}
 
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 3, Character: 36},
 			},
 		})
@@ -268,27 +414,28 @@ onStart => {
 				},
 			},
 		}, help.Signatures[0])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("KwargField", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
 type Options struct {
 	Count int
 }
 
 func configure(opts Options?) {}
 
-onStart => {
+func main() {
 	configure count = 1
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 8, Character: 13},
 			},
 		})
@@ -304,11 +451,13 @@ onStart => {
 				},
 			},
 		}, help.Signatures[0])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("OverloadKwargField", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
 type Worker struct{}
 
 type CountOptions struct {
@@ -329,16 +478,15 @@ func (Worker).handle = (
 	(Worker).handleName
 )
 
-onStart => {
+func main() {
 	worker.handle count = 1
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 22, Character: 18},
 			},
 		})
@@ -354,11 +502,13 @@ onStart => {
 				},
 			},
 		}, help.Signatures[0])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 
 	t.Run("OverloadIncompleteKwargName", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
 type Worker struct{}
 
 type CountOptions struct {
@@ -379,16 +529,15 @@ func (Worker).handle = (
 	(Worker).handleName
 )
 
-onStart => {
+func main() {
 	worker.handle cou = 1
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 22, Character: 16},
 			},
 		})
@@ -398,23 +547,24 @@ onStart => {
 		assert.Equal(t, uint32(0), help.ActiveParameter)
 		assert.Equal(t, "handle(opts main.CountOptions)", help.Signatures[0].Label)
 		assert.Equal(t, "handle(opts main.NameOptions)", help.Signatures[1].Label)
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.Error(t, err)
 	})
 
 	t.Run("VariadicKwargActiveParameter", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
 func process(opts map[string]string?, args ...int) {}
 
-onStart => {
+func main() {
     process 1, name = "x"
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		})
 
 		positionalHelp, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 4, Character: 12},
 			},
 		})
@@ -436,7 +586,7 @@ onStart => {
 
 		kwargHelp, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 4, Character: 23},
 			},
 		})
@@ -445,5 +595,7 @@ onStart => {
 		require.Len(t, kwargHelp.Signatures, 1)
 		assert.Equal(t, uint32(0), kwargHelp.ActiveParameter)
 		assert.Equal(t, positionalHelp.Signatures[0], kwargHelp.Signatures[0])
+		_, err = s.workspaceRootFS.TypeInfo()
+		assert.NoError(t, err)
 	})
 }

--- a/internal/server/spx_inlay_hint_test.go
+++ b/internal/server/spx_inlay_hint_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectInlayHintsSpx(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		arguments string
+		want      []InlayHint
+	}{
+		{name: "SpxStepToWithAmbiguousArgument", arguments: "1,"},
+		{
+			name:      "SpxStepToWithPositionArguments",
+			arguments: "1, 2",
+			want: []InlayHint{
+				{Position: Position{Line: 2, Character: 12}, Label: "x", Kind: Parameter},
+				{Position: Position{Line: 2, Character: 15}, Label: "y", Kind: Parameter},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			files := map[string][]byte{
+				"main.spx":                           {},
+				"MySprite.spx":                       []byte("\nonStart => {\n\tstepToWith " + tt.arguments + "\n}\n"),
+				"assets/index.json":                  []byte(`{}`),
+				"assets/sprites/MySprite/index.json": []byte(`{}`),
+			}
+			s := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+
+			result, _, astFile, err := s.compileAndGetASTFileForDocumentURI("file:///MySprite.spx")
+			require.NoError(t, err)
+			require.NotNil(t, astFile)
+
+			inlayHints := collectInlayHints(result.proj, astFile, 0, 0)
+			require.Len(t, inlayHints, len(tt.want))
+			for i, want := range tt.want {
+				assert.Equal(t, want, inlayHints[i])
+			}
+		})
+	}
+}

--- a/internal/server/spx_util.go
+++ b/internal/server/spx_util.go
@@ -24,14 +24,18 @@ func IsSpxEventHandlerFuncName(name string) bool {
 
 // IsInSpxPkg reports whether the given object is defined in the spx package.
 func IsInSpxPkg(obj gotypes.Object) bool {
-	return obj != nil && obj.Pkg() == GetSpxPkg()
+	if obj == nil {
+		return false
+	}
+	pkg := obj.Pkg()
+	return pkg != nil && pkg.Path() == SpxPkgPath && pkg == GetSpxPkg()
 }
 
 // GetSimplifiedTypeString returns the string representation of the given type,
 // with the spx package name omitted while other packages use their short names.
 func GetSimplifiedTypeString(typ gotypes.Type) string {
 	return gotypes.TypeString(typ, func(p *gotypes.Package) string {
-		if p == GetSpxPkg() {
+		if p.Path() == SpxPkgPath && p == GetSpxPkg() {
 			return ""
 		}
 		return p.Name()

--- a/internal/server/spx_util_test.go
+++ b/internal/server/spx_util_test.go
@@ -10,6 +10,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsInSpxPkg(t *testing.T) {
+	t.Run("NilObject", func(t *testing.T) {
+		assert.False(t, IsInSpxPkg(nil))
+	})
+
+	for _, tt := range []struct {
+		name string
+		pkg  *gotypes.Package
+		want bool
+	}{
+		{name: "NoPackage"},
+		{name: "OtherPackageNamedSpx", pkg: gotypes.NewPackage("example.com/spx", "spx")},
+		{name: "SpxSubpackage", pkg: gotypes.NewPackage(SpxPkgPath+"/subpkg", "subpkg")},
+		{name: "SpxPackage", pkg: GetSpxPkg(), want: true},
+		{name: "DistinctSpxPackage", pkg: gotypes.NewPackage(SpxPkgPath, "spx")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := gotypes.NewTypeName(token.NoPos, tt.pkg, "Value", gotypes.Typ[gotypes.Int])
+			assert.Equal(t, tt.want, IsInSpxPkg(obj))
+		})
+	}
+}
+
+func TestGetSimplifiedTypeString(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		pkg  *gotypes.Package
+		want string
+	}{
+		{name: "NoPackage", want: "Value"},
+		{name: "OtherPackage", pkg: gotypes.NewPackage("example.com/sample", "sample"), want: "sample.Value"},
+		{name: "OtherPackageNamedSpx", pkg: gotypes.NewPackage("example.com/spx", "spx"), want: "spx.Value"},
+		{name: "SpxPackage", pkg: GetSpxPkg(), want: "Value"},
+		{name: "DistinctSpxPackage", pkg: gotypes.NewPackage(SpxPkgPath, "spx"), want: "spx.Value"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			named := gotypes.NewNamed(gotypes.NewTypeName(token.NoPos, tt.pkg, "Value", nil), gotypes.NewStruct(nil, nil), nil)
+			assert.Equal(t, tt.want, GetSimplifiedTypeString(named))
+		})
+	}
+}
+
 func TestResolvedNamedType(t *testing.T) {
 	pkg := gotypes.NewPackage("example.com/pkg", "pkg")
 	named := gotypes.NewNamed(gotypes.NewTypeName(token.NoPos, pkg, "Point", nil), gotypes.NewStruct(nil, nil), nil)

--- a/internal/testframework/testdata/framework.go
+++ b/internal/testframework/testdata/framework.go
@@ -23,6 +23,12 @@ func (a *App) Measure__0(value int) int { return value }
 // Measure__1 is the string overload of Measure.
 func (a *App) Measure__1(value string) int { return len(value) }
 
+// RunWhen accepts a deferred condition and a callback.
+func RunWhen(__xgo_autoclosure_condition func() bool, callback func()) {}
+
+// XGot_App_XGox_Create provides a method with an explicit type argument.
+func XGot_App_XGox_Create[T any](a *App, name string) *T { return nil }
+
 // Item is the work base class.
 type Item struct{}
 


### PR DESCRIPTION
Resolve signature help and inlay hints from project AST and type information so their tests can use the isolated classfile framework. Keep spx-specific `stepToWith` coverage in a dedicated test file.

Avoid loading spx package data when checking or formatting unrelated packages. Preserve spx package identity and type display behavior. Skip AST files without source positions to avoid signature help panics.

Cover source file kinds, cross-file calls, overload ambiguity, kwargs, autoclosures, decorators, XGox calls, UTF-16 positions, range filtering, and document updates with partial type information.