### PR TITLE
fix(server): use project data for hover

### DIFF
--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -6,7 +6,6 @@ import (
 	"iter"
 	"path"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
 	"github.com/goplus/xgolsw/internal/analysis/passes/inspect"
 	"github.com/goplus/xgolsw/internal/analysis/protocol"
-	"github.com/goplus/xgolsw/internal/pkgdata"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/goplus/xgolsw/xgo"
 	"github.com/goplus/xgolsw/xgo/types"
@@ -33,10 +31,7 @@ var errNoMainSpxFile = errors.New("no valid main.spx file found in main package"
 // compileResult contains the compile results and additional information from
 // the compile process.
 type compileResult struct {
-	proj *xgo.Project
-
-	// enumInfo stores source-level enum types and members.
-	enumInfo *enumInfo
+	definitionContext
 
 	// mainSpxFile is the main.spx file path.
 	mainSpxFile string
@@ -69,153 +64,17 @@ type compileResult struct {
 }
 
 // newCompileResult creates a new [compileResult].
-func newCompileResult(proj *xgo.Project) *compileResult {
+func newCompileResult(proj *xgo.Project, lookupPkgDoc func(string) (*pkgdoc.PkgDoc, error)) *compileResult {
 	return &compileResult{
-		proj:                          proj,
-		enumInfo:                      &enumInfo{},
+		definitionContext: definitionContext{
+			proj:         proj,
+			enumInfo:     &enumInfo{},
+			lookupPkgDoc: lookupPkgDoc,
+		},
 		spxSpriteTypes:                make(map[gotypes.Type]struct{}),
 		spxSpriteResourceAutoBindings: make(map[gotypes.Object]struct{}),
 		diagnostics:                   make(map[DocumentURI][]Diagnostic),
 	}
-}
-
-// spxDefinitionsFor returns all spx definitions for the given object. It
-// returns multiple definitions only if the object is an XGo overloadable
-// function.
-func (r *compileResult) spxDefinitionsFor(obj gotypes.Object, selectorTypeName string) []SpxDefinition {
-	if obj == nil {
-		return nil
-	}
-	if xgoutil.IsInBuiltinPkg(obj) {
-		return []SpxDefinition{GetSpxDefinitionForBuiltinObj(obj)}
-	}
-
-	var pkgDoc *pkgdoc.PkgDoc
-	if xgoutil.IsInMainPkg(obj) {
-		pkgDoc, _ = r.proj.PkgDoc()
-	} else {
-		pkgPath := xgoutil.PkgPath(obj.Pkg())
-		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)
-	}
-
-	switch obj := obj.(type) {
-	case *gotypes.Var:
-		typeInfo, _ := r.proj.TypeInfo()
-		astPkg, _ := r.proj.ASTPackage()
-		forceVar := xgoutil.IsDefinedInClassFieldsDecl(r.proj.Fset, typeInfo, astPkg, obj)
-		return []SpxDefinition{GetSpxDefinitionForVar(obj, selectorTypeName, forceVar, pkgDoc)}
-	case *gotypes.Const:
-		if r.enumInfo.isRegularConstObject(obj) {
-			return []SpxDefinition{GetSpxDefinitionForConst(obj, pkgDoc)}
-		}
-		if r.enumInfo.isSyntheticObject(obj) {
-			return nil
-		}
-		if members := r.enumInfo.membersForObject(obj); len(members) > 0 {
-			return []SpxDefinition{r.spxDefinitionForEnumMembers(members...)}
-		}
-		return []SpxDefinition{GetSpxDefinitionForConst(obj, pkgDoc)}
-	case *gotypes.TypeName:
-		def := GetSpxDefinitionForType(obj, pkgDoc)
-		if r.enumInfo.typeFor(obj.Type()) != nil {
-			def.CompletionItemKind = EnumCompletion
-		}
-		return []SpxDefinition{def}
-	case *gotypes.Func:
-		if typeInfo, _ := r.proj.TypeInfo(); typeInfo != nil {
-			if defIdent := typeInfo.ObjToDef[obj]; defIdent != nil && defIdent.Implicit() {
-				return nil
-			}
-		}
-		if xgoutil.IsUnexpandableXGoOverloadableFunc(obj) {
-			return nil
-		}
-		if funcOverloads := xgoutil.ExpandXGoOverloadableFunc(obj); funcOverloads != nil {
-			defs := make([]SpxDefinition, 0, len(funcOverloads))
-			for _, funcOverload := range funcOverloads {
-				defs = append(defs, GetSpxDefinitionForFunc(funcOverload, selectorTypeName, pkgDoc))
-			}
-			return defs
-		}
-		return []SpxDefinition{GetSpxDefinitionForFunc(obj, selectorTypeName, pkgDoc)}
-	case *gotypes.PkgName:
-		return []SpxDefinition{GetSpxDefinitionForPkg(obj, pkgDoc)}
-	}
-	return nil
-}
-
-// spxDefinitionsForIdent returns all spx definitions for the given identifier.
-// It returns multiple definitions only if the identifier is an XGo
-// overloadable function.
-func (r *compileResult) spxDefinitionsForIdent(ident *ast.Ident) []SpxDefinition {
-	if ident.Name == "_" {
-		return nil
-	}
-	typeInfo, _ := r.proj.TypeInfo()
-	if typeInfo == nil {
-		return nil
-	}
-	if members := r.enumInfo.membersForIdent(r.proj, typeInfo, ident); len(members) > 0 {
-		return []SpxDefinition{r.spxDefinitionForEnumMembers(members...)}
-	}
-	obj := r.enumInfo.objectForIdent(typeInfo, ident)
-	return r.spxDefinitionsFor(obj, SelectorTypeNameForIdent(r.proj, ident))
-}
-
-// spxDefinitionsForNamedStruct returns all spx definitions for the given named
-// struct type.
-func (r *compileResult) spxDefinitionsForNamedStruct(named *gotypes.Named) []SpxDefinition {
-	var defs []SpxDefinition
-	for structMember := range xgoutil.StructMembers(named) {
-		defs = append(defs, r.spxDefinitionsFor(structMember.Member, structMember.Selector.Obj().Name())...)
-	}
-	return defs
-}
-
-// spxDefinitionForField returns the spx definition for the given field and
-// optional selector type name.
-func (r *compileResult) spxDefinitionForField(field *gotypes.Var, selectorTypeName string) SpxDefinition {
-	var (
-		forceVar bool
-		pkgDoc   *pkgdoc.PkgDoc
-	)
-	if typeInfo, _ := r.proj.TypeInfo(); typeInfo != nil {
-		if defIdent := typeInfo.ObjToDef[field]; defIdent != nil {
-			if selectorTypeName == "" {
-				selectorTypeName = SelectorTypeNameForIdent(r.proj, defIdent)
-			}
-			astPkg, _ := r.proj.ASTPackage()
-			forceVar = xgoutil.IsDefinedInClassFieldsDecl(r.proj.Fset, typeInfo, astPkg, field)
-			pkgDoc, _ = r.proj.PkgDoc()
-		}
-	} else {
-		pkg := field.Pkg()
-		pkgPath := xgoutil.PkgPath(pkg)
-		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)
-	}
-	return GetSpxDefinitionForVar(field, selectorTypeName, forceVar, pkgDoc)
-}
-
-// spxDefinitionForMethod returns the spx definition for the given method and
-// optional selector type name.
-func (r *compileResult) spxDefinitionForMethod(method *gotypes.Func, selectorTypeName string) SpxDefinition {
-	var pkgDoc *pkgdoc.PkgDoc
-	if typeInfo, _ := r.proj.TypeInfo(); typeInfo != nil {
-		if defIdent := typeInfo.ObjToDef[method]; defIdent != nil {
-			if selectorTypeName == "" {
-				selectorTypeName = SelectorTypeNameForIdent(r.proj, defIdent)
-			}
-			pkgDoc, _ = r.proj.PkgDoc()
-		}
-	} else {
-		if idx := strings.LastIndex(selectorTypeName, "."); idx >= 0 {
-			selectorTypeName = selectorTypeName[idx+1:]
-		}
-		pkg := method.Pkg()
-		pkgPath := xgoutil.PkgPath(pkg)
-		pkgDoc, _ = pkgdata.GetPkgDoc(pkgPath)
-	}
-	return GetSpxDefinitionForFunc(method, selectorTypeName, pkgDoc)
 }
 
 // isInSpxEventHandler checks if the given position is inside an spx event
@@ -277,36 +136,6 @@ func (r *compileResult) spxResourceRefAtPosition(position token.Position) *SpxRe
 		}
 	}
 	return bestRef
-}
-
-// spxImportsAtASTFilePosition returns the import at the given position in the given AST file.
-func (r *compileResult) spxImportsAtASTFilePosition(astFile *ast.File, position token.Position) *SpxReferencePkg {
-	fset := r.proj.Fset
-	for _, imp := range astFile.Imports {
-		nodePos := fset.Position(imp.Pos())
-		nodeEnd := fset.Position(imp.End())
-		if nodePos.Filename != position.Filename ||
-			position.Line != nodePos.Line ||
-			position.Column < nodePos.Column ||
-			position.Column > nodeEnd.Column {
-			continue
-		}
-
-		pkg, err := strconv.Unquote(imp.Path.Value)
-		if err != nil {
-			continue
-		}
-		pkgDoc, err := pkgdata.GetPkgDoc(pkg)
-		if err != nil {
-			continue
-		}
-		return &SpxReferencePkg{
-			Pkg:     pkgDoc,
-			PkgPath: pkg,
-			Node:    imp,
-		}
-	}
-	return nil
 }
 
 // hasSpxSpriteType reports whether the given type is an spx sprite type.
@@ -386,7 +215,7 @@ func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
 		return nil, errNoMainSpxFile
 	}
 
