### PR TITLE
fix(server): use project data for formatting

### DIFF
--- a/internal/server/format.go
+++ b/internal/server/format.go
@@ -6,9 +6,9 @@ import (
 	gotypes "go/types"
 	"io/fs"
 	"iter"
+	"maps"
 	"path"
 	"slices"
-	"time"
 
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/format"
@@ -20,25 +20,26 @@ import (
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification#textDocument_formatting
 func (s *Server) textDocumentFormatting(params *DocumentFormattingParams) ([]TextEdit, error) {
-	spxFile, err := s.fromDocumentURI(params.TextDocument.URI)
+	filename, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get file path from document uri %q: %w", params.TextDocument.URI, err)
 	}
-	if path.Ext(spxFile) != ".spx" {
-		return nil, nil // Not an spx source file.
+	proj := s.getProj()
+	switch path.Ext(filename) {
+	case ".xgo", ".gop", ".gox":
+	default:
+		if _, _, ok := proj.Mod.ClassInfo(path.Base(filename)); !ok {
+			return nil, nil
+		}
 	}
-
-	snapshot := s.getProj().Snapshot()
-	file, ok := snapshot.File(spxFile)
+	file, ok := proj.File(filename)
 	if !ok {
-		return nil, fmt.Errorf("failed to read spx source file: %w", fs.ErrNotExist)
+		return nil, fmt.Errorf("failed to read source file: %w", fs.ErrNotExist)
 	}
 	original := file.Content
-	// FIXME(wyvern): Remove this workaround when the server supports CRLF line endings.
-	original = bytes.ReplaceAll(original, []byte("\r\n"), []byte("\n"))
-	formatted, err := s.formatSpx(snapshot, spxFile, original)
+	formatted, err := formatSource(proj, filename, original)
 	if err != nil {
-		return nil, fmt.Errorf("failed to format spx source file: %w", err)
+		return nil, fmt.Errorf("failed to format source file: %w", err)
 	}
 
 	if bytes.Equal(formatted, original) {
@@ -47,11 +48,7 @@ func (s *Server) textDocumentFormatting(params *DocumentFormattingParams) ([]Tex
 
 	// Simply replace the entire document.
 	lines := bytes.Count(original, []byte("\n"))
-	lastNewLine := bytes.LastIndex(original, []byte("\n"))
-	lastLineContent := original
-	if lastNewLine >= 0 {
-		lastLineContent = lastLineContent[lastNewLine+1:]
-	}
+	lastLineContent := original[bytes.LastIndexByte(original, '\n')+1:]
 	return []TextEdit{
 		{
 			Range: Range{
@@ -66,61 +63,62 @@ func (s *Server) textDocumentFormatting(params *DocumentFormattingParams) ([]Tex
 	}, nil
 }
 
-// spxFormatter defines a function that formats an spx source file in the given
-// root file system snapshot.
-type spxFormatter func(snapshot *xgo.Project, spxFile string) (formatted []byte, err error)
+// sourceFormatter formats a source file in the given project snapshot.
+type sourceFormatter func(snapshot *xgo.Project, filename string) (formatted []byte, err error)
 
-// formatSpx applies a series of formatters to an spx source file in order.
+// formatSource applies a series of formatters to a source file in order.
 //
 // The formatters are applied in the following order:
 //  1. XGo formatter
 //  2. Lambda parameter elimination
-//  3. Declaration reordering
-func (s *Server) formatSpx(snapshot *xgo.Project, spxFile string, original []byte) ([]byte, error) {
+//  3. Classfile declaration reordering
+func formatSource(proj *xgo.Project, filename string, original []byte) ([]byte, error) {
+	// Type checking can modify other classfiles too. Use fresh caches for all
+	// files and a fresh file set so temporary source positions are not retained
+	// by the project after formatting.
+	files := maps.Collect(proj.Files())
+	files[filename] = &xgo.File{Content: original}
+	snapshot := xgo.NewProject(nil, files, xgo.FeatASTCache|xgo.FeatTypeInfoCache)
+	snapshot.PkgPath = proj.PkgPath
+	snapshot.Mod = proj.Mod
+	snapshot.Importer = proj.Importer
 	formatted := original
-	for _, formatter := range []spxFormatter{
-		s.formatSpxXGo,
-		s.formatSpxLambda,
-		s.formatSpxDecls,
+	for _, formatter := range []sourceFormatter{
+		formatXGo,
+		formatLambda,
+		formatClassDecls,
 	} {
-		subFormatted, err := formatter(snapshot, spxFile)
+		next, err := formatter(snapshot, filename)
 		if err != nil {
 			return nil, err
 		}
-		if subFormatted != nil && !bytes.Equal(subFormatted, formatted) {
-			snapshot = snapshot.SnapshotWithOverlay(map[string]*xgo.File{
-				spxFile: {
-					Content: subFormatted,
-					ModTime: time.Now(),
-				},
-			})
-			formatted = subFormatted
+		if next != nil && !bytes.Equal(next, formatted) {
+			snapshot.PutFile(filename, &xgo.File{Content: next})
+			formatted = next
 		}
 	}
 	return formatted, nil
 }
 
-// formatSpxXGo formats an spx source file with XGo formatter.
-func (s *Server) formatSpxXGo(snapshot *xgo.Project, spxFile string) ([]byte, error) {
-	file, ok := snapshot.File(spxFile)
+// formatXGo formats a source file with XGo formatter.
+func formatXGo(snapshot *xgo.Project, filename string) ([]byte, error) {
+	file, ok := snapshot.File(filename)
 	if !ok {
 		return nil, fs.ErrNotExist
 	}
-	original := file.Content
-	formatted, err := format.Source(original, classInfo, spxFile)
+	formatted, err := format.Source(file.Content, snapshot.Mod.ClassInfo, filename)
 	if err != nil {
 		return nil, err
 	}
 	if len(formatted) == 0 || string(formatted) == "\n" {
 		return []byte{}, nil
 	}
-	return formatted, err
+	return formatted, nil
 }
 
-// formatSpxLambda formats an spx source file by eliminating unused lambda parameters.
-func (s *Server) formatSpxLambda(snapshot *xgo.Project, spxFile string) ([]byte, error) {
-	snapshot.UpdateFiles(s.fileMapGetter())
-	astFile, _ := snapshot.ASTFile(spxFile)
+// formatLambda formats a source file by eliminating unused lambda parameters.
+func formatLambda(snapshot *xgo.Project, filename string) ([]byte, error) {
+	astFile, _ := snapshot.ASTFile(filename)
 	if astFile == nil {
 		return nil, nil
 	}
@@ -141,10 +139,10 @@ func (s *Server) formatSpxLambda(snapshot *xgo.Project, spxFile string) ([]byte,
 	return formatted, nil
 }
 
-// formatSpxDecls formats an spx source file by reordering declarations.
-func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, error) {
-	astFile, _ := snapshot.ASTFile(spxFile)
-	if astFile == nil {
+// formatClassDecls reorders classfile declarations and groups class fields.
+func formatClassDecls(snapshot *xgo.Project, filename string) ([]byte, error) {
+	astFile, _ := snapshot.ASTFile(filename)
+	if astFile == nil || !astFile.IsClass {
 		return nil, nil
 	}
 
@@ -431,12 +429,7 @@ func (s *Server) formatSpxDecls(snapshot *xgo.Project, spxFile string) ([]byte, 
 	if len(formatted) == 0 || string(formatted) == "\n" {
 		return []byte{}, nil
 	}
-	return format.Source(formatted, classInfo, spxFile)
-}
-
-// classInfo is the parser class information used when formatting SPX files.
-func classInfo(string) (autoLambdas map[string]int, isProj, ok bool) {
-	return nil, true, true
+	return format.Source(formatted, snapshot.Mod.ClassInfo, filename)
 }
 
 // getDeclDoc returns the doc comment of a declaration if any.

--- a/internal/server/format_test.go
+++ b/internal/server/format_test.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"bytes"
 	gotypes "go/types"
 	"io/fs"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/format"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 	"github.com/stretchr/testify/assert"
@@ -13,46 +15,295 @@ import (
 )
 
 func TestServerTextDocumentFormatting(t *testing.T) {
+	t.Run("SourceKinds", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			filename string
+			source   string
+			want     string
+		}{
+			{
+				name: "XGo", filename: "main.xgo",
+				source: "var first=1\nvar second=2\ntype Count int\necho first,second\n",
+				want:   "var first = 1\nvar second = 2\n\ntype Count int\n\necho first, second\n",
+			},
+			{
+				name: "LegacyXGo", filename: "main.gop",
+				source: "var first=1\nvar second=2\ntype Count int\necho first,second\n",
+				want:   "var first = 1\nvar second = 2\n\ntype Count int\n\necho first, second\n",
+			},
+			{
+				name: "StandaloneClass", filename: "Record.gox",
+				source: "var count Count\ntype Count int\n",
+				want:   "type Count int\n\nvar (\n\tcount Count\n)\n",
+			},
+			{
+				name: "ProjectClass", filename: "main_fixture.gox",
+				source: "var count Count\ntype Count int\n",
+				want:   "type Count int\n\nvar (\n\tcount Count\n)\n",
+			},
+			{
+				name: "WorkClass", filename: "Worker_fixture.gox",
+				source: "var count Count\ntype Count int\n",
+				want:   "type Count int\n\nvar (\n\tcount Count\n)\n",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
+				params := &DocumentFormattingParams{
+					TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
+				}
+				edits, err := s.textDocumentFormatting(params)
+				require.NoError(t, err)
+				require.Len(t, edits, 1)
+				assert.Equal(t, tt.want, edits[0].NewText)
+
+				s.ModifyFiles([]FileChange{{Path: tt.filename, Content: []byte(edits[0].NewText), Version: 1}})
+				edits, err = s.textDocumentFormatting(params)
+				require.NoError(t, err)
+				assert.Empty(t, edits)
+			})
+		}
+	})
+
+	t.Run("ClassfileRegistration", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{"main.unit": []byte("var count Count\ntype Count int\n")})
+		params := &DocumentFormattingParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.unit"},
+		}
+		edits, err := s.textDocumentFormatting(params)
+		require.NoError(t, err)
+		assert.Nil(t, edits)
+
+		mod := s.workspaceRootFS.Mod
+		class, ok := mod.LookupClass("_fixture.gox")
+		require.True(t, ok)
+		class.Ext = ".unit"
+		class.FullExt = "main.unit"
+		class.Works[0].Ext = ".unit"
+		require.NoError(t, mod.ImportClasses())
+		edits, err = s.textDocumentFormatting(params)
+		require.NoError(t, err)
+		require.Len(t, edits, 1)
+		assert.Equal(t, "type Count int\n\nvar (\n\tcount Count\n)\n", edits[0].NewText)
+	})
+
+	t.Run("AutoLambda", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte("onStart {echo \"ready\"}\nonEvent \"value\", (value)=>{echo \"value\"}\n"),
+		})
+		class, ok := s.workspaceRootFS.Mod.LookupClass("_fixture.gox")
+		require.True(t, ok)
+		class.AutoLambdas = map[string]int{"onStart": 0}
+		_, err := s.workspaceRootFS.TypeInfo()
+		require.NoError(t, err)
+		params := &DocumentFormattingParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
+		}
+		edits, err := s.textDocumentFormatting(params)
+		require.NoError(t, err)
+		require.Len(t, edits, 1)
+		assert.Equal(t, "onStart {\n\techo \"ready\"\n}\nonEvent \"value\", () => {\n\techo \"value\"\n}\n", edits[0].NewText)
+
+		s.ModifyFiles([]FileChange{{Path: "main_fixture.gox", Content: []byte(edits[0].NewText), Version: 1}})
+		edits, err = s.textDocumentFormatting(params)
+		require.NoError(t, err)
+		assert.Empty(t, edits)
+	})
+
+	t.Run("FileUpdates", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte("onStart => {\n\techo \"old\"\n}\n"),
+		})
+		_, err := s.workspaceRootFS.TypeInfo()
+		require.NoError(t, err)
+
+		s.ModifyFiles([]FileChange{
+			{Path: "main_fixture.gox", Content: []byte("var limit int = 2\n"), Version: 1},
+			{Path: "Worker_fixture.gox", Content: []byte("onEvent \"value\", (value)=>{echo limit}\nonValue (value)=>{echo \"ready\"}\n"), Version: 1},
+		})
+		_, err = s.workspaceRootFS.TypeInfo()
+		require.NoError(t, err)
+		params := &DocumentFormattingParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///Worker_fixture.gox"},
+		}
+		edits, err := s.textDocumentFormatting(params)
+		require.NoError(t, err)
+		require.Len(t, edits, 1)
+		assert.Equal(t, "onEvent \"value\", () => {\n\techo limit\n}\nonValue (value) => {\n\techo \"ready\"\n}\n", edits[0].NewText)
+	})
+
+	t.Run("FileSetIsolation", func(t *testing.T) {
+		for _, tt := range []struct {
+			name   string
+			source string
+			want   string
+		}{
+			{
+				name:   "NoChangesNeeded",
+				source: "onStart => {\n\techo \"ready\"\n}\n",
+				want:   "onStart => {\n\techo \"ready\"\n}\n",
+			},
+			{
+				name:   "WithChanges",
+				source: "var count int\nonEvent \"value\", (value)=>{echo count}\n",
+				want:   "var (\n\tcount int\n)\n\nonEvent \"value\", () => {\n\techo count\n}\n",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{
+					"main_fixture.gox":   []byte(tt.source),
+					"Worker_fixture.gox": []byte("var count int\n"),
+				})
+				proj := s.workspaceRootFS
+				// Populate the importer before measuring the project's file set.
+				_, err := proj.TypeInfo()
+				require.NoError(t, err)
+				countFiles := func() int {
+					count := 0
+					proj.Fset.Iterate(func(*token.File) bool {
+						count++
+						return true
+					})
+					return count
+				}
+				wantCount := countFiles()
+				wantBase := proj.Fset.Base()
+				params := &DocumentFormattingParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
+				}
+
+				for range 3 {
+					edits, err := s.textDocumentFormatting(params)
+					require.NoError(t, err)
+					if tt.want == tt.source {
+						assert.Empty(t, edits)
+					} else {
+						require.Len(t, edits, 1)
+						assert.Equal(t, tt.want, edits[0].NewText)
+					}
+					assert.Equal(t, wantCount, countFiles())
+					assert.Equal(t, wantBase, proj.Fset.Base())
+				}
+			})
+		}
+	})
+
+	t.Run("OtherFileASTIsolation", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox":   []byte("onEvent \"value\", (value) => {\n\techo \"ready\"\n}\n"),
+			"Worker_fixture.gox": []byte("var count int\n"),
+		})
+		proj := s.workspaceRootFS
+		workerAST, err := proj.ASTFile("Worker_fixture.gox")
+		require.NoError(t, err)
+		declCount := len(workerAST.Decls)
+		edits, err := s.textDocumentFormatting(&DocumentFormattingParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
+		})
+		require.NoError(t, err)
+		require.Len(t, edits, 1)
+		assert.Equal(t, "onEvent \"value\", () => {\n\techo \"ready\"\n}\n", edits[0].NewText)
+		assert.Len(t, workerAST.Decls, declCount)
+		cachedAST, err := proj.ASTFile("Worker_fixture.gox")
+		require.NoError(t, err)
+		assert.Same(t, workerAST, cachedAST)
+	})
+
+	t.Run("PlainXGoLambda", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte("import \"example.com/framework\"\nvar app framework.App\napp.onEvent \"value\", (value)=>{echo \"ready\"}\n"),
+		})
+		_, err := s.workspaceRootFS.TypeInfo()
+		require.NoError(t, err)
+		edits, err := s.textDocumentFormatting(&DocumentFormattingParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+		})
+		require.NoError(t, err)
+		require.Len(t, edits, 1)
+		assert.Equal(t, "import \"example.com/framework\"\n\nvar app framework.App\n\napp.onEvent \"value\", () => {\n\techo \"ready\"\n}\n", edits[0].NewText)
+	})
+
+	t.Run("LineEndingsAndUTF16", func(t *testing.T) {
+		for _, tt := range []struct {
+			name   string
+			source string
+			want   string
+			end    Position
+		}{
+			{
+				name: "UTF16LastLine", source: "echo   \"\U0001f680\"", want: "echo \"\U0001f680\"\n",
+				end: Position{Line: 0, Character: 11},
+			},
+			{
+				name: "CRLFOnly", source: "echo \"ready\"\r\n", want: "echo \"ready\"\n",
+				end: Position{Line: 1, Character: 0},
+			},
+			{
+				name: "CRLFWithUTF16LastLine", source: "echo \"ready\"\r\necho   \"\U0001f680\"", want: "echo \"ready\"\necho \"\U0001f680\"\n",
+				end: Position{Line: 1, Character: 11},
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+				edits, err := s.textDocumentFormatting(&DocumentFormattingParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+				})
+				require.NoError(t, err)
+				assert.Equal(t, []TextEdit{{Range: Range{End: tt.end}, NewText: tt.want}}, edits)
+			})
+		}
+	})
+
+	t.Run("InvalidSyntax", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{"main.xgo": []byte("func {\n")})
+		edits, err := s.textDocumentFormatting(&DocumentFormattingParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+		})
+		assert.ErrorContains(t, err, "failed to format source file")
+		assert.Nil(t, edits)
+	})
+
 	t.Run("Normal", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
-// An spx game.
+			"main_fixture.gox": []byte(`
+// A classfile project.
 
 var (
-  MyAircraft MyAircraft
-  Bullet Bullet
+  title string
+  count int
 )
 type Score int
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
+		assert.Equal(t, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 8, Character: 0},
 			},
-			NewText: `// An spx game.
+			NewText: `// A classfile project.
 
 type Score int
 
 var (
-	MyAircraft MyAircraft
-	Bullet     Bullet
+	title string
+	count int
 )
 `,
-		})
+		}, edits[0])
 	})
 
 	t.Run("EnumAndFuncDecorator", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`import "time"
+			"main_fixture.gox": []byte(`import "time"
 
 @retry(time.Second)
 func run() {
@@ -67,9 +318,9 @@ func retry(delay time.Duration, fn func()) {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -93,7 +344,7 @@ func retry(delay time.Duration, fn func()) {
 
 	t.Run("StaticValues", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`const .kind, Rect.name = "shape", "rect"
+			"main_fixture.gox": []byte(`const .kind, Rect.name = "shape", "rect"
 
 var (
 .count int=1
@@ -104,9 +355,9 @@ width int
 type Rect int
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -124,13 +375,13 @@ var (
 `, edits[0].NewText)
 	})
 
-	t.Run("NonSpxFile", func(t *testing.T) {
+	t.Run("UnsupportedFile", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.xgo": []byte(`echo "Hello, XGo!"`),
+			"notes.txt": []byte(`echo "Hello, XGo!"`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///notes.txt"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -139,9 +390,9 @@ var (
 	})
 
 	t.Run("FileNotFound", func(t *testing.T) {
-		s := New(newProjectWithoutModTime(map[string][]byte{}), nil, fileMapGetter(map[string][]byte{}), &MockScheduler{})
+		s := newTestServer(t, nil)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///notexist.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///notexist_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -151,11 +402,11 @@ var (
 
 	t.Run("NoChangesNeeded", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(``),
+			"main_fixture.gox": []byte("onStart => {\n\techo \"ready\"\n}\n"),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -165,97 +416,97 @@ var (
 
 	t.Run("AcceptableFormatError", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 
-var MyAircraft MyAircraft
+var title string
 !InvalidSyntax
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
+		assert.Equal(t, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 4, Character: 0},
 			},
-			NewText: `// An spx game.
+			NewText: `// A classfile project.
 
 var (
-	MyAircraft MyAircraft
+	title string
 )
 
 !InvalidSyntax
 `,
-		})
+		}, edits[0])
 	})
 
 	t.Run("ClassFieldsDeclarationWithComments", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 
 // Class fields.
 var (
-    // The aircraft.
-    MyAircraft MyAircraft // The only aircraft.
+    // The title.
+    title string // The project title.
 
-    Bullet Bullet // The first bullet.
-    // The second bullet.
-    Bullet2 Bullet
-    // The third bullet.
-    Bullet3 Bullet
-    Bullet4 Bullet // The fourth bullet.
-    // The fifth bullet.
-    Bullet5 Bullet
+    count int // The first counter.
+    // The second counter.
+    count2 int
+    // The third counter.
+    count3 int
+    count4 int // The fourth counter.
+    // The fifth counter.
+    count5 int
 
-    Bullet6 Bullet // The sixth bullet.
+    count6 int // The sixth counter.
 )
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Equal(t, `// An spx game.
+		assert.Equal(t, `// A classfile project.
 
 // Class fields.
 var (
-	// The aircraft.
-	MyAircraft MyAircraft // The only aircraft.
+	// The title.
+	title string // The project title.
 
-	Bullet Bullet // The first bullet.
-	// The second bullet.
-	Bullet2 Bullet
-	// The third bullet.
-	Bullet3 Bullet
-	Bullet4 Bullet // The fourth bullet.
-	// The fifth bullet.
-	Bullet5 Bullet
+	count int // The first counter.
+	// The second counter.
+	count2 int
+	// The third counter.
+	count3 int
+	count4 int // The fourth counter.
+	// The fifth counter.
+	count5 int
 
-	Bullet6 Bullet // The sixth bullet.
+	count6 int // The sixth counter.
 )
 `, edits[0].NewText)
 	})
 
 	t.Run("ClassFieldsDeclarationWithClosingComment", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`var (
+			"main_fixture.gox": []byte(`var (
     score int
 ) // Class fields.
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -269,45 +520,46 @@ var (
 
 	t.Run("ClassFieldsDeclarationWithoutDoc", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 
 	var (
-		// The aircraft.
-		MyAircraft MyAircraft // The only aircraft.
-		Bullet Bullet
+		// The title.
+		title string // The project title.
+		count int
 	)
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Equal(t, `// An spx game.
+		assert.Equal(t, `// A classfile project.
 
 var (
-	// The aircraft.
-	MyAircraft MyAircraft // The only aircraft.
-	Bullet     Bullet
+	// The title.
+	title string // The project title.
+	count int
 )
 `, edits[0].NewText)
 	})
 
-	t.Run("NoTypeSpriteVarDeclaration", func(t *testing.T) {
+	t.Run("EmbeddedClassField", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"Worker_fixture.gox": {},
+			"main_fixture.gox": []byte(`// A classfile project.
 
 var (
-	MySprite
+	Worker
 )
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -317,17 +569,17 @@ var (
 
 	t.Run("WithImportStmt", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 import "math"
 
-onClick => {
+onStart => {
 	println math.floor(2.5)
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -337,44 +589,76 @@ onClick => {
 
 	t.Run("WithUnusedLambdaParams", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
-onKey [KeyLeft, KeyRight], (key) => {
-	println "key"
+			"main_fixture.gox": []byte(`// A classfile project.
+onEvent "value", (value) => {
+	println "value"
 }
 
-onKey [KeyLeft, KeyRight], (key) => {
-	println key
+onEvent "value", (value) => {
+	println value
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
+
+		proj := s.workspaceRootFS
+		astFile, err := proj.ASTFile("main_fixture.gox")
+		require.NoError(t, err)
+		typeInfo, err := proj.TypeInfo()
+		require.NoError(t, err)
+		var before bytes.Buffer
+		require.NoError(t, format.Node(&before, proj.Fset, astFile))
+		require.Equal(t, string(m["main_fixture.gox"]), before.String())
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
+		assert.Equal(t, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 8, Character: 0},
 			},
-			NewText: `// An spx game.
-onKey [KeyLeft, KeyRight], () => {
-	println "key"
+			NewText: `// A classfile project.
+onEvent "value", () => {
+	println "value"
 }
 
-onKey [KeyLeft, KeyRight], (key) => {
-	println key
+onEvent "value", (value) => {
+	println value
 }
 `,
-		})
+		}, edits[0])
+
+		// Formatting must not change the cached AST or the pending document.
+		var after bytes.Buffer
+		require.NoError(t, format.Node(&after, proj.Fset, astFile))
+		assert.Equal(t, before.String(), after.String())
+		cachedAST, err := proj.ASTFile("main_fixture.gox")
+		require.NoError(t, err)
+		assert.Same(t, astFile, cachedAST)
+		cachedTypeInfo, err := proj.TypeInfo()
+		require.NoError(t, err)
+		assert.Same(t, typeInfo, cachedTypeInfo)
+		file, ok := proj.File("main_fixture.gox")
+		require.True(t, ok)
+		assert.Equal(t, m["main_fixture.gox"], file.Content)
+
+		repeatedEdits, err := s.textDocumentFormatting(params)
+		require.NoError(t, err)
+		assert.Equal(t, edits, repeatedEdits)
+
+		s.ModifyFiles([]FileChange{{Path: "main_fixture.gox", Content: []byte(edits[0].NewText), Version: 1}})
+		edits, err = s.textDocumentFormatting(params)
+		require.NoError(t, err)
+		assert.Empty(t, edits)
 	})
 
 	t.Run("WithUnusedLambdaParamsInKwarg", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`type Worker struct{}
+			"main_fixture.gox": []byte(`type Worker struct{}
 
 type Options0 struct {
 	Handler func()
@@ -404,15 +688,15 @@ onStart => {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
+		assert.Equal(t, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 28, Character: 0},
@@ -449,63 +733,16 @@ onStart => {
 	}
 }
 `,
-		})
-	})
-
-	t.Run("WithUnusedLambdaParamsForSprite", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": {},
-			"MySprite.spx": []byte(`// An spx game.
-onKey [KeyLeft, KeyRight], (key) => {
-	println "key"
-}
-onTouchStart "MySprite", (s) => {
-	println "touched", s
-}
-onTouchStart "MySprite", (s) => {}
-onTouchStart (s, t) => { // type mismatch
-}
-onTouchStart 123, (s) => { // type mismatch
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-		}
-
-		edits, err := s.textDocumentFormatting(params)
-		require.NoError(t, err)
-		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
-			Range: Range{
-				Start: Position{Line: 0, Character: 0},
-				End:   Position{Line: 12, Character: 0},
-			},
-			NewText: `// An spx game.
-onKey [KeyLeft, KeyRight], () => {
-	println "key"
-}
-onTouchStart "MySprite", (s) => {
-	println "touched", s
-}
-onTouchStart "MySprite", () => {
-}
-onTouchStart (s, t) => { // type mismatch
-}
-onTouchStart 123, (s) => { // type mismatch
-}
-`,
-		})
+		}, edits[0])
 	})
 
 	t.Run("EmptyFile", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(``),
+			"main_fixture.gox": []byte(``),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -515,28 +752,28 @@ onTouchStart 123, (s) => { // type mismatch
 
 	t.Run("WhitespaceOnlyFile", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(` `),
+			"main_fixture.gox": []byte(` `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
+		assert.Equal(t, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 0, Character: 1},
 			},
 			NewText: ``,
-		})
+		}, edits[0])
 	})
 
 	t.Run("WithFloatingComments", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`import "fmt"
+			"main_fixture.gox": []byte(`import "fmt"
 
 // floating comment1
 
@@ -561,15 +798,15 @@ const b = "123"
 // floating comment5
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
+		assert.Equal(t, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 23, Character: 0},
@@ -599,12 +836,12 @@ func test() {
 
 // floating comment5
 `,
-		})
+		}, edits[0])
 	})
 
 	t.Run("WithTrailingComments", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`import "fmt" // trailing comment for import "fmt"
+			"main_fixture.gox": []byte(`import "fmt" // trailing comment for import "fmt"
 
 const foo = "bar" // trailing comment for const foo
 
@@ -613,15 +850,15 @@ var a int // trailing comment for var a
 func test() {} // trailing comment for func test
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
+		assert.Equal(t, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 7, Character: 0},
@@ -636,12 +873,12 @@ var (
 
 func test() {} // trailing comment for func test
 `,
-		})
+		}, edits[0])
 	})
 
 	t.Run("WithMethods", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 
 type Foo struct{}
 
@@ -654,20 +891,20 @@ func (Foo) Bar() {}
 func Bar() {}
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Contains(t, edits, TextEdit{
+		assert.Equal(t, TextEdit{
 			Range: Range{
 				Start: Position{Line: 0, Character: 0},
 				End:   Position{Line: 11, Character: 0},
 			},
-			NewText: `// An spx game.
+			NewText: `// A classfile project.
 
 type Foo struct{}
 
@@ -679,35 +916,35 @@ var (
 
 func Bar() {}
 `,
-		})
+		}, edits[0])
 	})
 
 	t.Run("ClassFieldsDeclarationWithAndWithoutInit", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 
 var (
 	dir int
-	snakeBodyParts []Sprite
+	values []int
 
 	moveStep int = 20
 )
 
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Equal(t, `// An spx game.
+		assert.Equal(t, `// A classfile project.
 
 var (
-	dir            int
-	snakeBodyParts []Sprite
+	dir    int
+	values []int
 
 	moveStep int = 20
 )
@@ -716,11 +953,11 @@ var (
 
 	t.Run("EmptyClassFieldsDeclaration", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte("var ( )\n"),
+			"main_fixture.gox": []byte("var ( )\n"),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
@@ -731,7 +968,7 @@ var (
 
 	t.Run("DuplicateClassFieldsDeclaration", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 
 var (
 	score int
@@ -743,20 +980,19 @@ var (
 
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "multiple top-level var declarations in classfile")
+		assert.ErrorContains(t, err, "multiple top-level var declarations in classfile")
 		assert.Nil(t, edits)
 	})
 
 	t.Run("ClassFieldsDeclarationWithMixedComments", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 
 var (
 	// Score for the player
@@ -773,15 +1009,15 @@ var (
 
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
 		require.NoError(t, err)
 		require.Len(t, edits, 1)
-		assert.Equal(t, `// An spx game.
+		assert.Equal(t, `// A classfile project.
 
 var (
 	// Score for the player
@@ -800,7 +1036,7 @@ var (
 
 	t.Run("DuplicateClassFieldsDeclarationWithoutParens", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 
 var x int
 var y int = 10
@@ -809,20 +1045,19 @@ var name string = "Player"
 
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "multiple top-level var declarations in classfile")
+		assert.ErrorContains(t, err, "multiple top-level var declarations in classfile")
 		assert.Nil(t, edits)
 	})
 
 	t.Run("WithShadowEntryComments", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// An spx game.
+			"main_fixture.gox": []byte(`// A classfile project.
 var (
 	count int
 )
@@ -834,9 +1069,9 @@ onStart => {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		params := &DocumentFormattingParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		edits, err := s.textDocumentFormatting(params)

--- a/internal/server/spx_format_test.go
+++ b/internal/server/spx_format_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerTextDocumentFormattingSpx(t *testing.T) {
+	t.Run("WithUnusedLambdaParamsForSprite", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": {},
+			"MySprite.spx": []byte(`// An spx game.
+onKey [KeyLeft, KeyRight], (key) => {
+	println "key"
+}
+onTouchStart "MySprite", (s) => {
+	println "touched", s
+}
+onTouchStart "MySprite", (s) => {}
+onTouchStart (s, t) => { // type mismatch
+}
+onTouchStart 123, (s) => { // type mismatch
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		params := &DocumentFormattingParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+		}
+
+		edits, err := s.textDocumentFormatting(params)
+		require.NoError(t, err)
+		require.Len(t, edits, 1)
+		assert.Equal(t, TextEdit{
+			Range: Range{
+				Start: Position{Line: 0, Character: 0},
+				End:   Position{Line: 12, Character: 0},
+			},
+			NewText: `// An spx game.
+onKey [KeyLeft, KeyRight], () => {
+	println "key"
+}
+onTouchStart "MySprite", (s) => {
+	println "touched", s
+}
+onTouchStart "MySprite", () => {
+}
+onTouchStart (s, t) => { // type mismatch
+}
+onTouchStart 123, (s) => { // type mismatch
+}
+`,
+		}, edits[0])
+	})
+}

--- a/internal/testframework/testdata/framework.go
+++ b/internal/testframework/testdata/framework.go
@@ -17,6 +17,12 @@ func (a *App) initApp() {}
 // OnStart accepts a project callback.
 func (a *App) OnStart(callback func()) {}
 
+// OnEvent__0 accepts an event callback without a value.
+func (a *App) OnEvent__0(name string, callback func()) {}
+
+// OnEvent__1 accepts an event callback with an inferred integer value.
+func (a *App) OnEvent__1(name string, callback func(int)) {}
+
 // Measure__0 is the integer overload of Measure.
 func (a *App) Measure__0(value int) int { return value }
 

--- a/xgo/ast.go
+++ b/xgo/ast.go
@@ -49,7 +49,7 @@ func buildASTFileCache(proj *Project, path string, file *File) (cache any, err e
 		mode |= parser.ParseXGoClass
 	}
 	astFile, parserErr := parser.ParseEntry(proj.Fset, path, file.Content, parser.Config{
-		ClassKind: proj.Mod.ClassKind,
+		ClassInfo: proj.Mod.ClassInfo,
 		Mode:      mode,
 	})
 	cache = &astFileCache{astFile, parserErr}


### PR DESCRIPTION
Use project classfile registrations to format XGo and classfiles. Migrate general formatting tests to the isolated framework and keep the `Sprite`/`SpriteImpl` regression in a dedicated spx test.

Preserve each formatter stage's output and use fresh AST and type caches so formatting respects document updates without modifying live caches. Use a fresh file set to avoid retaining temporary source positions across requests. Pass `ClassInfo` consistently to retain registered auto lambda rules.

Cover file kinds, classfile registration, auto lambdas, idempotence, cross-file AST isolation, repeated formatting without file set growth, CRLF, and UTF-16 edit ranges.