-	result := newCompileResult(snapshot)
+	result := newCompileResult(snapshot, s.lookupPkgDoc)
 	for _, spxFile := range spxFiles {
 		documentURI := s.toDocumentURI(spxFile)
 		result.diagnostics[documentURI] = []Diagnostic{}

--- a/internal/server/definition_context.go
+++ b/internal/server/definition_context.go
@@ -1,0 +1,191 @@
+package server
+
+import (
+	gotypes "go/types"
+	"strconv"
+	"strings"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/goplus/xgolsw/xgo"
+	"github.com/goplus/xgolsw/xgo/xgoutil"
+)
+
+// definitionContext holds project data and documentation used to describe symbols.
+type definitionContext struct {
+	proj     *xgo.Project
+	enumInfo *enumInfo
+
+	// lookupPkgDoc returns immutable package documentation. Reuse the same
+	// instance for unchanged documentation and return a new instance when it
+	// changes, as definition caches include documentation identity.
+	lookupPkgDoc func(string) (*pkgdoc.PkgDoc, error)
+}
+
+// spxDefinitionsFor returns all spx definitions for the given object. It
+// returns multiple definitions only if the object is an XGo overloadable
+// function.
+func (r *definitionContext) spxDefinitionsFor(obj gotypes.Object, selectorTypeName string) []SpxDefinition {
+	if obj == nil {
+		return nil
+	}
+	if xgoutil.IsInBuiltinPkg(obj) {
+		return []SpxDefinition{getDefinitionForBuiltinObj(obj, r.proj.Importer, r.lookupPkgDoc)}
+	}
+
+	var pkgDoc *pkgdoc.PkgDoc
+	if pkgName, ok := obj.(*gotypes.PkgName); ok {
+		pkgDoc, _ = r.lookupPkgDoc(pkgName.Imported().Path())
+	} else if xgoutil.IsInMainPkg(obj) {
+		pkgDoc, _ = r.proj.PkgDoc()
+	} else {
+		pkgDoc, _ = r.lookupPkgDoc(xgoutil.PkgPath(obj.Pkg()))
+	}
+
+	switch obj := obj.(type) {
+	case *gotypes.Var:
+		typeInfo, _ := r.proj.TypeInfo()
+		astPkg, _ := r.proj.ASTPackage()
+		forceVar := xgoutil.IsDefinedInClassFieldsDecl(r.proj.Fset, typeInfo, astPkg, obj)
+		return []SpxDefinition{GetSpxDefinitionForVar(obj, selectorTypeName, forceVar, pkgDoc)}
+	case *gotypes.Const:
+		if r.enumInfo.isRegularConstObject(obj) {
+			return []SpxDefinition{GetSpxDefinitionForConst(obj, pkgDoc)}
+		}
+		if r.enumInfo.isSyntheticObject(obj) {
+			return nil
+		}
+		if members := r.enumInfo.membersForObject(obj); len(members) > 0 {
+			return []SpxDefinition{r.spxDefinitionForEnumMembers(members...)}
+		}
+		return []SpxDefinition{GetSpxDefinitionForConst(obj, pkgDoc)}
+	case *gotypes.TypeName:
+		def := GetSpxDefinitionForType(obj, pkgDoc)
+		if r.enumInfo.typeFor(obj.Type()) != nil {
+			def.CompletionItemKind = EnumCompletion
+		}
+		return []SpxDefinition{def}
+	case *gotypes.Func:
+		if typeInfo, _ := r.proj.TypeInfo(); typeInfo != nil {
+			if defIdent := typeInfo.ObjToDef[obj]; defIdent != nil && defIdent.Implicit() {
+				return nil
+			}
+		}
+		if xgoutil.IsUnexpandableXGoOverloadableFunc(obj) {
+			return nil
+		}
+		if funcOverloads := xgoutil.ExpandXGoOverloadableFunc(obj); funcOverloads != nil {
+			defs := make([]SpxDefinition, 0, len(funcOverloads))
+			for _, funcOverload := range funcOverloads {
+				defs = append(defs, GetSpxDefinitionForFunc(funcOverload, selectorTypeName, pkgDoc))
+			}
+			return defs
+		}
+		return []SpxDefinition{GetSpxDefinitionForFunc(obj, selectorTypeName, pkgDoc)}
+	case *gotypes.PkgName:
+		return []SpxDefinition{GetSpxDefinitionForPkg(obj, pkgDoc)}
+	}
+	return nil
+}
+
+// spxDefinitionsForIdent returns all spx definitions for the given identifier.
+// It returns multiple definitions only if the identifier is an XGo
+// overloadable function.
+func (r *definitionContext) spxDefinitionsForIdent(ident *ast.Ident) []SpxDefinition {
+	if ident.Name == "_" {
+		return nil
+	}
+	typeInfo, _ := r.proj.TypeInfo()
+	if typeInfo == nil {
+		return nil
+	}
+	if members := r.enumInfo.membersForIdent(r.proj, typeInfo, ident); len(members) > 0 {
+		return []SpxDefinition{r.spxDefinitionForEnumMembers(members...)}
+	}
+	obj := r.enumInfo.objectForIdent(typeInfo, ident)
+	return r.spxDefinitionsFor(obj, SelectorTypeNameForIdent(r.proj, ident))
+}
+
+// spxDefinitionsForNamedStruct returns all spx definitions for the given named
+// struct type.
+func (r *definitionContext) spxDefinitionsForNamedStruct(named *gotypes.Named) []SpxDefinition {
+	var defs []SpxDefinition
+	for structMember := range xgoutil.StructMembers(named) {
+		defs = append(defs, r.spxDefinitionsFor(structMember.Member, structMember.Selector.Obj().Name())...)
+	}
+	return defs
+}
+
+// spxDefinitionForField returns the spx definition for the given field and
+// optional selector type name.
+func (r *definitionContext) spxDefinitionForField(field *gotypes.Var, selectorTypeName string) SpxDefinition {
+	typeInfo, _ := r.proj.TypeInfo()
+	if typeInfo == nil {
+		pkgDoc, _ := r.lookupPkgDoc(xgoutil.PkgPath(field.Pkg()))
+		return GetSpxDefinitionForVar(field, selectorTypeName, false, pkgDoc)
+	}
+	defIdent := typeInfo.ObjToDef[field]
+	if defIdent == nil {
+		return GetSpxDefinitionForVar(field, selectorTypeName, false, nil)
+	}
+	if selectorTypeName == "" {
+		selectorTypeName = SelectorTypeNameForIdent(r.proj, defIdent)
+	}
+	astPkg, _ := r.proj.ASTPackage()
+	forceVar := xgoutil.IsDefinedInClassFieldsDecl(r.proj.Fset, typeInfo, astPkg, field)
+	pkgDoc, _ := r.proj.PkgDoc()
+	return GetSpxDefinitionForVar(field, selectorTypeName, forceVar, pkgDoc)
+}
+
+// spxDefinitionForMethod returns the spx definition for the given method and
+// optional selector type name.
+func (r *definitionContext) spxDefinitionForMethod(method *gotypes.Func, selectorTypeName string) SpxDefinition {
+	typeInfo, _ := r.proj.TypeInfo()
+	if typeInfo == nil {
+		if idx := strings.LastIndex(selectorTypeName, "."); idx >= 0 {
+			selectorTypeName = selectorTypeName[idx+1:]
+		}
+		pkgDoc, _ := r.lookupPkgDoc(xgoutil.PkgPath(method.Pkg()))
+		return GetSpxDefinitionForFunc(method, selectorTypeName, pkgDoc)
+	}
+	defIdent := typeInfo.ObjToDef[method]
+	if defIdent == nil {
+		return GetSpxDefinitionForFunc(method, selectorTypeName, nil)
+	}
+	if selectorTypeName == "" {
+		selectorTypeName = SelectorTypeNameForIdent(r.proj, defIdent)
+	}
+	pkgDoc, _ := r.proj.PkgDoc()
+	return GetSpxDefinitionForFunc(method, selectorTypeName, pkgDoc)
+}
+
+// spxImportsAtASTFilePosition returns the import at the given position in the given AST file.
+func (r *definitionContext) spxImportsAtASTFilePosition(astFile *ast.File, position token.Position) *SpxReferencePkg {
+	fset := r.proj.Fset
+	for _, imp := range astFile.Imports {
+		nodePos := fset.Position(imp.Pos())
+		nodeEnd := fset.Position(imp.End())
+		if nodePos.Filename != position.Filename ||
+			position.Line != nodePos.Line ||
+			position.Column < nodePos.Column ||
+			position.Column > nodeEnd.Column {
+			continue
+		}
+
+		pkg, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		pkgDoc, err := r.lookupPkgDoc(pkg)
+		if err != nil {
+			continue
+		}
+		return &SpxReferencePkg{
+			Pkg:     pkgDoc,
+			PkgPath: pkg,
+			Node:    imp,
+		}
+	}
+	return nil
+}

--- a/internal/server/enum.go
+++ b/internal/server/enum.go
@@ -1194,7 +1194,7 @@ func enumNumericConstantConstraint(value constant.Value) gotypes.BasicInfo {
 
 // spxDefinitionForEnumMembers returns one definition for a non-empty set of
 // source-level members.
-func (r *compileResult) spxDefinitionForEnumMembers(members ...*enumMemberInfo) SpxDefinition {
+func (r *definitionContext) spxDefinitionForEnumMembers(members ...*enumMemberInfo) SpxDefinition {
 	first := members[0]
 	var def SpxDefinition
 	for _, member := range members {
@@ -1249,7 +1249,7 @@ func (r *compileResult) spxDefinitionForEnumMembers(members ...*enumMemberInfo) 
 
 // spxDefinitionsForEnumTypes returns definitions for members of the given
 // types. Members with the same source name are represented by one definition.
-func (r *compileResult) spxDefinitionsForEnumTypes(expectedTypes ...gotypes.Type) []SpxDefinition {
+func (r *definitionContext) spxDefinitionsForEnumTypes(expectedTypes ...gotypes.Type) []SpxDefinition {
 	if len(expectedTypes) == 0 {
 		return nil
 	}

--- a/internal/server/hover.go
+++ b/internal/server/hover.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	godoc "go/doc"
 	"strings"
 
@@ -16,70 +17,70 @@ func (s *Server) textDocumentHover(params *HoverParams) (*Hover, error) {
 		markupKind = preferredMarkupKind(capabilities.ContentFormat)
 	}
 
-	result, _, astFile, err := s.compileAndGetASTFileForDocumentURI(params.TextDocument.URI)
+	filename, err := s.fromDocumentURI(params.TextDocument.URI)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get file path from document URI %q: %w", params.TextDocument.URI, err)
 	}
-	if astFile == nil {
+	proj := s.getProjWithFile()
+	astPkg, _ := proj.ASTPackage()
+	if astPkg == nil {
 		return nil, nil
 	}
-	if !astFile.Pos().IsValid() {
+	astFile := astPkg.Files[filename]
+	if astFile == nil || !astFile.Pos().IsValid() {
 		return nil, nil
 	}
-	position := ToPosition(result.proj, astFile, params.Position)
-
-	if spxResourceRef := result.spxResourceRefAtPosition(position); spxResourceRef != nil {
-		return &Hover{
-			Contents: resourceMarkupContent(spxResourceRef.ID.URI(), markupKind),
-			Range:    RangeForNode(result.proj, spxResourceRef.Node),
-		}, nil
+	position := ToPosition(proj, astFile, params.Position)
+	if hover, err := s.hoverForSpxResource(proj, filename, position, markupKind); hover != nil || err != nil {
+		return hover, err
 	}
-
-	typeInfo, _ := result.proj.TypeInfo()
+	typeInfo, _ := proj.TypeInfo()
 	if typeInfo == nil {
 		return nil, nil
 	}
-	if hover := hoverForXGoUnit(result.proj, typeInfo, astFile, position, markupKind); hover != nil {
+	ctx := &definitionContext{
+		proj:         proj,
+		enumInfo:     newEnumInfo(astPkg, typeInfo),
+		lookupPkgDoc: s.lookupPkgDoc,
+	}
+	if hover := hoverForXGoUnit(proj, typeInfo, astFile, position, markupKind); hover != nil {
 		return hover, nil
 	}
-	if tokenFile := xgoutil.NodeTokenFile(result.proj.Fset, astFile); tokenFile != nil {
+	if tokenFile := xgoutil.NodeTokenFile(proj.Fset, astFile); tokenFile != nil {
 		pos := tokenFile.Pos(position.Offset)
-		if member := result.enumInfo.declarationMemberAt(pos); member != nil {
-			def := result.spxDefinitionForEnumMembers(member)
-			return hoverForSpxDefs(result.proj, []SpxDefinition{def}, member.ident, markupKind), nil
+		if member := ctx.enumInfo.declarationMemberAt(pos); member != nil {
+			def := ctx.spxDefinitionForEnumMembers(member)
+			return hoverForSpxDefs(proj, []SpxDefinition{def}, member.ident, markupKind), nil
 		}
-		if ident, obj := result.enumInfo.regularConstDeclarationAt(pos); ident != nil {
-			return hoverForSpxDefs(result.proj, result.spxDefinitionsFor(obj, ""), ident, markupKind), nil
+		if ident, obj := ctx.enumInfo.regularConstDeclarationAt(pos); ident != nil {
+			return hoverForSpxDefs(proj, ctx.spxDefinitionsFor(obj, ""), ident, markupKind), nil
 		}
 	}
-	ident, obj, kwargTarget := objectAtPosition(result.proj, typeInfo, astFile, position)
+	ident, obj, kwargTarget := objectAtPosition(proj, typeInfo, astFile, position)
 	if kwargTarget != nil {
 		return hoverForSpxDefs(
-			result.proj, result.spxDefinitionsFor(obj, getTypeFromObject(typeInfo, obj)), kwargTarget.ident, markupKind,
+			proj, ctx.spxDefinitionsFor(obj, getTypeFromObject(typeInfo, obj)), kwargTarget.ident, markupKind,
 		), nil
 	}
 	if ident == nil {
 		// Check if the position is within an import declaration.
 		// If so, return the package documentation.
-		rpkg := result.spxImportsAtASTFilePosition(astFile, position)
-		if rpkg != nil {
-			return &Hover{
-				Contents: MarkupContent{
-					Kind:  markupKind,
-					Value: godoc.Synopsis(rpkg.Pkg.Doc),
-				},
-				Range: RangeForNode(result.proj, rpkg.Node),
-			}, nil
-		}
-		return nil, nil
-	}
-	if ident.Name == "this" {
-		astPkg, _ := result.proj.ASTPackage()
-		if xgoutil.IsSyntheticThisIdent(result.proj.Fset, typeInfo, astPkg, ident) {
+		rpkg := ctx.spxImportsAtASTFilePosition(astFile, position)
+		if rpkg == nil {
 			return nil, nil
 		}
+		return &Hover{
+			Contents: MarkupContent{
+				Kind:  markupKind,
+				Value: godoc.Synopsis(rpkg.Pkg.Doc),
+			},
+			Range: RangeForNode(proj, rpkg.Node),
+		}, nil
 	}
-	return hoverForSpxDefs(result.proj, result.spxDefinitionsForIdent(ident), ident, markupKind), nil
+	if ident.Name == "this" && xgoutil.IsSyntheticThisIdent(proj.Fset, typeInfo, astPkg, ident) {
+		return nil, nil
+	}
+	return hoverForSpxDefs(proj, ctx.spxDefinitionsForIdent(ident), ident, markupKind), nil
 }
 
 // hoverForSpxDefs renders spx definitions into a hover at node.

--- a/internal/server/hover_test.go
+++ b/internal/server/hover_test.go
@@ -1,16 +1,233 @@
 package server
 
 import (
+	"io/fs"
 	"testing"
 
+	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/goplus/xgolsw/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestServerTextDocumentHover(t *testing.T) {
+	t.Run("SourceKinds", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			filename string
+			owner    string
+		}{
+			{name: "XGo", filename: "main.xgo"},
+			{name: "LegacyXGo", filename: "main.gop"},
+			{name: "StandaloneClass", filename: "Record.gox", owner: "Record."},
+			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App."},
+			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker."},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				files := map[string][]byte{
+					tt.filename: []byte("// Count documentation.\nvar Count int\nCount = 1\n"),
+				}
+				if tt.name == "WorkClass" {
+					files["main_fixture.gox"] = nil
+				}
+				s := newTestServer(t, files)
+				_, err := s.workspaceRootFS.TypeInfo()
+				require.NoError(t, err)
+				for _, position := range []Position{{Line: 1, Character: 4}, {Line: 2}} {
+					hover, err := s.textDocumentHover(&HoverParams{
+						TextDocumentPositionParams: TextDocumentPositionParams{
+							TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
+							Position:     position,
+						},
+					})
+					require.NoError(t, err)
+					require.NotNil(t, hover)
+					assert.Contains(t, hover.Contents.Value, `def-id="xgo:main?`+tt.owner+`Count"`)
+					assert.Contains(t, hover.Contents.Value, "Count documentation.")
+					assert.Equal(t, Range{
+						Start: position,
+						End:   Position{Line: position.Line, Character: position.Character + 5},
+					}, hover.Range)
+				}
+			})
+		}
+	})
+
+	t.Run("Documentation", func(t *testing.T) {
+		for _, markup := range []struct {
+			name string
+			kind MarkupKind
+		}{
+			{name: "Markdown", kind: Markdown}, {name: "PlainText", kind: PlainText},
+		} {
+			for _, tt := range []struct {
+				name     string
+				source   string
+				position Position
+				want     string
+			}{
+				{name: "Import", source: "import \"example.com/framework\"\n", position: Position{Character: 8},
+					want: "Package framework provides a minimal classfile framework for language tests."},
+				{name: "Package", source: "import \"example.com/framework\"\nvar item framework.Item\n", position: Position{Line: 1, Character: 10},
+					want: "Package framework provides a minimal classfile framework for language tests."},
+				{name: "Type", source: "import \"example.com/framework\"\nvar item framework.Item\n", position: Position{Line: 1, Character: 19},
+					want: "Item is the work base class."},
+				{name: "Method", source: "import \"example.com/framework\"\nvar item framework.Item\nitem.apply 1\n", position: Position{Line: 2, Character: 5},
+					want: "Apply accepts a value on a work instance."},
+				{name: "Function", source: "import \"example.com/framework\"\nframework.runWhen true, => {}\n", position: Position{Line: 1, Character: 10},
+					want: "RunWhen accepts a deferred condition and a callback."},
+				{name: "Constant", source: "import \"example.com/framework\"\necho framework.Low\n", position: Position{Line: 1, Character: 15},
+					want: "Low and High are values used by framework methods."},
+			} {
+				t.Run(tt.name+markup.name, func(t *testing.T) {
+					s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+					_, err := s.initialize(&InitializeParams{XInitializeParams: protocol.XInitializeParams{
+						Capabilities: protocol.ClientCapabilities{TextDocument: protocol.TextDocumentClientCapabilities{
+							Hover: &protocol.HoverClientCapabilities{ContentFormat: []protocol.MarkupKind{markup.kind}},
+						}},
+					}})
+					require.NoError(t, err)
+					s.finishInitialize(nil)
+					hover, err := s.textDocumentHover(&HoverParams{
+						TextDocumentPositionParams: TextDocumentPositionParams{
+							TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}, Position: tt.position,
+						},
+					})
+					require.NoError(t, err)
+					require.NotNil(t, hover)
+					assert.Equal(t, markup.kind, hover.Contents.Kind)
+					assert.Contains(t, hover.Contents.Value, tt.want)
+					if tt.name == "Package" && markup.kind == Markdown {
+						assert.Contains(t, hover.Contents.Value, `def-id="xgo:example.com/framework"`)
+					}
+				})
+			}
+		}
+	})
+
+	t.Run("MissingDocumentation", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			source   string
+			position Position
+			want     string
+		}{
+			{name: "Import", source: "import \"example.com/framework\"\n", position: Position{Character: 8}},
+			{name: "Method", source: "import \"example.com/framework\"\nvar item framework.Item\nitem.apply 1\n", position: Position{Line: 2, Character: 5},
+				want: `overview="func apply(value int)"`},
+			{name: "BuiltinAlias", source: "var number int128\n", position: Position{Character: 12},
+				want: `overview="type Int128"`},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+				s.lookupPkgDoc = func(string) (*pkgdoc.PkgDoc, error) { return nil, fs.ErrNotExist }
+				hover, err := s.textDocumentHover(&HoverParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}, Position: tt.position,
+					},
+				})
+				require.NoError(t, err)
+				if tt.want == "" {
+					assert.Nil(t, hover)
+				} else {
+					require.NotNil(t, hover)
+					assert.Contains(t, hover.Contents.Value, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("BuiltinDocumentation", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{"main.xgo": []byte("var count int8\n")})
+		s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+			require.Equal(t, "builtin", pkgPath)
+			return &pkgdoc.PkgDoc{Types: map[string]*pkgdoc.TypeDoc{
+				"int8": {Doc: "A signed 8-bit integer from the test documentation."},
+			}}, nil
+		}
+		hover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}, Position: Position{Character: 10},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Contains(t, hover.Contents.Value, "A signed 8-bit integer from the test documentation.")
+		assert.Contains(t, hover.Contents.Value, `def-id="xgo:builtin?int8" overview="type int8"`)
+	})
+
+	t.Run("DocumentationIsolation", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			source   string
+			position Position
+			setDoc   func(*pkgdoc.PkgDoc, string)
+		}{
+			{name: "Method", source: "measure 1\n", position: Position{Character: 1},
+				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Types["App"].Methods["Measure__0"] = text }},
+			{name: "Type", source: "import \"example.com/framework\"\nvar item framework.Item\n", position: Position{Line: 1, Character: 19},
+				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Types["Item"].Doc = text }},
+			{name: "Field", source: "import \"example.com/framework\"\nvar item framework.Item\nitem.Value = 1\n", position: Position{Line: 2, Character: 5},
+				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Types["Item"].Fields["Value"] = text }},
+			{name: "Constant", source: "import \"example.com/framework\"\necho framework.Low\n", position: Position{Line: 1, Character: 15},
+				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Consts["Low"] = text }},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{"main_fixture.gox": []byte(tt.source)})
+				params := &HoverParams{TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"}, Position: tt.position,
+				}}
+				for _, text := range []string{"First documentation.", "Second documentation."} {
+					doc := testframework.NewPkgDoc(t)
+					tt.setDoc(doc, text)
+					s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+						require.Equal(t, testframework.PkgPath, pkgPath)
+						return doc, nil
+					}
+					hover, err := s.textDocumentHover(params)
+					require.NoError(t, err)
+					require.NotNil(t, hover)
+					assert.Contains(t, hover.Contents.Value, text)
+				}
+			})
+		}
+	})
+
+	t.Run("DocumentUpdates", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{"main.xgo": []byte("// Before update.\nvar value int\n")})
+		params := &HoverParams{TextDocumentPositionParams: TextDocumentPositionParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}, Position: Position{Line: 1, Character: 4},
+		}}
+		before, err := s.textDocumentHover(params)
+		require.NoError(t, err)
+		require.NotNil(t, before)
+		assert.Contains(t, before.Contents.Value, "Before update.")
+		s.ModifyFiles([]FileChange{{Path: "main.xgo", Content: []byte("// After update.\nvar value string\n"), Version: 1}})
+		after, err := s.textDocumentHover(params)
+		require.NoError(t, err)
+		require.NotNil(t, after)
+		assert.Contains(t, after.Contents.Value, "After update.")
+		assert.Contains(t, after.Contents.Value, "var value string")
+		assert.NotContains(t, after.Contents.Value, "Before update.")
+	})
+
+	t.Run("UTF16Range", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte("var count int\r\necho \"\U0001f600\", count\r\n"),
+		})
+		hover, err := s.textDocumentHover(&HoverParams{TextDocumentPositionParams: TextDocumentPositionParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}, Position: Position{Line: 1, Character: 12},
+		}})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Equal(t, Range{Start: Position{Line: 1, Character: 11}, End: Position{Line: 1, Character: 16}}, hover.Range)
+		assert.Contains(t, hover.Contents.Value, "var count int")
+	})
+
 	t.Run("Normal", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main_fixture.gox": []byte(`
 import (
 	"fmt"
 	"image"
@@ -41,33 +258,15 @@ type Point struct {
 }
 
 fmt.Println(int8(1))
-
-play "MySound"
-MySprite.turn Left
-MySprite.setCostume "costume1"
-Game.onClick => {}
-onClick => {}
-Camera.follow "MySprite"
 `),
-			"MySprite.spx": []byte(`
-MySprite.onClick => {}
-onClick => {}
-onStart => {
-	MySprite.turn Right
-	clone
-	imagePoint.X = 100
-}
-onTouchStart "MySprite", => {}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{"costumes":[{"name":"costume1"}]}`),
-			"assets/sounds/MySound/index.json":   []byte(`{}`),
+			"Worker_fixture.gox": []byte("imagePoint.X = 100\n"),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		s := newTestServer(t, m)
 
 		varHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 8, Character: 1},
 			},
 		})
@@ -76,7 +275,7 @@ onTouchStart "MySprite", => {}
 		assert.Equal(t, &Hover{
 			Contents: MarkupContent{
 				Kind:  Markdown,
-				Value: "<pre is=\"definition-item\" def-id=\"xgo:main?Game.count\" overview=\"var count int\">\ncount is a variable.\n</pre>\n",
+				Value: "<pre is=\"definition-item\" def-id=\"xgo:main?App.count\" overview=\"var count int\">\ncount is a variable.\n</pre>\n",
 			},
 			Range: Range{
 				Start: Position{Line: 8, Character: 1},
@@ -86,7 +285,7 @@ onTouchStart "MySprite", => {}
 
 		constHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 14, Character: 6},
 			},
 		})
@@ -105,7 +304,7 @@ onTouchStart "MySprite", => {}
 
 		funcHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 17, Character: 5},
 			},
 		})
@@ -114,7 +313,7 @@ onTouchStart "MySprite", => {}
 		assert.Equal(t, &Hover{
 			Contents: MarkupContent{
 				Kind:  Markdown,
-				Value: "<pre is=\"definition-item\" def-id=\"xgo:main?Game.Add\" overview=\"func Add(x int, y int) int\">\nAdd is a function.\n</pre>\n",
+				Value: "<pre is=\"definition-item\" def-id=\"xgo:main?App.Add\" overview=\"func Add(x int, y int) int\">\nAdd is a function.\n</pre>\n",
 			},
 			Range: Range{
 				Start: Position{Line: 17, Character: 5},
@@ -124,7 +323,7 @@ onTouchStart "MySprite", => {}
 
 		typeHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 22, Character: 5},
 			},
 		})
@@ -143,7 +342,7 @@ onTouchStart "MySprite", => {}
 
 		typeFieldHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 24, Character: 1},
 			},
 		})
@@ -162,7 +361,7 @@ onTouchStart "MySprite", => {}
 
 		pkgHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 30, Character: 0},
 			},
 		})
@@ -175,7 +374,7 @@ onTouchStart "MySprite", => {}
 
 		pkgFuncHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 30, Character: 4},
 			},
 		})
@@ -188,7 +387,7 @@ onTouchStart "MySprite", => {}
 
 		builtinFuncHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 30, Character: 12},
 			},
 		})
@@ -197,7 +396,7 @@ onTouchStart "MySprite", => {}
 		assert.Equal(t, &Hover{
 			Contents: MarkupContent{
 				Kind:  Markdown,
-				Value: "<pre is=\"definition-item\" def-id=\"xgo:builtin?int8\" overview=\"type int8\">\nint8 is the set of all signed 8-bit integers.\nRange: -128 through 127.\n</pre>\n",
+				Value: "<pre is=\"definition-item\" def-id=\"xgo:builtin?int8\" overview=\"type int8\">\n</pre>\n",
 			},
 			Range: Range{
 				Start: Position{Line: 30, Character: 12},
@@ -205,189 +404,10 @@ onTouchStart "MySprite", => {}
 			},
 		}, builtinFuncHover)
 
-		mySoundRefHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 32, Character: 5},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mySoundRefHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<resource-preview resource=\"spx://resources/sounds/MySound\" />\n",
-			},
-			Range: Range{
-				Start: Position{Line: 32, Character: 5},
-				End:   Position{Line: 32, Character: 14},
-			},
-		}, mySoundRefHover)
-
-		mySpriteRefHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 33, Character: 0},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mySpriteRefHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<resource-preview resource=\"spx://resources/sprites/MySprite\" />\n",
-			},
-			Range: Range{
-				Start: Position{Line: 33, Character: 0},
-				End:   Position{Line: 33, Character: 8},
-			},
-		}, mySpriteRefHover)
-
-		mySpriteCostumeRefHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 34, Character: 20},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mySpriteCostumeRefHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<resource-preview resource=\"spx://resources/sprites/MySprite/costumes/costume1\" />\n",
-			},
-			Range: Range{
-				Start: Position{Line: 34, Character: 20},
-				End:   Position{Line: 34, Character: 30},
-			},
-		}, mySpriteCostumeRefHover)
-
-		mySpriteSetCostumeFuncHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 34, Character: 9},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mySpriteSetCostumeFuncHover)
-		assert.Equal(t, Range{
-			Start: Position{Line: 34, Character: 9},
-			End:   Position{Line: 34, Character: 19},
-		}, mySpriteSetCostumeFuncHover.Range)
-
-		GameOnClickHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 35, Character: 5},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, GameOnClickHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Game.onClick\" overview=\"func onClick(onClick func())\">\n</pre>\n",
-			},
-			Range: Range{
-				Start: Position{Line: 35, Character: 5},
-				End:   Position{Line: 35, Character: 12},
-			},
-		}, GameOnClickHover)
-
-		mainSpxOnClickHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 36, Character: 0},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mainSpxOnClickHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Game.onClick\" overview=\"func onClick(onClick func())\">\n</pre>\n",
-			},
-			Range: Range{
-				Start: Position{Line: 36, Character: 0},
-				End:   Position{Line: 36, Character: 7},
-			},
-		}, mainSpxOnClickHover)
-
-		mainSpxCameraFollowHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 37, Character: 8},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mainSpxCameraFollowHover)
-		assert.Contains(t, mainSpxCameraFollowHover.Contents.Value, `def-id="xgo:github.com/goplus/spx/v3?Game.follow#1"`)
-		assert.Equal(t, Range{
-			Start: Position{Line: 37, Character: 7},
-			End:   Position{Line: 37, Character: 13},
-		}, mainSpxCameraFollowHover.Range)
-
-		mySpriteOnClickFuncHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 1, Character: 9},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mySpriteOnClickFuncHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Sprite.onClick\" overview=\"func onClick(onClick func())\">\n</pre>\n",
-			},
-			Range: Range{
-				Start: Position{Line: 1, Character: 9},
-				End:   Position{Line: 1, Character: 16},
-			},
-		}, mySpriteOnClickFuncHover)
-
-		mySpriteSpxOnClickFuncHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 2, Character: 0},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mySpriteSpxOnClickFuncHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Sprite.onClick\" overview=\"func onClick(onClick func())\">\n</pre>\n",
-			},
-			Range: Range{
-				Start: Position{Line: 2, Character: 0},
-				End:   Position{Line: 2, Character: 7},
-			},
-		}, mySpriteSpxOnClickFuncHover)
-
-		mySpriteCloneFuncHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 5, Character: 1},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, mySpriteCloneFuncHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Sprite.clone#0\" overview=\"func clone()\">\n</pre>\n",
-			},
-			Range: Range{
-				Start: Position{Line: 5, Character: 1},
-				End:   Position{Line: 5, Character: 6},
-			},
-		}, mySpriteCloneFuncHover)
-
 		imagePointFieldHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 6, Character: 12},
+				TextDocument: TextDocumentIdentifier{URI: "file:///Worker_fixture.gox"},
+				Position:     Position{Line: 0, Character: 11},
 			},
 		})
 		require.NoError(t, err)
@@ -398,62 +418,72 @@ onTouchStart "MySprite", => {}
 				Value: "<pre is=\"definition-item\" def-id=\"xgo:image?Point.X\" overview=\"field X int\">\n</pre>\n",
 			},
 			Range: Range{
-				Start: Position{Line: 6, Character: 12},
-				End:   Position{Line: 6, Character: 13},
+				Start: Position{Line: 0, Character: 11},
+				End:   Position{Line: 0, Character: 12},
 			},
 		}, imagePointFieldHover)
 
-		onTouchStartFirstArgHover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 8, Character: 14},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, onTouchStartFirstArgHover)
-		assert.Equal(t, &Hover{
-			Contents: MarkupContent{
-				Kind:  Markdown,
-				Value: "<resource-preview resource=\"spx://resources/sprites/MySprite\" />\n",
-			},
-			Range: Range{
-				Start: Position{Line: 8, Character: 13},
-				End:   Position{Line: 8, Character: 23},
-			},
-		}, onTouchStartFirstArgHover)
 	})
 
 	t.Run("Autoclosure", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main_fixture.gox": []byte(`
 onStart => {
-	repeatUntil true, => {}
+	runWhen true, => {}
 }
 `),
-			"assets/index.json": []byte(`{}`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 2, Character: 2},
 			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, hover)
-		assert.Contains(t, hover.Contents.Value, `overview="func repeatUntil(condition bool, call func())"`)
+		assert.Contains(t, hover.Contents.Value, `overview="func runWhen(condition bool, callback func())"`)
+	})
+
+	t.Run("UnavailableDocument", func(t *testing.T) {
+		for _, tt := range []struct {
+			name      string
+			uri       DocumentURI
+			wantError bool
+		}{
+			{name: "Empty", uri: "file:///empty.xgo"},
+			{name: "Missing", uri: "file:///missing.xgo"},
+			{name: "Unsupported", uri: "file:///notes.txt"},
+			{name: "InvalidURI", uri: "https://example.com/main.xgo", wantError: true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{
+					"empty.xgo": nil,
+					"notes.txt": []byte("var count int\n"),
+				})
+				hover, err := s.textDocumentHover(&HoverParams{TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: tt.uri},
+				}})
+				if tt.wantError {
+					assert.ErrorContains(t, err, "failed to get file path")
+				} else {
+					require.NoError(t, err)
+				}
+				assert.Nil(t, hover)
+			})
+		}
 	})
 
 	t.Run("InvalidPosition", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`var x int`),
+			"main.xgo": []byte(`var x int`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 99, Character: 99},
 			},
 		})
@@ -463,20 +493,20 @@ onStart => {
 
 	t.Run("ImportsAtASTFilePosition", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 import (
-	"fmt"
+	"example.com/framework"
 	"image"
 )
 
-fmt.Println("Hello, World!")
+framework.RunWhen true, => {}
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		importHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 2, Character: 1},
 			},
 		})
@@ -485,27 +515,27 @@ fmt.Println("Hello, World!")
 		assert.Equal(t, &Hover{
 			Contents: MarkupContent{
 				Kind:  Markdown,
-				Value: "Package fmt implements formatted I/O with functions analogous to C's printf and scanf.",
+				Value: "Package framework provides a minimal classfile framework for language tests.",
 			},
 			Range: Range{
 				Start: Position{Line: 2, Character: 1},
-				End:   Position{Line: 2, Character: 6},
+				End:   Position{Line: 2, Character: 24},
 			},
 		}, importHover)
 	})
 
 	t.Run("Append", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 var nums []int
 nums = append(nums, 1)
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 2, Character: 7},
 			},
 		})
@@ -520,16 +550,16 @@ nums = append(nums, 1)
 
 	t.Run("WithXGoBuiltins", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 var num int128
 echo num
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover1, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 1, Character: 8},
 			},
 		})
@@ -543,7 +573,7 @@ echo num
 
 		hover2, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 2, Character: 0},
 			},
 		})
@@ -558,19 +588,13 @@ echo num
 
 	t.Run("WithNonENCharacters", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	var 中文 []int
-	中文 = append(中文, 1)
-	println "非英文", 中文
-}
-`),
+			"main.xgo": []byte("\nfunc run() {\n\tvar \u4e2d\u6587 []int\n\t\u4e2d\u6587 = append(\u4e2d\u6587, 1)\n\tprintln \"\u975e\u82f1\u6587\", \u4e2d\u6587\n}\n"),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover1, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 3, Character: 14},
 			},
 		})
@@ -584,7 +608,7 @@ onStart => {
 
 		hover2, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 3, Character: 18},
 			},
 		})
@@ -593,7 +617,7 @@ onStart => {
 
 		hover3, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 4, Character: 17},
 			},
 		})
@@ -608,17 +632,17 @@ onStart => {
 
 	t.Run("VariadicFunctionCall", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
+			"main.xgo": []byte(`
+func run() {
 	echo 1
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 2, Character: 1},
 			},
 		})
@@ -634,63 +658,57 @@ onStart => {
 
 	t.Run("XGotMethodCall", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main_fixture.gox": []byte(`
 onStart => {
-	getWidget Monitor, "myWidget"
+	create int, "value"
 }
 `),
-			"assets/index.json": []byte(`{"zorder":[{"name":"myWidget"}]}`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 2, Character: 1},
 			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, hover)
-		assert.Contains(t, hover.Contents.Value, `def-id="xgo:github.com/goplus/spx/v3?Game.getWidget"`)
-		assert.Contains(t, hover.Contents.Value, `overview="func getWidget(T Type, name WidgetName) *T"`)
-		assert.Contains(t, hover.Contents.Value, `GetWidget returns the widget instance (in given type) with given name. It panics if not found.`)
+		assert.Contains(t, hover.Contents.Value, `def-id="xgo:example.com/framework?App.create"`)
+		assert.Contains(t, hover.Contents.Value, `overview="func create(T Type, name string) *T"`)
+		assert.Contains(t, hover.Contents.Value, `Create provides a method with an explicit type argument.`)
 		assert.Equal(t, Range{
 			Start: Position{Line: 2, Character: 1},
-			End:   Position{Line: 2, Character: 10},
+			End:   Position{Line: 2, Character: 7},
 		}, hover.Range)
 	})
 
 	t.Run("StartWithInvalidChar", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
-“”var (
-	maps []int
-)
-`),
+			"main.xgo": []byte("\n\u201c\u201dvar (\n\tmaps []int\n)\n"),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 2, Character: 1},
 			},
 		})
 		require.NoError(t, err)
 		require.Nil(t, hover)
-		assert.Empty(t, hover)
 	})
 
 	t.Run("BlankIdentShouldReturnNilHover", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`const _ = 1
+			"main.xgo": []byte(`const _ = 1
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 0, Character: 6},
 			},
 		})
@@ -700,16 +718,16 @@ onStart => {
 
 	t.Run("SyntheticThisShouldReturnNilHover", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`onClick => {
+			"main_fixture.gox": []byte(`onStart => {
     _ = this
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 				Position:     Position{Line: 1, Character: 8},
 			},
 		})
@@ -719,16 +737,16 @@ onStart => {
 
 	t.Run("NonSyntheticThisShouldStillHover", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`// this is a variable.
+			"main.xgo": []byte(`// this is a variable.
 var this int
 this = 1
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 1, Character: 4},
 			},
 		})
@@ -737,31 +755,29 @@ this = 1
 		assert.Contains(t, hover.Contents.Value, `overview="var this int"`)
 	})
 
-	t.Run("SpriteLineStartShouldNotResolveToSyntheticThis", func(t *testing.T) {
+	t.Run("WorkLineStartShouldNotResolveToSyntheticThis", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`onStart => {}
+			"main_fixture.gox": []byte(`onValue value => {}
 `),
-			"MySprite.spx": []byte(`onStart => {
-    step 10
-    turn Left
+			"Worker_fixture.gox": []byte(`onValue value => {
+    apply value
+    apply 2
 }
 `),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
-		// The characters on `onStart` should map to `onStart`, not synthetic `this`.
+		// The characters on `onValue` should map to `onValue`, not synthetic `this`.
 		for _, ch := range []uint32{0, 1, 2, 3, 4, 5, 6} {
 			hover, err := s.textDocumentHover(&HoverParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+					TextDocument: TextDocumentIdentifier{URI: "file:///Worker_fixture.gox"},
 					Position:     Position{Line: 0, Character: ch},
 				},
 			})
 			require.NoError(t, err)
 			require.NotNil(t, hover)
-			assert.Contains(t, hover.Contents.Value, `def-id="xgo:github.com/goplus/spx/v3?Sprite.onStart"`)
+			assert.Contains(t, hover.Contents.Value, `def-id="xgo:example.com/framework?Item.onValue"`)
 			assert.NotContains(t, hover.Contents.Value, `var this`)
 		}
 
@@ -770,7 +786,7 @@ this = 1
 			for _, ch := range []uint32{0, 1, 2, 3} {
 				hover, err := s.textDocumentHover(&HoverParams{
 					TextDocumentPositionParams: TextDocumentPositionParams{
-						TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+						TextDocument: TextDocumentIdentifier{URI: "file:///Worker_fixture.gox"},
 						Position:     Position{Line: line, Character: ch},
 					},
 				})
@@ -782,7 +798,7 @@ this = 1
 
 	t.Run("KwargField", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 type Options struct {
 	// Count is a kwarg field.
 	Count int
@@ -790,16 +806,16 @@ type Options struct {
 
 func configure(opts Options?) {}
 
-onStart => {
+func run() {
 	configure count = 1
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 9, Character: 12},
 			},
 		})
@@ -819,19 +835,19 @@ onStart => {
 
 	t.Run("MapKwargHasNoHover", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 func configure(opts map[string]int?) {}
 
-onStart => {
+func run() {
 	configure count = 1
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 4, Character: 12},
 			},
 		})
@@ -841,7 +857,7 @@ onStart => {
 
 	t.Run("KwargInterfaceMethod", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 type Client struct{}
 
 type Params interface {
@@ -855,16 +871,16 @@ func (c Client) Params() Params { return nil }
 
 func (c Client) complete(prompt string, params Params?) {}
 
-onStart => {
+func run() {
 	client.complete "hi", maxTokens = 1
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 15, Character: 25},
 			},
 		})
@@ -880,7 +896,7 @@ onStart => {
 
 	t.Run("DuplicateEnumMembers", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`type First const (
+			"main.xgo": []byte(`type First const (
 	// First member documentation.
 	Unknown = iota
 )
@@ -898,11 +914,11 @@ var (
 echo Unknown
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 		hoverAt := func(line, character uint32) *Hover {
 			hover, err := s.textDocumentHover(&HoverParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 					Position:     Position{Line: line, Character: character},
 				},
 			})
@@ -932,7 +948,7 @@ echo Unknown
 
 	t.Run("EnumMemberSharedWithRegularConstant", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`const (
+			"main.xgo": []byte(`const (
 	// Regular documentation.
 	Shared = 1
 )
@@ -948,7 +964,7 @@ func run() {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		for _, tt := range []struct {
 			name        string
@@ -984,7 +1000,7 @@ func run() {
 			t.Run(tt.name, func(t *testing.T) {
 				hover, err := s.textDocumentHover(&HoverParams{
 					TextDocumentPositionParams: TextDocumentPositionParams{
-						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 						Position:     tt.position,
 					},
 				})
@@ -998,7 +1014,7 @@ func run() {
 
 	t.Run("ParenthesizedDuplicateEnumMembers", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`type First const (
+			"main.xgo": []byte(`type First const (
 	// First member documentation.
 	Unknown = iota
 )
@@ -1016,7 +1032,7 @@ func run() {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		for _, position := range []Position{
 			{Line: 13, Character: 22},
@@ -1024,7 +1040,7 @@ func run() {
 		} {
 			hover, err := s.textDocumentHover(&HoverParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 					Position:     position,
 				},
 			})
@@ -1037,7 +1053,7 @@ func run() {
 
 	t.Run("TupleDuplicateEnumMembers", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`type First const (
+			"main.xgo": []byte(`type First const (
 	// First member documentation.
 	Unknown = iota
 )
@@ -1054,7 +1070,7 @@ func run() {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		for _, tt := range []struct {
 			name        string
@@ -1078,7 +1094,7 @@ func run() {
 			t.Run(tt.name, func(t *testing.T) {
 				hover, err := s.textDocumentHover(&HoverParams{
 					TextDocumentPositionParams: TextDocumentPositionParams{
-						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 						Position:     tt.position,
 					},
 				})
@@ -1092,7 +1108,7 @@ func run() {
 
 	t.Run("ContextualDuplicateEnumMembers", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`type First const (
+			"main.xgo": []byte(`type First const (
 	// First member documentation.
 	Unknown = iota
 )
@@ -1137,7 +1153,7 @@ func run(second Second) {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		for _, tt := range []struct {
 			name     string
@@ -1165,7 +1181,7 @@ func run(second Second) {
 			t.Run(tt.name, func(t *testing.T) {
 				hover, err := s.textDocumentHover(&HoverParams{
 					TextDocumentPositionParams: TextDocumentPositionParams{
-						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 						Position:     tt.position,
 					},
 				})
@@ -1186,7 +1202,7 @@ func run(second Second) {
 			t.Run(tt.name, func(t *testing.T) {
 				hover, err := s.textDocumentHover(&HoverParams{
 					TextDocumentPositionParams: TextDocumentPositionParams{
-						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 						Position:     tt.position,
 					},
 				})
@@ -1200,7 +1216,7 @@ func run(second Second) {
 
 	t.Run("ContextualDuplicateEnumMemberInLambda", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`type First const (
+			"main.xgo": []byte(`type First const (
 	// First member documentation.
 	Unknown = iota
 )
@@ -1217,11 +1233,11 @@ func run() {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 13, Character: 9},
 			},
 		})
@@ -1233,7 +1249,7 @@ func run() {
 
 	t.Run("LocalEnumMember", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`func run() {
+			"main.xgo": []byte(`func run() {
 	type Color const (
 		// Local red documentation.
 		Red = iota
@@ -1242,7 +1258,7 @@ func run() {
 }
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		for _, position := range []Position{
 			{Line: 3, Character: 2},
@@ -1250,7 +1266,7 @@ func run() {
 		} {
 			hover, err := s.textDocumentHover(&HoverParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 					Position:     position,
 				},
 			})
@@ -1260,62 +1276,55 @@ func run() {
 		}
 	})
 
-	t.Run("XGoUnit", func(t *testing.T) {
-		s := newXGoUnitTestServer(xgoUnitCompletionSource)
+	for _, tt := range []struct {
+		name         string
+		source       string
+		unit         string
+		multiplier   string
+		endCharacter uint32
+	}{
+		{
+			name:         "XGoUnit",
+			source:       "import \"time\"\n\nfunc wait(d time.Duration) {}\n\nfunc run() {\n\twait 1m\n}\n",
+			unit:         "m",
+			multiplier:   "60000000000",
+			endCharacter: 8,
+		},
+		{
+			name:         "XGoUnicodeUnit",
+			source:       "import \"time\"\n\nfunc wait(d time.Duration) {}\n\nfunc run() {\n\twait 1\u00b5s\n}\n",
+			unit:         "\u00b5s",
+			multiplier:   "1000",
+			endCharacter: 9,
+		},
+		{
+			name:         "XGoUnitImportedAliasFallback",
+			source:       "import \"example.com/unit\"\n\nfunc wait(d unit.Delay) {}\n\nfunc run() {\n\twait 1ms\n}\n",
+			unit:         "ms",
+			multiplier:   "1000000",
+			endCharacter: 9,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+			proj := s.workspaceRootFS
+			proj.Importer = xgoUnitTestImporter{fallback: proj.Importer}
 
-		hover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 15, Character: 7},
-			},
+			hover, err := s.textDocumentHover(&HoverParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 5, Character: 7},
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, hover)
+			assert.Equal(t, Range{
+				Start: Position{Line: 5, Character: 7},
+				End:   Position{Line: 5, Character: tt.endCharacter},
+			}, hover.Range)
+			assert.Contains(t, hover.Contents.Value, "unit `"+tt.unit+"`")
+			assert.Contains(t, hover.Contents.Value, "time.Duration")
+			assert.Contains(t, hover.Contents.Value, "Multiplier: `"+tt.multiplier+"`")
 		})
-		require.NoError(t, err)
-		require.NotNil(t, hover)
-		assert.Equal(t, Range{
-			Start: Position{Line: 15, Character: 7},
-			End:   Position{Line: 15, Character: 8},
-		}, hover.Range)
-		assert.Contains(t, hover.Contents.Value, "unit `m`")
-		assert.Contains(t, hover.Contents.Value, "time.Duration")
-		assert.Contains(t, hover.Contents.Value, "Multiplier: `60000000000`")
-	})
-
-	t.Run("XGoUnicodeUnit", func(t *testing.T) {
-		s := newXGoUnitTestServer("import \"time\"\n\nfunc wait(d time.Duration) {}\n\nonStart => {\n\twait 1\u00b5s\n}\n")
-
-		hover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 5, Character: 7},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, hover)
-		assert.Equal(t, Range{
-			Start: Position{Line: 5, Character: 7},
-			End:   Position{Line: 5, Character: 9},
-		}, hover.Range)
-		assert.Contains(t, hover.Contents.Value, "unit `\u00b5s`")
-		assert.Contains(t, hover.Contents.Value, "Multiplier: `1000`")
-	})
-
-	t.Run("XGoUnitImportedAliasFallback", func(t *testing.T) {
-		s := newXGoUnitTestServer("import \"example.com/unit\"\n\nfunc wait(d unit.Delay) {}\n\nonStart => {\n\twait 1ms\n}\n")
-
-		hover, err := s.textDocumentHover(&HoverParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 5, Character: 7},
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, hover)
-		assert.Equal(t, Range{
-			Start: Position{Line: 5, Character: 7},
-			End:   Position{Line: 5, Character: 9},
-		}, hover.Range)
-		assert.Contains(t, hover.Contents.Value, "unit `ms`")
-		assert.Contains(t, hover.Contents.Value, "time.Duration")
-		assert.Contains(t, hover.Contents.Value, "Multiplier: `1000000`")
-	})
+	}
 }

--- a/internal/server/markup_test.go
+++ b/internal/server/markup_test.go
@@ -95,13 +95,13 @@ func TestCompletionDocumentation(t *testing.T) {
 
 func TestServerTextDocumentHoverPlainTextEnum(t *testing.T) {
 	files := map[string][]byte{
-		"main.spx": []byte(`type Color const (
+		"main.xgo": []byte(`type Color const (
 	// Red documentation.
 	Red = iota
 )
 `),
 	}
-	server := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+	server := newTestServer(t, files)
 	_, err := server.initialize(&InitializeParams{
 		XInitializeParams: protocol.XInitializeParams{
 			Capabilities: protocol.ClientCapabilities{
@@ -118,7 +118,7 @@ func TestServerTextDocumentHoverPlainTextEnum(t *testing.T) {
 
 	hover, err := server.textDocumentHover(&HoverParams{
 		TextDocumentPositionParams: TextDocumentPositionParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 			Position:     Position{Line: 2, Character: 1},
 		},
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,7 +17,9 @@ import (
 	"github.com/goplus/xgolsw/i18n"
 	"github.com/goplus/xgolsw/internal"
 	"github.com/goplus/xgolsw/internal/analysis"
+	"github.com/goplus/xgolsw/internal/pkgdata"
 	"github.com/goplus/xgolsw/jsonrpc2"
+	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/goplus/xgolsw/xgo"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 )
@@ -50,6 +52,7 @@ type Server struct {
 	analyzers          []*analysis.Analyzer
 	fileMapGetter      FileMapGetter // TODO(wyvern): Remove this field.
 	cancelCauseFuncs   sync.Map      // Map of request IDs to cancel functions (with cause).
+	lookupPkgDoc       func(string) (*pkgdoc.PkgDoc, error)
 	scheduler          Scheduler
 	language           i18n.Language // Current language for error message translation
 	initMu             sync.Mutex
@@ -84,6 +87,7 @@ func New(proj *xgo.Project, replier MessageReplier, fileMapGetter FileMapGetter,
 		analyzers:        initAnalyzers(true),
 		fileMapGetter:    fileMapGetter,
 		scheduler:        scheduler,
+		lookupPkgDoc:     pkgdata.GetPkgDoc,
 		language:         i18n.LanguageEN, // Default to English until initialize is called
 	}
 }

--- a/internal/server/spx_definition.go
+++ b/internal/server/spx_definition.go
@@ -255,10 +255,15 @@ var (
 
 // GetSpxDefinitionForBuiltinObj returns the spx definition for the given object.
 func GetSpxDefinitionForBuiltinObj(obj gotypes.Object) SpxDefinition {
+	return getDefinitionForBuiltinObj(obj, internal.Importer, pkgdata.GetPkgDoc)
+}
+
+// getDefinitionForBuiltinObj describes a builtin using the provided package data.
+func getDefinitionForBuiltinObj(obj gotypes.Object, importer gotypes.Importer, lookupPkgDoc func(string) (*pkgdoc.PkgDoc, error)) SpxDefinition {
 	const pkgPath = "builtin"
 
 	idName := obj.Name()
-	if def, err := getSpxDefinitionForXGoBuiltinAlias(idName); err == nil {
+	if def, err := getDefinitionForXGoBuiltinAlias(idName, importer, lookupPkgDoc); err == nil {
 		return def
 	}
 
@@ -268,7 +273,7 @@ func GetSpxDefinitionForBuiltinObj(obj gotypes.Object) SpxDefinition {
 	}
 
 	var detail string
-	if pkgDoc, err := pkgdata.GetPkgDoc(pkgPath); err == nil {
+	if pkgDoc, err := lookupPkgDoc(pkgPath); err == nil {
 		if doc, ok := pkgDoc.Vars[idName]; ok {
 			detail = doc
 		} else if doc, ok := pkgDoc.Consts[idName]; ok {
@@ -335,7 +340,7 @@ var GetBuiltinSpxDefinitions = sync.OnceValue(func() []SpxDefinition {
 		}
 	}
 	for alias := range xgoBuiltinAliases {
-		def, err := getSpxDefinitionForXGoBuiltinAlias(alias)
+		def, err := getDefinitionForXGoBuiltinAlias(alias, internal.Importer, pkgdata.GetPkgDoc)
 		if err != nil {
 			panic(fmt.Errorf("failed to get spx definition for xgo builtin alias %q: %w", alias, err))
 		}
@@ -344,9 +349,8 @@ var GetBuiltinSpxDefinitions = sync.OnceValue(func() []SpxDefinition {
 	return slices.Clip(defs)
 })
 
-// getSpxDefinitionForXGoBuiltinAlias returns the spx definition for the
-// given XGo builtin alias.
-func getSpxDefinitionForXGoBuiltinAlias(alias string) (SpxDefinition, error) {
+// getDefinitionForXGoBuiltinAlias resolves a builtin alias using the provided package data.
+func getDefinitionForXGoBuiltinAlias(alias string, importer gotypes.Importer, lookupPkgDoc func(string) (*pkgdoc.PkgDoc, error)) (SpxDefinition, error) {
 	ref, ok := xgoBuiltinAliases[alias]
 	if !ok {
 		return SpxDefinition{}, fmt.Errorf("unknown xgo builtin alias: %s", alias)
@@ -356,14 +360,11 @@ func getSpxDefinitionForXGoBuiltinAlias(alias string) (SpxDefinition, error) {
 	if !ok {
 		return SpxDefinition{}, fmt.Errorf("invalid xgo builtin alias: %s", alias)
 	}
-	pkg, err := internal.Importer.Import(pkgPath)
+	pkg, err := importer.Import(pkgPath)
 	if err != nil {
 		return SpxDefinition{}, fmt.Errorf("failed to import package for xgo builtin alias %q: %w", alias, err)
 	}
-	pkgDoc, err := pkgdata.GetPkgDoc(pkgPath)
-	if err != nil {
-		return SpxDefinition{}, fmt.Errorf("failed to get package doc for xgo builtin alias %q: %w", alias, err)
-	}
+	pkgDoc, _ := lookupPkgDoc(pkgPath)
 
 	obj := pkg.Scope().Lookup(name)
 	if obj == nil {
@@ -606,6 +607,7 @@ var nonMainPkgSpxDefCacheForVars sync.Map // map[nonMainPkgSpxDefCacheForVarsKey
 type nonMainPkgSpxDefCacheForVarsKey struct {
 	v                *gotypes.Var
 	selectorTypeName string
+	pkgDoc           *pkgdoc.PkgDoc
 }
 
 // spxMemberDefinitionPkgPath returns the package path used in definition IDs for
@@ -628,6 +630,7 @@ func GetSpxDefinitionForVar(v *gotypes.Var, selectorTypeName string, forceVar bo
 		cacheKey := nonMainPkgSpxDefCacheForVarsKey{
 			v:                v,
 			selectorTypeName: selectorTypeName,
+			pkgDoc:           pkgDoc,
 		}
 		if defIface, ok := nonMainPkgSpxDefCacheForVars.Load(cacheKey); ok {
 			return defIface.(SpxDefinition)
@@ -692,16 +695,23 @@ func GetSpxDefinitionForVar(v *gotypes.Var, selectorTypeName string, forceVar bo
 
 // nonMainPkgSpxDefCacheForConsts is a cache of non-main package spx definitions
 // for constants.
-var nonMainPkgSpxDefCacheForConsts sync.Map // map[*types.Const]SpxDefinition
+var nonMainPkgSpxDefCacheForConsts sync.Map // map[nonMainPkgSpxDefCacheForConstsKey]SpxDefinition
+
+// nonMainPkgSpxDefCacheForConstsKey identifies a symbol and its package documentation.
+type nonMainPkgSpxDefCacheForConstsKey struct {
+	obj    *gotypes.Const
+	pkgDoc *pkgdoc.PkgDoc
+}
 
 // GetSpxDefinitionForConst returns the spx definition for the provided constant.
 func GetSpxDefinitionForConst(c *gotypes.Const, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
 	if !xgoutil.IsInMainPkg(c) {
-		if defIface, ok := nonMainPkgSpxDefCacheForConsts.Load(c); ok {
+		cacheKey := nonMainPkgSpxDefCacheForConstsKey{c, pkgDoc}
+		if defIface, ok := nonMainPkgSpxDefCacheForConsts.Load(cacheKey); ok {
 			return defIface.(SpxDefinition)
 		}
 		defer func() {
-			nonMainPkgSpxDefCacheForConsts.Store(c, def)
+			nonMainPkgSpxDefCacheForConsts.Store(cacheKey, def)
 		}()
 	}
 
@@ -736,16 +746,23 @@ func GetSpxDefinitionForConst(c *gotypes.Const, pkgDoc *pkgdoc.PkgDoc) (def SpxD
 
 // nonMainPkgSpxDefCacheForTypes is a cache of non-main package spx definitions
 // for types.
-var nonMainPkgSpxDefCacheForTypes sync.Map // map[*types.TypeName]SpxDefinition
+var nonMainPkgSpxDefCacheForTypes sync.Map // map[nonMainPkgSpxDefCacheForTypesKey]SpxDefinition
+
+// nonMainPkgSpxDefCacheForTypesKey identifies a symbol and its package documentation.
+type nonMainPkgSpxDefCacheForTypesKey struct {
+	obj    *gotypes.TypeName
+	pkgDoc *pkgdoc.PkgDoc
+}
 
 // GetSpxDefinitionForType returns the spx definition for the provided type.
 func GetSpxDefinitionForType(typeName *gotypes.TypeName, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
 	if !xgoutil.IsInMainPkg(typeName) {
-		if defIface, ok := nonMainPkgSpxDefCacheForTypes.Load(typeName); ok {
+		cacheKey := nonMainPkgSpxDefCacheForTypesKey{typeName, pkgDoc}
+		if defIface, ok := nonMainPkgSpxDefCacheForTypes.Load(cacheKey); ok {
 			return defIface.(SpxDefinition)
 		}
 		defer func() {
-			nonMainPkgSpxDefCacheForTypes.Store(typeName, def)
+			nonMainPkgSpxDefCacheForTypes.Store(cacheKey, def)
 		}()
 	}
 
@@ -798,6 +815,7 @@ var nonMainPkgSpxDefCacheForFuncs sync.Map // map[nonMainPkgSpxDefCacheForFuncsK
 type nonMainPkgSpxDefCacheForFuncsKey struct {
 	fun          *gotypes.Func
 	recvTypeName string
+	pkgDoc       *pkgdoc.PkgDoc
 }
 
 // GetSpxDefinitionForFunc returns the spx definition for the provided function.
@@ -806,6 +824,7 @@ func GetSpxDefinitionForFunc(fun *gotypes.Func, recvTypeName string, pkgDoc *pkg
 		cacheKey := nonMainPkgSpxDefCacheForFuncsKey{
 			fun:          fun,
 			recvTypeName: recvTypeName,
+			pkgDoc:       pkgDoc,
 		}
 		if defIface, ok := nonMainPkgSpxDefCacheForFuncs.Load(cacheKey); ok {
 			return defIface.(SpxDefinition)
@@ -959,16 +978,23 @@ func makeSpxDefinitionOverviewForFunc(fun *gotypes.Func) (overview, parsedRecvTy
 
 // nonMainPkgSpxDefCacheForPkgs is a cache of non-main package spx definitions
 // for packages.
-var nonMainPkgSpxDefCacheForPkgs sync.Map // map[*types.PkgName]SpxDefinition
+var nonMainPkgSpxDefCacheForPkgs sync.Map // map[nonMainPkgSpxDefCacheForPkgsKey]SpxDefinition
+
+// nonMainPkgSpxDefCacheForPkgsKey identifies a symbol and its package documentation.
+type nonMainPkgSpxDefCacheForPkgsKey struct {
+	obj    *gotypes.PkgName
+	pkgDoc *pkgdoc.PkgDoc
+}
 
 // GetSpxDefinitionForPkg returns the spx definition for the provided package.
 func GetSpxDefinitionForPkg(pkgName *gotypes.PkgName, pkgDoc *pkgdoc.PkgDoc) (def SpxDefinition) {
 	if !xgoutil.IsInMainPkg(pkgName) {
-		if defIface, ok := nonMainPkgSpxDefCacheForPkgs.Load(pkgName); ok {
+		cacheKey := nonMainPkgSpxDefCacheForPkgsKey{pkgName, pkgDoc}
+		if defIface, ok := nonMainPkgSpxDefCacheForPkgs.Load(cacheKey); ok {
 			return defIface.(SpxDefinition)
 		}
 		defer func() {
-			nonMainPkgSpxDefCacheForPkgs.Store(pkgName, def)
+			nonMainPkgSpxDefCacheForPkgs.Store(cacheKey, def)
 		}()
 	}
 
@@ -981,7 +1007,7 @@ func GetSpxDefinitionForPkg(pkgName *gotypes.PkgName, pkgDoc *pkgdoc.PkgDoc) (de
 		TypeHint: pkgName.Type(),
 
 		ID: SpxDefinitionIdentifier{
-			Package: ToPtr(xgoutil.PkgPath(pkgName.Pkg())),
+			Package: ToPtr(xgoutil.PkgPath(pkgName.Imported())),
 		},
 		Overview: "package " + pkgName.Name(),
 		Detail:   detail,

--- a/internal/server/spx_hover.go
+++ b/internal/server/spx_hover.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"fmt"
+	"path"
+	"slices"
+
+	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/xgo"
+)
+
+// hoverForSpxResource returns a preview for a resource in an spx classfile.
+func (s *Server) hoverForSpxResource(proj *xgo.Project, filename string, position token.Position, markupKind MarkupKind) (*Hover, error) {
+	if path.Ext(filename) != ".spx" {
+		return nil, nil
+	}
+	class, ok := proj.Mod.LookupClass(".spx")
+	if !ok || !slices.Contains(class.PkgPaths, SpxPkgPath) {
+		return nil, nil
+	}
+	result, err := s.compileAt(proj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile: %w", err)
+	}
+	ref := result.spxResourceRefAtPosition(position)
+	if ref == nil {
+		return nil, nil
+	}
+	return &Hover{
+		Contents: resourceMarkupContent(ref.ID.URI(), markupKind),
+		Range:    RangeForNode(proj, ref.Node),
+	}, nil
+}

--- a/internal/server/spx_hover_test.go
+++ b/internal/server/spx_hover_test.go
@@ -1,0 +1,358 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerTextDocumentHoverSpx(t *testing.T) {
+	t.Run("PackageDocumentationLookup", func(t *testing.T) {
+		files := map[string][]byte{
+			"main.spx":                       []byte("import \"fmt\"\nfmt.Println(1)\nplay \"Sound\"\n"),
+			"assets/index.json":              []byte(`{}`),
+			"assets/sounds/Sound/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+		const wantDoc = "Documentation supplied by the server."
+		doc := &pkgdoc.PkgDoc{
+			Path:  "fmt",
+			Funcs: map[string]string{"Println": wantDoc},
+		}
+		var lookups []string
+		s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+			assert.Equal(t, "fmt", pkgPath)
+			lookups = append(lookups, pkgPath)
+			return doc, nil
+		}
+
+		result, err := s.compileAt(s.workspaceRootFS)
+		require.NoError(t, err)
+		pkg, err := result.proj.Importer.Import("fmt")
+		require.NoError(t, err)
+		defs := result.spxDefinitionsFor(pkg.Scope().Lookup("Println"), "")
+		require.Len(t, defs, 1)
+		assert.Equal(t, wantDoc, defs[0].Detail)
+		assert.Equal(t, []string{"fmt"}, lookups)
+
+		hover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 1, Character: 5},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Contains(t, hover.Contents.Value, wantDoc)
+		assert.Equal(t, []string{"fmt", "fmt"}, lookups)
+
+		hover, err = s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 2, Character: 7},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Equal(t, resourceMarkupContent("spx://resources/sounds/Sound", Markdown), hover.Contents)
+		assert.Equal(t, []string{"fmt", "fmt"}, lookups)
+	})
+
+	t.Run("ResourcesAndMembers", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+play "MySound"
+MySprite.turn Left
+MySprite.setCostume "costume1"
+Game.onClick => {}
+onClick => {}
+Camera.follow "MySprite"
+`),
+			"MySprite.spx": []byte(`
+MySprite.onClick => {}
+onClick => {}
+onStart => {
+	MySprite.turn Right
+	clone
+}
+onTouchStart "MySprite", => {}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{"costumes":[{"name":"costume1"}]}`),
+			"assets/sounds/MySound/index.json":   []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		mySoundRefHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 1, Character: 5},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mySoundRefHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<resource-preview resource=\"spx://resources/sounds/MySound\" />\n",
+			},
+			Range: Range{
+				Start: Position{Line: 1, Character: 5},
+				End:   Position{Line: 1, Character: 14},
+			},
+		}, mySoundRefHover)
+
+		mySpriteRefHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 2, Character: 0},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mySpriteRefHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<resource-preview resource=\"spx://resources/sprites/MySprite\" />\n",
+			},
+			Range: Range{
+				Start: Position{Line: 2, Character: 0},
+				End:   Position{Line: 2, Character: 8},
+			},
+		}, mySpriteRefHover)
+
+		mySpriteCostumeRefHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 3, Character: 20},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mySpriteCostumeRefHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<resource-preview resource=\"spx://resources/sprites/MySprite/costumes/costume1\" />\n",
+			},
+			Range: Range{
+				Start: Position{Line: 3, Character: 20},
+				End:   Position{Line: 3, Character: 30},
+			},
+		}, mySpriteCostumeRefHover)
+
+		mySpriteSetCostumeFuncHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 3, Character: 9},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mySpriteSetCostumeFuncHover)
+		assert.Equal(t, Range{
+			Start: Position{Line: 3, Character: 9},
+			End:   Position{Line: 3, Character: 19},
+		}, mySpriteSetCostumeFuncHover.Range)
+
+		GameOnClickHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 4, Character: 5},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, GameOnClickHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Game.onClick\" overview=\"func onClick(onClick func())\">\n</pre>\n",
+			},
+			Range: Range{
+				Start: Position{Line: 4, Character: 5},
+				End:   Position{Line: 4, Character: 12},
+			},
+		}, GameOnClickHover)
+
+		mainSpxOnClickHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 5, Character: 0},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mainSpxOnClickHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Game.onClick\" overview=\"func onClick(onClick func())\">\n</pre>\n",
+			},
+			Range: Range{
+				Start: Position{Line: 5, Character: 0},
+				End:   Position{Line: 5, Character: 7},
+			},
+		}, mainSpxOnClickHover)
+
+		mainSpxCameraFollowHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 6, Character: 8},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mainSpxCameraFollowHover)
+		assert.Contains(t, mainSpxCameraFollowHover.Contents.Value, `def-id="xgo:github.com/goplus/spx/v3?Game.follow#1"`)
+		assert.Equal(t, Range{
+			Start: Position{Line: 6, Character: 7},
+			End:   Position{Line: 6, Character: 13},
+		}, mainSpxCameraFollowHover.Range)
+
+		mySpriteOnClickFuncHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+				Position:     Position{Line: 1, Character: 9},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mySpriteOnClickFuncHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Sprite.onClick\" overview=\"func onClick(onClick func())\">\n</pre>\n",
+			},
+			Range: Range{
+				Start: Position{Line: 1, Character: 9},
+				End:   Position{Line: 1, Character: 16},
+			},
+		}, mySpriteOnClickFuncHover)
+
+		mySpriteSpxOnClickFuncHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+				Position:     Position{Line: 2, Character: 0},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mySpriteSpxOnClickFuncHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Sprite.onClick\" overview=\"func onClick(onClick func())\">\n</pre>\n",
+			},
+			Range: Range{
+				Start: Position{Line: 2, Character: 0},
+				End:   Position{Line: 2, Character: 7},
+			},
+		}, mySpriteSpxOnClickFuncHover)
+
+		mySpriteCloneFuncHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+				Position:     Position{Line: 5, Character: 1},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mySpriteCloneFuncHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<pre is=\"definition-item\" def-id=\"xgo:github.com/goplus/spx/v3?Sprite.clone#0\" overview=\"func clone()\">\n</pre>\n",
+			},
+			Range: Range{
+				Start: Position{Line: 5, Character: 1},
+				End:   Position{Line: 5, Character: 6},
+			},
+		}, mySpriteCloneFuncHover)
+
+		onTouchStartFirstArgHover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+				Position:     Position{Line: 7, Character: 14},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, onTouchStartFirstArgHover)
+		assert.Equal(t, &Hover{
+			Contents: MarkupContent{
+				Kind:  Markdown,
+				Value: "<resource-preview resource=\"spx://resources/sprites/MySprite\" />\n",
+			},
+			Range: Range{
+				Start: Position{Line: 7, Character: 13},
+				End:   Position{Line: 7, Character: 23},
+			},
+		}, onTouchStartFirstArgHover)
+	})
+
+	t.Run("XGotMethodCall", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	getWidget Monitor, "myWidget"
+}
+`),
+			"assets/index.json": []byte(`{"zorder":[{"name":"myWidget"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		hover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 2, Character: 1},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Contains(t, hover.Contents.Value, `def-id="xgo:github.com/goplus/spx/v3?Game.getWidget"`)
+		assert.Contains(t, hover.Contents.Value, `overview="func getWidget(T Type, name WidgetName) *T"`)
+		assert.Contains(t, hover.Contents.Value, `GetWidget returns the widget instance (in given type) with given name. It panics if not found.`)
+		assert.Equal(t, Range{
+			Start: Position{Line: 2, Character: 1},
+			End:   Position{Line: 2, Character: 10},
+		}, hover.Range)
+	})
+
+	t.Run("SpriteLineStartShouldNotResolveToSyntheticThis", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`onStart => {}
+`),
+			"MySprite.spx": []byte(`onStart => {
+    step 10
+    turn Left
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		// The characters on `onStart` should map to `onStart`, not synthetic `this`.
+		for _, ch := range []uint32{0, 1, 2, 3, 4, 5, 6} {
+			hover, err := s.textDocumentHover(&HoverParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+					Position:     Position{Line: 0, Character: ch},
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, hover)
+			assert.Contains(t, hover.Contents.Value, `def-id="xgo:github.com/goplus/spx/v3?Sprite.onStart"`)
+			assert.NotContains(t, hover.Contents.Value, `var this`)
+		}
+
+		// The first four characters on indented lines are whitespaces and should not produce hover.
+		for _, line := range []uint32{1, 2} {
+			for _, ch := range []uint32{0, 1, 2, 3} {
+				hover, err := s.textDocumentHover(&HoverParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+						Position:     Position{Line: line, Character: ch},
+					},
+				})
+				require.NoError(t, err)
+				assert.Nil(t, hover)
+			}
+		}
+	})
+
+}

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -1,9 +1,13 @@
 package server
 
 import (
+	"io/fs"
+	"strings"
 	"testing"
 
 	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestServer(t *testing.T, files map[string][]byte) *Server {
@@ -13,5 +17,16 @@ func newTestServer(t *testing.T, files map[string][]byte) *Server {
 	s := New(proj, nil, fileMapGetter(files), &MockScheduler{})
 	proj.Mod = testframework.NewModule(t)
 	proj.Importer = testframework.NewImporter(t, proj.Fset)
+	frameworkDoc := testframework.NewPkgDoc(t)
+	s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+		t.Helper()
+
+		require.False(t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
+			"unexpected spx documentation lookup: %s", pkgPath)
+		if pkgPath == testframework.PkgPath {
+			return frameworkDoc, nil
+		}
+		return nil, fs.ErrNotExist
+	}
 	return s
 }

--- a/internal/testframework/framework.go
+++ b/internal/testframework/framework.go
@@ -14,6 +14,7 @@ import (
 	"github.com/goplus/mod/modload"
 	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,4 +75,16 @@ func (i *importer) Import(pkgPath string) (*gotypes.Package, error) {
 		return i.framework, nil
 	}
 	return i.fallback.Import(pkgPath)
+}
+
+// NewPkgDoc returns documentation parsed from the framework source.
+func NewPkgDoc(t *testing.T) *pkgdoc.PkgDoc {
+	t.Helper()
+
+	astFile, err := goparser.ParseFile(token.NewFileSet(), "testdata/framework.go", source, goparser.ParseComments)
+	require.NoError(t, err)
+	return pkgdoc.NewGo(PkgPath, &goast.Package{
+		Name:  astFile.Name.Name,
+		Files: map[string]*goast.File{"testdata/framework.go": astFile},
+	})
 }

--- a/internal/testframework/testdata/framework.go
+++ b/internal/testframework/testdata/framework.go
@@ -36,7 +36,10 @@ func RunWhen(__xgo_autoclosure_condition func() bool, callback func()) {}
 func XGot_App_XGox_Create[T any](a *App, name string) *T { return nil }
 
 // Item is the work base class.
-type Item struct{}
+type Item struct {
+	// Value stores the work item's value.
+	Value int
+}
 
 // Main is the work entry point.
 func (i *Item) Main() {}


### PR DESCRIPTION
Resolve hover from project AST, type, and enum information. Migrate common hover tests to plain XGo and the isolated classfile framework, with documentation parsed from fixture source. Keep spx resource and member regressions in dedicated tests.

Allow hover tests to supply package documentation and use the project importer for builtin aliases. Include documentation in symbol cache keys, resolve package hovers through the imported package, and preserve builtin alias signatures when documentation is unavailable.

Cover source file kinds, cross-file fields, documentation isolation, Markdown and plain text, UTF-16 ranges, document updates, and unavailable documents without requiring embedded package data.