### PR TITLE
test(server): decouple completion tests from spx

### DIFF
--- a/internal/server/command_test.go
+++ b/internal/server/command_test.go
@@ -564,7 +564,7 @@ onStart => {
 	})
 
 	t.Run("XGoUnitValue", func(t *testing.T) {
-		s := newXGoUnitTestServer(`import "time"
+		s := newSpxUnitTestServer(t, `import "time"
 
 func wait(d time.Duration) {}
 
@@ -591,7 +591,7 @@ onStart => {
 	})
 
 	t.Run("XGoUnitImportedAliasFallbackValue", func(t *testing.T) {
-		s := newXGoUnitTestServer(`import "example.com/unit"
+		s := newSpxUnitTestServer(t, `import "example.com/unit"
 
 func wait(d unit.Delay) {}
 
@@ -618,7 +618,7 @@ onStart => {
 	})
 
 	t.Run("XGoUnitInterfaceKwargValue", func(t *testing.T) {
-		s := newXGoUnitTestServer(`import "time"
+		s := newSpxUnitTestServer(t, `import "time"
 
 type Params interface {
 	Delay(time.Duration) Params
@@ -654,7 +654,7 @@ onStart => {
 	})
 
 	t.Run("XGoUnitUnsupportedContexts", func(t *testing.T) {
-		s := newXGoUnitTestServer(`import "time"
+		s := newSpxUnitTestServer(t, `import "time"
 
 type Options struct {
 	Delay time.Duration
@@ -2314,4 +2314,19 @@ func findAddressInputSlot(inputSlots []SpxInputSlot, name string) *SpxInputSlot 
 		}
 	}
 	return nil
+}
+
+// newSpxUnitTestServer provides XGo unit fixtures for input slot tests,
+// whose command entry point still requires an spx document.
+func newSpxUnitTestServer(t *testing.T, source string) *Server {
+	t.Helper()
+
+	m := map[string][]byte{
+		"main.spx":          []byte(source),
+		"assets/index.json": []byte(`{}`),
+	}
+	proj := newProjectWithoutModTime(m)
+	s := New(proj, nil, fileMapGetter(m), &MockScheduler{})
+	s.workspaceRootFS.Importer = xgoUnitTestImporter{fallback: s.workspaceRootFS.Importer}
+	return s
 }

--- a/internal/server/compile_test.go
+++ b/internal/server/compile_test.go
@@ -26,6 +26,12 @@ func plain() string {
 	return "plain"
 }
 
+func unresolved() string {
+	return "unresolved"
+}
+
+func external() string
+
 func excess() string {
 	return "resourceWithExtraValue", "extraValue"
 }
@@ -53,6 +59,9 @@ func nested() string {
 		}
 		var results *gotypes.Tuple
 		switch funcDecl.Name.Name {
+		case "unresolved":
+			// Incomplete type information can omit a function's definition.
+			continue
 		case "resource":
 			results = gotypes.NewTuple(
 				gotypes.NewVar(token.NoPos, nil, "", resourceType),
@@ -93,6 +102,7 @@ func nested() string {
 	assert.NotContains(t, gotByValue, `"extraValue"`)
 	assert.NotContains(t, gotByValue, `"ordinary"`)
 	assert.NotContains(t, gotByValue, `"plain"`)
+	assert.NotContains(t, gotByValue, `"unresolved"`)
 	assert.NotContains(t, gotByValue, `"nestedFunction"`)
 }
 

--- a/internal/server/completion.go
+++ b/internal/server/completion.go
@@ -16,7 +16,6 @@ import (
 	"github.com/goplus/xgo/cl"
 	"github.com/goplus/xgo/scanner"
 	"github.com/goplus/xgo/token"
-	"github.com/goplus/xgolsw/internal/pkgdata"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/goplus/xgolsw/xgo/types"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
@@ -63,6 +62,7 @@ func (s *Server) textDocumentCompletion(params *CompletionParams) (any, error) {
 			lookupPkgDoc: s.lookupPkgDoc,
 		},
 		itemSet:        newCompletionItemSet(documentationKind),
+		listPkgs:       s.listPkgs,
 		typeInfo:       typeInfo,
 		filename:       filename,
 		astFile:        astFile,
@@ -116,7 +116,8 @@ const (
 type completionContext struct {
 	definitionContext
 
-	itemSet *completionItemSet
+	itemSet  *completionItemSet
+	listPkgs func() ([]string, error)
 
 	typeInfo       *types.Info
 	spxResult      *compileResult
@@ -1170,7 +1171,7 @@ func (ctx *completionContext) collectGeneral() error {
 
 // collectImport collects import completions.
 func (ctx *completionContext) collectImport() error {
-	pkgs, err := pkgdata.ListPkgs()
+	pkgs, err := ctx.listPkgs()
 	if err != nil {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}

--- a/internal/server/completion_import_test.go
+++ b/internal/server/completion_import_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerTextDocumentCompletionImports(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		source   string
+		position Position
+	}{
+		{name: "InImportStringLit", source: "\nimport \"f\n", position: Position{Line: 1, Character: 9}},
+		{name: "InImportGroupStringLit", source: "\nimport (\n\t\"f\n", position: Position{Line: 2, Character: 3}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+			s.listPkgs = func() ([]string, error) {
+				return []string{"fmt", testframework.PkgPath, "example.com/missing"}, nil
+			}
+			lookup := s.lookupPkgDoc
+			s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+				if pkgPath == "fmt" {
+					return &pkgdoc.PkgDoc{Doc: "Package fmt formats values."}, nil
+				}
+				return lookup(pkgPath)
+			}
+
+			items := completionItemsAt(t, s, "main.xgo", tt.position)
+			assert.ElementsMatch(t, []string{"fmt", testframework.PkgPath}, completionItemLabels(items))
+			item := completionItemByLabel(items, "fmt")
+			require.NotNil(t, item)
+			assert.Equal(t, ModuleCompletion, item.Kind)
+			assert.Equal(t, "fmt", item.InsertText)
+			assert.Equal(t, ToPtr(PlainTextTextFormat), item.InsertTextFormat)
+			data := requireValueAs[*CompletionItemData](t, item.Data)
+			assert.Equal(t, ToPtr("fmt"), data.Definition.Package)
+			require.NotNil(t, item.Documentation)
+			doc := requireValueAs[MarkupContent](t, item.Documentation.Value)
+			assert.Contains(t, doc.Value, "Package fmt formats values.")
+		})
+	}
+
+	t.Run("EmptyPackageList", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{"main.xgo": []byte("import \"f\n")})
+		s.listPkgs = func() ([]string, error) { return nil, nil }
+		assert.Empty(t, completionItemsAt(t, s, "main.xgo", Position{Character: 9}))
+	})
+
+	t.Run("PackageListError", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{"main.xgo": []byte("import \"f\n")})
+		s.listPkgs = func() ([]string, error) { return nil, fs.ErrPermission }
+		_, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+				Position:     Position{Character: 9},
+			},
+		})
+		assert.ErrorIs(t, err, fs.ErrPermission)
+		assert.ErrorContains(t, err, "failed to list packages")
+	})
+}

--- a/internal/server/completion_kwarg_test.go
+++ b/internal/server/completion_kwarg_test.go
@@ -1,0 +1,564 @@
+package server
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerTextDocumentCompletionKwargs(t *testing.T) {
+	t.Run("CrossFileSourceKinds", func(t *testing.T) {
+		for _, tt := range []struct {
+			name         string
+			filename     string
+			needsProject bool
+		}{
+			{name: "XGo", filename: "main.xgo"},
+			{name: "LegacyXGo", filename: "main.gop"},
+			{name: "StandaloneClass", filename: "Record.gox"},
+			{name: "ProjectClass", filename: "main_fixture.gox"},
+			{name: "WorkClass", filename: "Worker_fixture.gox", needsProject: true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				files := map[string][]byte{
+					"options.xgo": []byte(`type Options struct {
+	Count int
+	// Name identifies the configured task.
+	Name string
+}
+`),
+					tt.filename: []byte(`func configure(opts Options?) {}
+func run() {
+	configure count = 1, na = "task"
+}
+`),
+				}
+				if tt.needsProject {
+					files["main_fixture.gox"] = nil
+				}
+				s := newTestServer(t, files)
+				items := completionItemsAt(t, s, tt.filename, Position{Line: 2, Character: 23})
+				assert.NotContains(t, completionItemLabels(items), "count")
+				item := completionItemByLabel(items, "name")
+				require.NotNil(t, item)
+				assert.Equal(t, 1, countCompletionItemLabel(items, "name"))
+				assert.Equal(t, FieldCompletion, item.Kind)
+				assert.Equal(t, "name = ${1:}", item.InsertText)
+				assert.Equal(t, ToPtr(SnippetTextFormat), item.InsertTextFormat)
+				data := requireValueAs[*CompletionItemData](t, item.Data)
+				assert.Equal(t, "xgo:main?Options.Name", data.Definition.String())
+				require.NotNil(t, item.Documentation)
+				doc := requireValueAs[MarkupContent](t, item.Documentation.Value)
+				assert.Contains(t, doc.Value, "Name identifies the configured task.")
+			})
+		}
+	})
+
+	t.Run("ClassfileCallbacks", func(t *testing.T) {
+		for _, class := range []struct {
+			name     string
+			filename string
+			callback string
+		}{
+			{name: "Project", filename: "main_fixture.gox", callback: `onEvent "tick", value => {`},
+			{name: "Work", filename: "Worker_fixture.gox", callback: "onValue value => {"},
+		} {
+			t.Run(class.name, func(t *testing.T) {
+				t.Run("FrameworkKwargName", func(t *testing.T) {
+					for _, tt := range []struct {
+						name string
+						call string
+					}{
+						{name: "BareIdent", call: "\tconfigure va"},
+						{name: "KwargExpr", call: "\tconfigure va = value"},
+					} {
+						t.Run(tt.name, func(t *testing.T) {
+							files := map[string][]byte{"main_fixture.gox": nil}
+							files[class.filename] = []byte("func configure(opts Item?) {}\n" + class.callback + "\n" + tt.call + "\n}\n")
+							s := newTestServer(t, files)
+							items := completionItemsAt(t, s, class.filename, Position{Line: 2, Character: 13})
+							item := completionItemByLabel(items, "value")
+							require.NotNil(t, item)
+							assert.Equal(t, FieldCompletion, item.Kind)
+							assert.Equal(t, "value = ${1:}", item.InsertText)
+							assert.Equal(t, ToPtr(SnippetTextFormat), item.InsertTextFormat)
+							data := requireValueAs[*CompletionItemData](t, item.Data)
+							assert.Equal(t, "xgo:"+testframework.PkgPath+"?Item.Value", data.Definition.String())
+							require.NotNil(t, item.Documentation)
+							doc := requireValueAs[MarkupContent](t, item.Documentation.Value)
+							assert.Contains(t, doc.Value, "Value stores the work item's value.")
+						})
+					}
+				})
+
+				t.Run("InferredKwargValue", func(t *testing.T) {
+					for _, tt := range []struct {
+						name   string
+						prefix string
+						eol    string
+					}{
+						{name: "ASCII", prefix: "\t", eol: "\n"},
+						{name: "UTF16Position", prefix: "\t/* \U0001f600\U0001f600 */ ", eol: "\r\n"},
+					} {
+						t.Run(tt.name, func(t *testing.T) {
+							files := map[string][]byte{"main_fixture.gox": nil}
+							files[class.filename] = []byte(strings.Join([]string{
+								"func configure(opts Item?) {}",
+								class.callback,
+								"\tvar title string",
+								tt.prefix + "configure value = value",
+								"\techo title",
+								"}",
+								"",
+							}, tt.eol))
+							s := newTestServer(t, files)
+							_, err := s.workspaceRootFS.TypeInfo()
+							require.NoError(t, err)
+
+							items := completionItemsAt(t, s, class.filename, Position{
+								Line:      3,
+								Character: uint32(UTF16Len(tt.prefix + "configure value = v")),
+							})
+							labels := completionItemLabels(items)
+							assert.Contains(t, labels, "value")
+							assert.NotContains(t, labels, "title")
+						})
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("ClassfileInterfaceKwargs", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			factory  string
+			receiver string
+			want     bool
+		}{
+			{name: "WithFactory", factory: "func Params() Params { return nil }\n", receiver: "client.", want: true},
+			{name: "WithoutFactory", receiver: "client."},
+			{name: "ImplicitReceiver", factory: "func Params() Params { return nil }\n"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{
+					"options.xgo": []byte(`type Params interface {
+	Count(n int) Params
+	Name(v string) Params
+}
+`),
+					"main_fixture.gox": nil,
+					"Worker_fixture.gox": []byte(tt.factory + `func configure(opts Params?) {}
+onValue value => {
+	var client Worker
+	` + tt.receiver + `configure name = "task", cou = 1
+	echo client, value
+}
+`),
+				})
+				items := completionItemsAt(t, s, "Worker_fixture.gox", Position{
+					Line:      uint32(strings.Count(tt.factory, "\n")) + 3,
+					Character: uint32(UTF16Len("\t" + tt.receiver + `configure name = "task", co`)),
+				})
+				if !tt.want {
+					labels := completionItemLabels(items)
+					assert.NotContains(t, labels, "count")
+					assert.NotContains(t, labels, "name")
+					return
+				}
+				item := completionItemByLabel(items, "count")
+				require.NotNil(t, item)
+				assert.NotContains(t, completionItemLabels(items), "name")
+				assert.Equal(t, FunctionCompletion, item.Kind)
+				assert.Equal(t, "count = ${1:}", item.InsertText)
+				assert.Equal(t, ToPtr(SnippetTextFormat), item.InsertTextFormat)
+				data := requireValueAs[*CompletionItemData](t, item.Data)
+				assert.Equal(t, "xgo:main?Params.Count", data.Definition.String())
+				require.NotNil(t, item.Documentation)
+				doc := requireValueAs[MarkupContent](t, item.Documentation.Value)
+				assert.Contains(t, doc.Value, "func Count(n int) main.Params")
+			})
+		}
+	})
+
+	t.Run("KwargNameCompletion", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Options struct {
+	Count int
+	Name string
+}
+
+func configure(opts Options?) {}
+
+func run() {
+	configure cou = 1
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 9, Character: 13})
+		assert.True(t, slices.ContainsFunc(items, func(item CompletionItem) bool {
+			return item.Label == "count" &&
+				item.InsertText == "count = ${1:}" &&
+				item.InsertTextFormat != nil &&
+				*item.InsertTextFormat == SnippetTextFormat
+		}))
+		assert.Contains(t, completionItemLabels(items), "name")
+	})
+
+	t.Run("NonOptionalKwargNameCompletion", func(t *testing.T) {
+		for _, tt := range []struct {
+			name string
+			code string
+		}{
+			{
+				name: "BareIdent",
+				code: `
+type Options struct {
+	Count int
+	Name string
+}
+
+func configure(opts Options) {}
+
+func run() {
+	configure cou
+}
+`,
+			},
+			{
+				name: "KwargExpr",
+				code: `
+type Options struct {
+	Count int
+	Name string
+}
+
+func configure(opts Options) {}
+
+func run() {
+	configure cou = 1
+}
+`,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{
+					"main.xgo": []byte(tt.code),
+				})
+
+				items := completionItemsAt(t, s, "main.xgo", Position{Line: 9, Character: 13})
+				labels := completionItemLabels(items)
+				assert.Contains(t, labels, "count")
+				assert.Contains(t, labels, "name")
+			})
+		}
+	})
+
+	t.Run("KwargNameCompletionSkipsLaterLocalFieldName", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Options struct {
+	Count int
+	count string
+}
+
+func configure(opts Options?) {}
+
+func run() {
+	configure cou = 1
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 9, Character: 13})
+		assert.Equal(t, 1, countCompletionItemLabel(items, "count"))
+	})
+
+	t.Run("KwargValueCompletion", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Options struct {
+	Count int
+}
+
+func configure(opts Options?) {}
+
+func run() {
+	var count int
+	configure count = cou
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 9, Character: 23})
+		assert.Contains(t, completionItemLabels(items), "count")
+	})
+
+	t.Run("OverloadKwargNameCompletion", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Worker struct{}
+
+type CountOptions struct {
+	Count int
+}
+
+type NameOptions struct {
+	Name string
+}
+
+var worker Worker
+
+func (w *Worker) handleCount(opts CountOptions?) {}
+func (w *Worker) handleName(opts NameOptions?) {}
+
+func (Worker).handle = (
+	(Worker).handleCount
+	(Worker).handleName
+)
+
+func run() {
+	worker.handle cou = 1
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 22, Character: 18})
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "count")
+		assert.Contains(t, labels, "name")
+	})
+
+	t.Run("OverloadKwargNameCompletionFiltersByPositionalArg", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Worker struct{}
+
+type CountOptions struct {
+	Count int
+}
+
+type NameOptions struct {
+	Name string
+}
+
+var worker Worker
+
+func (w *Worker) handleCount(prefix int, opts CountOptions?) {}
+func (w *Worker) handleName(prefix string, opts NameOptions?) {}
+
+func (Worker).handle = (
+	(Worker).handleCount
+	(Worker).handleName
+)
+
+func run() {
+	worker.handle "prefix", na = "x"
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 22, Character: 27})
+		labels := completionItemLabels(items)
+		assert.NotContains(t, labels, "count")
+		assert.Contains(t, labels, "name")
+	})
+
+	t.Run("OverloadKwargPositionalValueCompletionWithVariadicKwargParam", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Worker struct{}
+
+type Options struct {
+	Name string
+}
+
+var worker Worker
+
+func (w *Worker) handleNumbers(opts Options?, values ...int) {}
+func (w *Worker) handleString(prefix string, opts Options?) {}
+
+func (Worker).handle = (
+	(Worker).handleNumbers
+	(Worker).handleString
+)
+
+func run() {
+	var count int
+	var title string
+	worker.handle co, name = "x"
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 20, Character: 17})
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "count")
+		assert.Contains(t, labels, "title")
+	})
+
+	t.Run("OverloadKwargValueCompletion", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Worker struct{}
+
+type CountOptions struct {
+	Count int
+}
+
+type NameOptions struct {
+	Name string
+}
+
+var worker Worker
+
+func (w *Worker) handleCount(opts CountOptions?) {}
+func (w *Worker) handleName(opts NameOptions?) {}
+
+func (Worker).handle = (
+	(Worker).handleCount
+	(Worker).handleName
+)
+
+func run() {
+	var count int
+	var title string
+	worker.handle count = cou
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 24, Character: 27})
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "count")
+		assert.NotContains(t, labels, "title")
+	})
+
+	t.Run("EmptyKwargValueCompletion", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Options struct {
+	Count int
+}
+
+func configure(opts Options?) {}
+
+func run() {
+	var count int
+	var title string
+	configure count =
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 10, Character: 18})
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "count")
+		assert.NotContains(t, labels, "title")
+	})
+
+	t.Run("PositionalValueCompletionWithKwargs", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+func configure(opts map[string]string, values ...int) {}
+
+func run() {
+	var count int
+	var title string
+	configure cou, name = "x"
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 6, Character: 14})
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "count")
+		assert.NotContains(t, labels, "title")
+	})
+
+	t.Run("InterfaceKwargNameCompletion", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Client struct{}
+
+type Params interface {
+	MaxTokens(n int64) Params
+	Temperature(v float64) Params
+}
+
+var client Client
+
+func (c Client) Params() Params { return nil }
+
+func (c Client) complete(prompt string, params Params?) {}
+
+func run() {
+	client.complete "hi", maxT = 1
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 15, Character: 27})
+		assert.True(t, slices.ContainsFunc(items, func(item CompletionItem) bool {
+			return item.Label == "maxTokens" &&
+				item.InsertText == "maxTokens = ${1:}" &&
+				item.InsertTextFormat != nil &&
+				*item.InsertTextFormat == SnippetTextFormat
+		}))
+		assert.Contains(t, completionItemLabels(items), "temperature")
+	})
+
+	t.Run("InterfaceKwargNameCompletionWithoutFactory", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Client struct{}
+
+type Params interface {
+	MaxTokens(n int64) Params
+	Temperature(v float64) Params
+}
+
+var client Client
+
+func (c Client) complete(prompt string, params Params?) {}
+
+func run() {
+	client.complete "hi", maxT = 1
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 13, Character: 27})
+		labels := completionItemLabels(items)
+		assert.NotContains(t, labels, "maxTokens")
+		assert.NotContains(t, labels, "temperature")
+	})
+
+	t.Run("FreeFunctionInterfaceKwargNameCompletion", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+type Params interface {
+	MaxTokens(n int64) Params
+	Temperature(v float64) Params
+}
+
+func complete(prompt string, params Params?) {}
+
+func run() {
+	complete "hi", maxT = 1
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 9, Character: 20})
+		labels := completionItemLabels(items)
+		assert.NotContains(t, labels, "maxTokens")
+		assert.NotContains(t, labels, "temperature")
+	})
+}

--- a/internal/server/completion_symbol_test.go
+++ b/internal/server/completion_symbol_test.go
@@ -4,6 +4,7 @@ import (
 	gotypes "go/types"
 	"io/fs"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/goplus/mod/modfile"
@@ -118,6 +119,176 @@ func TestServerTextDocumentCompletionSymbols(t *testing.T) {
 		items := completionItemsAt(t, s, "Worker_fixture.gox", Position{Line: 2, Character: 1})
 		for _, label := range []string{"Count", "Value", "apply", "value"} {
 			assert.Contains(t, completionItemLabels(items), label)
+		}
+	})
+
+	t.Run("FrameworkMethodOverloads", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			filename string
+			source   string
+			position Position
+		}{
+			{name: "ImplicitReceiver", filename: "main_fixture.gox", source: "onStart => {\n\n}\n", position: Position{Line: 1}},
+			{name: "ExplicitReceiver", filename: "main.xgo", source: "import \"example.com/framework\"\nvar app framework.App\napp.measure(1)\n", position: Position{Line: 2, Character: 5}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
+				_, err := s.workspaceRootFS.TypeInfo()
+				require.NoError(t, err)
+				items := completionItemsAt(t, s, tt.filename, tt.position)
+				assert.Equal(t, 2, countCompletionItemLabel(items, "measure"))
+				assert.NotContains(t, completionItemLabels(items), "Measure__0")
+				assert.NotContains(t, completionItemLabels(items), "Measure__1")
+				overloads := make(map[string]CompletionItem)
+				for _, item := range items {
+					if item.Label != "measure" {
+						continue
+					}
+					data := requireValueAs[*CompletionItemData](t, item.Data)
+					require.NotNil(t, data.Definition)
+					assert.Equal(t, ToPtr(testframework.PkgPath), data.Definition.Package)
+					assert.Equal(t, ToPtr("App.measure"), data.Definition.Name)
+					require.NotNil(t, data.Definition.OverloadID)
+					overloads[*data.Definition.OverloadID] = item
+				}
+				require.Len(t, overloads, 2)
+				for _, overload := range []struct {
+					id       string
+					typeName string
+					doc      string
+				}{
+					{id: "0", typeName: "int", doc: "Measure__0 is the integer overload of Measure."},
+					{id: "1", typeName: "string", doc: "Measure__1 is the string overload of Measure."},
+				} {
+					item, ok := overloads[overload.id]
+					require.True(t, ok, overload.id)
+					assert.Equal(t, FunctionCompletion, item.Kind)
+					assert.Equal(t, "measure", item.InsertText)
+					assert.Equal(t, ToPtr(PlainTextTextFormat), item.InsertTextFormat)
+					require.NotNil(t, item.Documentation)
+					doc := requireValueAs[MarkupContent](t, item.Documentation.Value)
+					assert.Contains(t, doc.Value, `overview="func measure(value `+overload.typeName+`) int"`)
+					assert.Contains(t, doc.Value, overload.doc)
+				}
+			})
+		}
+	})
+
+	t.Run("ClassfileImplicitPackages", func(t *testing.T) {
+		for _, sourceKind := range []struct {
+			name     string
+			filename string
+			isClass  bool
+		}{
+			{name: "Project", filename: "main_fixture.gox", isClass: true},
+			{name: "Work", filename: "Worker_fixture.gox", isClass: true},
+			{name: "XGo", filename: "main.xgo"},
+		} {
+			t.Run(sourceKind.name, func(t *testing.T) {
+				for _, tt := range []struct {
+					name     string
+					withMath bool
+				}{
+					{name: "FrameworkOnly"},
+					{name: "WithAdditionalPackage", withMath: true},
+				} {
+					t.Run(tt.name, func(t *testing.T) {
+						files := map[string][]byte{"main_fixture.gox": nil}
+						files[sourceKind.filename] = []byte("func run() {\n\n}\n")
+						s := newTestServer(t, files)
+						if tt.withMath {
+							class, ok := s.workspaceRootFS.Mod.LookupClass("_fixture.gox")
+							require.True(t, ok)
+							class.PkgPaths = append(class.PkgPaths, "math")
+						}
+						lookup := s.lookupPkgDoc
+						s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+							if pkgPath == "math" {
+								return &pkgdoc.PkgDoc{Funcs: map[string]string{"Abs": "Additional package documentation."}}, nil
+							}
+							return lookup(pkgPath)
+						}
+						_, err := s.workspaceRootFS.TypeInfo()
+						require.NoError(t, err)
+						items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 1})
+						assert.Equal(t, sourceKind.isClass, slices.Contains(completionItemLabels(items), "runWhen"))
+						item := completionItemByLabel(items, "abs")
+						if !sourceKind.isClass || !tt.withMath {
+							assert.Nil(t, item)
+							return
+						}
+						require.NotNil(t, item)
+						assert.Equal(t, FunctionCompletion, item.Kind)
+						data := requireValueAs[*CompletionItemData](t, item.Data)
+						require.NotNil(t, data.Definition)
+						assert.Equal(t, "xgo:math?abs", data.Definition.String())
+						require.NotNil(t, item.Documentation)
+						doc := requireValueAs[MarkupContent](t, item.Documentation.Value)
+						assert.Contains(t, doc.Value, "Additional package documentation.")
+					})
+				}
+			})
+		}
+	})
+
+	t.Run("EmbeddedInterfaceMethods", func(t *testing.T) {
+		for _, tt := range []struct {
+			name         string
+			declarations string
+			embedded     string
+		}{
+			{name: "Direct", embedded: "fmt.Stringer"},
+			{name: "Alias", declarations: "type External = fmt.Stringer\n", embedded: "External"},
+			{name: "Nested", declarations: "type External interface { fmt.Stringer }\n", embedded: "External"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				source := "import \"fmt\"\n" + tt.declarations + `type Combined interface {
+	` + tt.embedded + `
+	methodOne()
+}
+
+func run() {
+	var value Combined
+	value.methodOne()
+}
+`
+				s := newTestServer(t, map[string][]byte{"main.xgo": []byte(source)})
+				lookup := s.lookupPkgDoc
+				s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+					if pkgPath == "fmt" {
+						return &pkgdoc.PkgDoc{Types: map[string]*pkgdoc.TypeDoc{
+							"Stringer": {Methods: map[string]string{"String": "Imported method documentation."}},
+						}}, nil
+					}
+					return lookup(pkgPath)
+				}
+				_, err := s.workspaceRootFS.TypeInfo()
+				require.NoError(t, err)
+				items := completionItemsAt(t, s, "main.xgo", Position{
+					Line:      uint32(strings.Count(source[:strings.Index(source, "\tvalue.methodOne()")], "\n")),
+					Character: uint32(UTF16Len("\tvalue.m")),
+				})
+				assert.ElementsMatch(t, []string{"string", "methodOne"}, completionItemLabels(items))
+				for _, method := range []struct {
+					label      string
+					definition string
+					doc        string
+				}{
+					{label: "string", definition: "xgo:fmt?Stringer.string", doc: "Imported method documentation."},
+					{label: "methodOne", definition: "xgo:main?Combined.methodOne", doc: `overview="func methodOne()"`},
+				} {
+					item := completionItemByLabel(items, method.label)
+					require.NotNil(t, item)
+					assert.Equal(t, FunctionCompletion, item.Kind)
+					data := requireValueAs[*CompletionItemData](t, item.Data)
+					require.NotNil(t, data.Definition)
+					assert.Equal(t, method.definition, data.Definition.String())
+					require.NotNil(t, item.Documentation)
+					doc := requireValueAs[MarkupContent](t, item.Documentation.Value)
+					assert.Contains(t, doc.Value, method.doc)
+				}
+			})
 		}
 	})
 

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -15,165 +15,42 @@ import (
 )
 
 func TestServerTextDocumentCompletion(t *testing.T) {
-	t.Run("Normal", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-
-MySprite.
-`),
-			"MySprite.spx": []byte(`
-onStart => {
-	MySprite.turn Right
+	t.Run("MemberAccessAtLineStart", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			filename string
+			position Position
+		}{
+			{name: "ProjectEOF", filename: "main_fixture.gox", position: Position{Line: 1, Character: 9}},
+			{name: "WorkCallback", filename: "Worker_fixture.gox", position: Position{Line: 1, Character: 10}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newTestServer(t, map[string][]byte{
+					"main_fixture.gox": []byte("var worker *Worker\nworker.ap"), // Cursor at EOF.
+					"Worker_fixture.gox": []byte(`onValue value => {
+	worker.ap
 }
 `),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
+				})
+				items := completionItemsAt(t, s, tt.filename, tt.position)
+				assert.Contains(t, completionItemLabels(items), "apply")
+			})
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		emptyLineItemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 0},
-			},
-		})
-		require.NoError(t, err)
-		emptyLineItems := emptyLineItemsResult.([]CompletionItem)
-		require.NotNil(t, emptyLineItems)
-		assert.NotEmpty(t, emptyLineItems)
-		assert.True(t, containsCompletionItemLabel(emptyLineItems, "println"))
-		assert.True(t, containsCompletionSpxDefinitionID(emptyLineItems, SpxDefinitionIdentifier{
-			Package: ToPtr("main"),
-			Name:    ToPtr("MySprite"),
-		}))
-
-		assert.Contains(t, emptyLineItems, SpxDefinition{
-			ID: SpxDefinitionIdentifier{
-				Package: ToPtr(SpxPkgPath),
-				Name:    ToPtr("Game.getWidget"),
-			},
-			Overview: "func getWidget(T Type, name WidgetName) *T",
-			Detail:   "GetWidget returns the widget instance (in given type) with given name. It panics if not found.\n",
-
-			CompletionItemLabel:            "getWidget",
-			CompletionItemKind:             FunctionCompletion,
-			CompletionItemInsertText:       "getWidget",
-			CompletionItemInsertTextFormat: PlainTextTextFormat,
-		}.CompletionItem())
-
-		mySpriteDotItemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 9},
-			},
-		})
-		require.NoError(t, err)
-		mySpriteDotItems := mySpriteDotItemsResult.([]CompletionItem)
-		require.NotNil(t, mySpriteDotItems)
-		assert.NotEmpty(t, mySpriteDotItems)
-		assert.False(t, containsCompletionItemLabel(mySpriteDotItems, "println"))
-		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
-			Package:    ToPtr(SpxPkgPath),
-			Name:       ToPtr("Sprite.turn"),
-			OverloadID: ToPtr("0"),
-		}))
-		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
-			Package:    ToPtr(SpxPkgPath),
-			Name:       ToPtr("Sprite.turn"),
-			OverloadID: ToPtr("0"),
-		}))
-		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
-			Package:    ToPtr(SpxPkgPath),
-			Name:       ToPtr("Sprite.turn"),
-			OverloadID: ToPtr("1"),
-		}))
-		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
-			Package:    ToPtr(SpxPkgPath),
-			Name:       ToPtr("Sprite.clone"),
-			OverloadID: ToPtr("0"),
-		}))
-		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
-			Package:    ToPtr(SpxPkgPath),
-			Name:       ToPtr("Sprite.clone"),
-			OverloadID: ToPtr("1"),
-		}))
 	})
 
-	t.Run("InSpxEventHandler", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 1},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.False(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
-			Package: ToPtr(SpxPkgPath),
-			Name:    ToPtr("Sprite.onStart"),
-		}))
-		assert.False(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
-			Package: ToPtr(SpxPkgPath),
-			Name:    ToPtr("Sprite.onClick"),
-		}))
-	})
-
-	t.Run("Autoclosure", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`const (
-	enabled = true
-	entry = "text"
-)
-
-onStart => {
-
-	repeatUntil e, => {}
-}
-`),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		signatureItemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 6, Character: 1},
-			},
-		})
-		require.NoError(t, err)
-		signatureItems := requireValueAs[[]CompletionItem](t, signatureItemsResult)
-		repeatUntilItem := completionItemByLabel(signatureItems, "repeatUntil")
-		require.NotNilf(t, repeatUntilItem, "%v", completionItemLabels(signatureItems))
-		require.NotNil(t, repeatUntilItem.Documentation)
-		documentation := requireValueAs[MarkupContent](t, repeatUntilItem.Documentation.Value)
-		assert.Contains(t, documentation.Value, `overview="func repeatUntil(condition bool, call func())"`)
-
-		argumentItemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 7, Character: 14},
-			},
-		})
-		require.NoError(t, err)
-		argumentItems := requireValueAs[[]CompletionItem](t, argumentItemsResult)
-		assert.Truef(t, containsCompletionItemLabel(argumentItems, "enabled"), "%v", completionItemLabels(argumentItems))
-		assert.Falsef(t, containsCompletionItemLabel(argumentItems, "entry"), "%v", completionItemLabels(argumentItems))
-	})
-
-	t.Run("FuncDecoratorArgument", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`const (
+	for _, sourceKind := range []struct {
+		name         string
+		filename     string
+		needsProject bool
+	}{
+		{name: "XGo", filename: "main.xgo"},
+		{name: "ProjectClass", filename: "main_fixture.gox"},
+		{name: "WorkClass", filename: "Worker_fixture.gox", needsProject: true},
+	} {
+		t.Run(sourceKind.name, func(t *testing.T) {
+			t.Run("FuncDecoratorArgument", func(t *testing.T) {
+				files := map[string][]byte{
+					sourceKind.filename: []byte(`const (
 	count   = 1
 	comment = "text"
 )
@@ -186,24 +63,21 @@ func retry(times int, fn func()) {
 func run() {
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+				}
+				if sourceKind.needsProject {
+					files["main_fixture.gox"] = nil
+				}
+				s := newTestServer(t, files)
 
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 9, Character: 9},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-		assert.False(t, containsCompletionItemLabel(items, "comment"))
-	})
+				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 9, Character: 9})
+				labels := completionItemLabels(items)
+				assert.Contains(t, labels, "count")
+				assert.NotContains(t, labels, "comment")
+			})
 
-	t.Run("FuncDecoratorImplicitArgument", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`const (
+			t.Run("FuncDecoratorImplicitArgument", func(t *testing.T) {
+				files := map[string][]byte{
+					sourceKind.filename: []byte(`const (
 	count   = 1
 	comment = "text"
 )
@@ -216,24 +90,21 @@ func retry(times int, fn func()) {
 func run() {
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+				}
+				if sourceKind.needsProject {
+					files["main_fixture.gox"] = nil
+				}
+				s := newTestServer(t, files)
 
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 9, Character: 12},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-		assert.True(t, containsCompletionItemLabel(items, "comment"))
-	})
+				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 9, Character: 12})
+				labels := completionItemLabels(items)
+				assert.Contains(t, labels, "count")
+				assert.Contains(t, labels, "comment")
+			})
 
-	t.Run("NestedFuncDecoratorArgument", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`const (
+			t.Run("NestedFuncDecoratorArgument", func(t *testing.T) {
+				files := map[string][]byte{
+					sourceKind.filename: []byte(`const (
 	count   = 1
 	comment = "text"
 )
@@ -250,24 +121,21 @@ func parse(text string) int {
 func run() {
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+				}
+				if sourceKind.needsProject {
+					files["main_fixture.gox"] = nil
+				}
+				s := newTestServer(t, files)
 
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 13, Character: 15},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		assert.Falsef(t, containsCompletionItemLabel(items, "count"), "%v", completionItemLabels(items))
-		assert.True(t, containsCompletionItemLabel(items, "comment"))
-	})
+				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 13, Character: 15})
+				labels := completionItemLabels(items)
+				assert.NotContains(t, labels, "count")
+				assert.Contains(t, labels, "comment")
+			})
 
-	t.Run("NestedCallArgument", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`const (
+			t.Run("NestedCallArgument", func(t *testing.T) {
+				files := map[string][]byte{
+					sourceKind.filename: []byte(`const (
 	count   = 1
 	comment = "text"
 )
@@ -283,1899 +151,202 @@ func run() {
 	consume(parse(co))
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+				}
+				if sourceKind.needsProject {
+					files["main_fixture.gox"] = nil
+				}
+				s := newTestServer(t, files)
 
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 13, Character: 17},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		assert.Falsef(t, containsCompletionItemLabel(items, "count"), "%v", completionItemLabels(items))
-		assert.True(t, containsCompletionItemLabel(items, "comment"))
-	})
+				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 13, Character: 17})
+				labels := completionItemLabels(items)
+				assert.NotContains(t, labels, "count")
+				assert.Contains(t, labels, "comment")
+			})
 
-	t.Run("PartialXGoxFunction", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`import "example.com/typeargs"
+			t.Run("PartialXGoxFunction", func(t *testing.T) {
+				files := map[string][]byte{
+					sourceKind.filename: []byte(`import "example.com/typeargs"
 
 const (
 	count   = 1
 	comment = "text"
 )
 
-onStart => {
+func run() {
 	typeargs.convert(string, count)
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-		s.workspaceRootFS.Importer = xgoxTestImporter{fallback: s.workspaceRootFS.Importer}
+				}
+				if sourceKind.needsProject {
+					files["main_fixture.gox"] = nil
+				}
+				s := newTestServer(t, files)
+				s.workspaceRootFS.Importer = xgoxTestImporter{fallback: s.workspaceRootFS.Importer}
 
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 8, Character: 31},
-			},
+				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 8, Character: 31})
+				labels := completionItemLabels(items)
+				assert.Contains(t, labels, "count")
+				assert.NotContains(t, labels, "comment")
+			})
 		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-		assert.False(t, containsCompletionItemLabel(items, "comment"))
-	})
-
-	t.Run("InImportStringLit", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-import "f
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 9},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "fmt"))
-	})
+	}
 
 	t.Run("IncompleteMapLiteralInCall", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
 println {"key": }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 15},
-			},
 		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
+
+		completionItemsAt(t, s, "main.xgo", Position{Line: 1, Character: 15})
 	})
 
-	t.Run("InImportGroupStringLit", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-import (
-	"f
+	t.Run("NoCompletionAfterNumberLiteral", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+func run() {
+	var x = 123.
+}
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 3},
-			},
 		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "fmt"))
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 2, Character: 13}) // After "123."
+		assert.Empty(t, items)
+	})
+
+	t.Run("NoCompletionAfterNumberLiteralInShortVarDecl", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`
+func run() {
+	x := 123.
+}
+`),
+		})
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 2, Character: 10}) // After "123."
+		assert.Empty(t, items)
+	})
+
+	t.Run("Autoclosure", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`const (
+	enabled = true
+	entry = "text"
+)
+
+onStart => {
+
+	runWhen e, => {}
+}
+`),
+		})
+
+		signatureItems := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 6, Character: 1})
+		runWhenItem := completionItemByLabel(signatureItems, "runWhen")
+		require.NotNilf(t, runWhenItem, "%v", completionItemLabels(signatureItems))
+		require.NotNil(t, runWhenItem.Documentation)
+		documentation := requireValueAs[MarkupContent](t, runWhenItem.Documentation.Value)
+		assert.Contains(t, documentation.Value, `overview="func runWhen(condition bool, callback func())"`)
+
+		argumentItems := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 7, Character: 10})
+		argumentLabels := completionItemLabels(argumentItems)
+		assert.Contains(t, argumentLabels, "enabled")
+		assert.NotContains(t, argumentLabels, "entry")
 	})
 
 	t.Run("GeneralOrUnknown", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`
 
 onStart => {
 
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		items1Result, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 1},
-			},
 		})
-		require.NoError(t, err)
-		items1 := items1Result.([]CompletionItem)
-		require.NotNil(t, items1)
+
+		items1 := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 1, Character: 1})
 		assert.NotEmpty(t, items1)
-		assert.True(t, containsCompletionItemLabel(items1, "len"))
+		assert.Contains(t, completionItemLabels(items1), "len")
 
-		items2Result, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 12},
-			},
-		})
-		require.NoError(t, err)
-		items2 := items2Result.([]CompletionItem)
-		require.NotNil(t, items2)
+		items2 := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 2, Character: 12})
 		assert.Empty(t, items2)
 
-		items3Result, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 3, Character: 1},
-			},
-		})
-		require.NoError(t, err)
-		items3 := items3Result.([]CompletionItem)
-		require.NotNil(t, items3)
+		items3 := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 3, Character: 1})
 		assert.NotEmpty(t, items3)
-		assert.True(t, containsCompletionItemLabel(items3, "len"))
+		assert.Contains(t, completionItemLabels(items3), "len")
 	})
 
 	t.Run("VarDecl", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`
 func test() {}
 onStart => {
 	var x i
 }
 `),
-			"MySprite.spx": []byte(`
+			"Worker_fixture.gox": []byte(`
 `),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 3, Character: 8},
-			},
 		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
+
+		items := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 3, Character: 8})
 		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "int"))
-		assert.True(t, containsCompletionItemLabel(items, "MySprite"))
-		assert.True(t, containsCompletionItemLabel(items, "Sprite"))
-		assert.False(t, containsCompletionItemLabel(items, "len"))
-		assert.False(t, containsCompletionItemLabel(items, "test"))
-		assert.False(t, containsCompletionItemLabel(items, "play"))
-	})
-
-	t.Run("VarDeclAndAssign", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	var x SpriteName = "m"
-}
-`),
-			"MySprite.spx": []byte(`
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 22},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "MySprite"))
-	})
-
-	t.Run("VarDeclAndAssignWithAlias", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type MySpriteName = SpriteName
-
-onStart => {
-	var x MySpriteName = "m"
-}
-`),
-			"MySprite.spx":                       []byte(``),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 4, Character: 24},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "MySprite"))
-	})
-
-	t.Run("SpxSoundResourceStringLit", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-play "r"
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sounds/recording/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 7},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "recording"))
-	})
-
-	t.Run("FuncOverloads", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-play r
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sounds/recording/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 6},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, `"recording"`))
-	})
-
-	t.Run("WithImplicitSpxSpriteResource", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-`),
-			"MySprite.spx": []byte(`
-onClick => {
-	setCostume "c"
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{"costumes":[{"name":"costume"}]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 2, Character: 14},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "costume"))
-	})
-
-	t.Run("WithExplicitSpxSpriteResource", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-MySprite.setCostume "c"
-`),
-			"MySprite.spx":                       []byte(``),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{"costumes":[{"name":"costume"}]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 22},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "costume"))
-	})
-
-	t.Run("WithCrossSpxSpriteResource", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-`),
-			"Sprite1.spx": []byte(`
-onClick => {
-	Sprite2.setCostume "c"
-}
-`),
-			"Sprite2.spx":                       []byte(``),
-			"assets/index.json":                 []byte(`{}`),
-			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Sprite1Costume"}]}`),
-			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Sprite2Costume"}]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///Sprite1.spx"},
-				Position:     Position{Line: 2, Character: 22},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "Sprite2Costume"))
-	})
-
-	t.Run("WithCrossSpxSpriteResourceInGoStmt", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(``),
-			"Sprite1.spx": []byte(`
-onClick => {
-	go Sprite2.setCostume("c")
-}
-`),
-			"Sprite2.spx":                       []byte(``),
-			"assets/index.json":                 []byte(`{}`),
-			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Sprite1Costume"}]}`),
-			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Sprite2Costume"}]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///Sprite1.spx"},
-				Position:     Position{Line: 2, Character: 25},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "Sprite2Costume"))
-	})
-
-	t.Run("WithCrossSpxSpriteResourceInDeferStmt", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(``),
-			"Sprite1.spx": []byte(`
-onClick => {
-	defer Sprite2.setCostume("c")
-}
-`),
-			"Sprite2.spx":                       []byte(``),
-			"assets/index.json":                 []byte(`{}`),
-			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Sprite1Costume"}]}`),
-			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Sprite2Costume"}]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///Sprite1.spx"},
-				Position:     Position{Line: 2, Character: 28},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "Sprite2Costume"))
-	})
-
-	t.Run("SpriteCostumeNameInImplicitCallUsesCurrentSprite", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(``),
-			"Sprite1.spx": []byte(`
-onStart => {
-	setCostume C
-}
-`),
-			"Sprite2.spx":                       []byte(``),
-			"Sprite3.spx":                       []byte(``),
-			"assets/index.json":                 []byte(`{}`),
-			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Crab2"},{"name":"Crab3"}]}`),
-			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
-			"assets/sprites/Sprite3/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///Sprite1.spx"},
-				Position:     Position{Line: 2, Character: 13},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
-		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
-	})
-
-	t.Run("SpriteCostumeNameInDeclDeduplicatesCrossSpriteNames", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	var costume SpriteCostumeName = C
-}
-`),
-			"Sprite1.spx":                       []byte(``),
-			"Sprite2.spx":                       []byte(``),
-			"Sprite3.spx":                       []byte(``),
-			"assets/index.json":                 []byte(`{}`),
-			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Crab2"},{"name":"Crab3"}]}`),
-			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
-			"assets/sprites/Sprite3/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 34},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
-		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
-	})
-
-	t.Run("StepToOverloadsDeduplicateSpriteNameSuggestions", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(``),
-			"Runner.spx": []byte(`
-onStart => {
-	stepTo C
-}
-`),
-			"Crab2.spx":                        []byte(``),
-			"Crab3.spx":                        []byte(``),
-			"assets/index.json":                []byte(`{}`),
-			"assets/sprites/Runner/index.json": []byte(`{"costumes":[]}`),
-			"assets/sprites/Crab2/index.json":  []byte(`{"costumes":[]}`),
-			"assets/sprites/Crab3/index.json":  []byte(`{"costumes":[]}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///Runner.spx"},
-				Position:     Position{Line: 2, Character: 10},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
-		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "int")
+		assert.Contains(t, labels, "Worker")
+		assert.Contains(t, labels, "Item")
+		assert.NotContains(t, labels, "len")
+		assert.NotContains(t, labels, "test")
+		assert.NotContains(t, labels, "runWhen")
 	})
 
 	t.Run("AtLineStartWithAnIdentifier", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onClick => {
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`
+onStart => {
 	pr
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 3},
-			},
 		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
+
+		items := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 2, Character: 3})
 		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "println"))
-	})
-
-	t.Run("AtLineStartWithAMemberAccessExpression", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-MySprite.setCo`), // Cursor at EOF.
-			"MySprite.spx": []byte(`
-onClick => {
-	MySprite.setCo
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		items1Result, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 14},
-			},
-		})
-		require.NoError(t, err)
-		items1 := items1Result.([]CompletionItem)
-		require.NotNil(t, items1)
-		assert.NotEmpty(t, items1)
-		assert.True(t, containsCompletionItemLabel(items1, "setCostume"))
-
-		items2Result, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 2, Character: 15},
-			},
-		})
-		require.NoError(t, err)
-		items2 := items2Result.([]CompletionItem)
-		require.NotNil(t, items2)
-		assert.NotEmpty(t, items2)
-		assert.True(t, containsCompletionItemLabel(items2, "setCostume"))
+		assert.Contains(t, completionItemLabels(items), "println")
 	})
 
 	t.Run("WithXGoBuiltins", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onClick => {
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`
+onStart => {
 	var n in
 }
 `),
-			"MySprite.spx": []byte(`
-onClick => {
+			"Worker_fixture.gox": []byte(`
+onValue value => {
 	ec
 }
 `),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		items1Result, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 9},
-			},
 		})
-		require.NoError(t, err)
-		items1 := items1Result.([]CompletionItem)
-		require.NotNil(t, items1)
+
+		items1 := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 2, Character: 9})
 		assert.NotEmpty(t, items1)
-		assert.True(t, containsCompletionItemLabel(items1, "int128"))
+		assert.Contains(t, completionItemLabels(items1), "int128")
 
-		items2Result, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 2, Character: 3},
-			},
-		})
-		require.NoError(t, err)
-		items2 := items2Result.([]CompletionItem)
-		require.NotNil(t, items2)
+		items2 := completionItemsAt(t, s, "Worker_fixture.gox", Position{Line: 2, Character: 3})
 		assert.NotEmpty(t, items2)
-		assert.True(t, containsCompletionItemLabel(items2, "echo"))
+		assert.Contains(t, completionItemLabels(items2), "echo")
 	})
 
 	t.Run("UnresolvedFuncCall", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
+		s := newTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte(`
 onStar => {
 }
 `),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 1, Character: 6},
-			},
 		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
+
+		items := completionItemsAt(t, s, "main_fixture.gox", Position{Line: 1, Character: 6})
 		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "onStart"))
-	})
-
-	t.Run("MathPackage", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	n := ab
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 8},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.NotEmpty(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "abs"))
-	})
-
-	t.Run("NoCompletionAfterNumberLiteral", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	var x = 123.
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 13}, // After "123."
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.Empty(t, items)
-	})
-
-	t.Run("NoCompletionAfterNumberLiteralInShortVarDecl", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	x := 123.
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 2, Character: 10}, // After "123."
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.Empty(t, items)
-	})
-
-	t.Run("SpriteInterfaceEmbedding", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type MyInterface interface {
-	Sprite
-	methodOne()
-}
-
-onStart => {
-	var iface MyInterface = MySprite
-	iface.on
-}
-`),
-			"MySprite.spx": []byte(`
-func methodOne() {}
-onStart => {}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 8, Character: 9}, // After "n"
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		assert.True(t, containsCompletionItemLabel(items, "onClick"))
-		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
-			Package: ToPtr("github.com/goplus/spx/v3"),
-			Name:    ToPtr("Sprite.onClick"),
-		}))
-		assert.True(t, containsCompletionItemLabel(items, "methodOne"))
-		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
-			Package: ToPtr("main"),
-			Name:    ToPtr("MyInterface.methodOne"),
-		}))
-	})
-
-	t.Run("PropertyNameCompletionInMainSpx", func(t *testing.T) {
-		// showVar in main.spx → getPropertyTarget returns "Game"
-		// → collectPropertyNames("Game") → property methods from embedded spx.Game appear
-		m := map[string][]byte{
-			"main.spx": []byte(`
-var score int
-onStart => {
-	showVar(x)
-}
-`),
-			"MySprite.spx":                       []byte(`onStart => {}`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 3, Character: 10}, // inside 'x' arg of showVar
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		// score is declared in main.spx and becomes a Game field.
-		assert.True(t, containsCompletionItemLabel(items, `"score"`))
-		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
-			Package: ToPtr("main"),
-			Name:    ToPtr("Game.score"),
-		}))
-		// Property method from embedded spx.Game.
-		assert.True(t, containsCompletionItemLabel(items, `"volume"`))
-	})
-
-	t.Run("PropertyNameCompletionInSpriteSpx", func(t *testing.T) {
-		// showVar in MySprite.spx → getPropertyTarget returns "MySprite" (not "Game").
-		// hp is a field of MySprite, so its appearance confirms the correct target is used.
-		m := map[string][]byte{
-			"main.spx": []byte(`
-`),
-			"MySprite.spx": []byte(`
-var hp int
-
-onStart => {
-	showVar(x)
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				// Line 4: "\tshowVar(x)" — tab(0)+showVar(1-7)+(8)+x(9)
-				Position: Position{Line: 4, Character: 10},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		// hp is a direct field of MySprite — confirms target is "MySprite", not "Game".
-		assert.True(t, containsCompletionItemLabel(items, `"hp"`))
-	})
-
-	t.Run("PropertyNameCompletionExplicitReceiver", func(t *testing.T) {
-		// MySprite.showVar(x) in main.spx → getPropertyTarget returns "MySprite"
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onStart => {
-	MySprite.showVar(x)
-}
-`),
-			"MySprite.spx": []byte(`
-var hp int
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				// Line 3: "\tMySprite.showVar(x)" — tab(0)+MySprite(1-8)+.(9)+showVar(10-16)+(17)+x(18)
-				Position: Position{Line: 2, Character: 19},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, containsCompletionItemLabel(items, `"hp"`))
-		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
-			Package: ToPtr("main"),
-			Name:    ToPtr("MySprite.hp"),
-		}))
-	})
-
-	t.Run("PropertyNameCompletionEmbeddedMethod", func(t *testing.T) {
-		// SpriteImpl is embedded in MySprite; its property methods should appear.
-		m := map[string][]byte{
-			"main.spx": []byte(`
-`),
-			"MySprite.spx": []byte(`
-var hp int
-
-showVar(
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-				Position:     Position{Line: 3, Character: 8},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		// Direct field of MySprite.
-		assert.True(t, containsCompletionItemLabel(items, `"hp"`))
-		// Property method from embedded spx.SpriteImpl (e.g. "xpos" → "Xpos").
-		assert.True(t, containsCompletionItemLabel(items, `"xpos"`))
-		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
-			Package: ToPtr("github.com/goplus/spx/v3"),
-			Name:    ToPtr("Sprite.xpos"),
-		}))
-	})
-
-	t.Run("PropertyNameCompletionInsideStringLit", func(t *testing.T) {
-		// When cursor is inside a string literal, insert text should NOT be quoted.
-		m := map[string][]byte{
-			"main.spx": []byte(`
-var score int
-
-showVar("s
-`),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 3, Character: 10},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		// Inside string literal: label/insertText is unquoted.
-		assert.True(t, containsCompletionItemLabel(items, "score"))
-		assert.False(t, containsCompletionItemLabel(items, `"score"`))
-	})
-
-	t.Run("KwargNameCompletion", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Options struct {
-	Count int
-	Name string
-}
-
-func configure(opts Options?) {}
-
-onStart => {
-	configure cou = 1
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 9, Character: 13},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, slices.ContainsFunc(items, func(item CompletionItem) bool {
-			return item.Label == "count" &&
-				item.InsertText == "count = ${1:}" &&
-				item.InsertTextFormat != nil &&
-				*item.InsertTextFormat == SnippetTextFormat
-		}))
-		assert.True(t, containsCompletionItemLabel(items, "name"))
-	})
-
-	t.Run("NonOptionalKwargNameCompletion", func(t *testing.T) {
-		for _, tt := range []struct {
-			name string
-			code string
-		}{
-			{
-				name: "BareIdent",
-				code: `
-type Options struct {
-	Count int
-	Name string
-}
-
-func configure(opts Options) {}
-
-onStart => {
-	configure cou
-}
-`,
-			},
-			{
-				name: "KwargExpr",
-				code: `
-type Options struct {
-	Count int
-	Name string
-}
-
-func configure(opts Options) {}
-
-onStart => {
-	configure cou = 1
-}
-`,
-			},
-		} {
-			t.Run(tt.name, func(t *testing.T) {
-				m := map[string][]byte{
-					"main.spx": []byte(tt.code),
-				}
-				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-					TextDocumentPositionParams: TextDocumentPositionParams{
-						TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-						Position:     Position{Line: 9, Character: 13},
-					},
-				})
-				require.NoError(t, err)
-				items := itemsResult.([]CompletionItem)
-				require.NotNil(t, items)
-				assert.True(t, containsCompletionItemLabel(items, "count"))
-				assert.True(t, containsCompletionItemLabel(items, "name"))
-			})
-		}
-	})
-
-	t.Run("KwargNameCompletionSkipsLaterLocalFieldName", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Options struct {
-	Count int
-	count string
-}
-
-func configure(opts Options?) {}
-
-onStart => {
-	configure cou = 1
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 9, Character: 13},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.Equal(t, 1, countCompletionItemLabel(items, "count"))
-	})
-
-	t.Run("KwargValueCompletion", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Options struct {
-	Count int
-}
-
-func configure(opts Options?) {}
-
-onStart => {
-	var count int
-	configure count = cou
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 9, Character: 23},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-	})
-
-	t.Run("OverloadKwargNameCompletion", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Worker struct{}
-
-type CountOptions struct {
-	Count int
-}
-
-type NameOptions struct {
-	Name string
-}
-
-var worker Worker
-
-func (w *Worker) handleCount(opts CountOptions?) {}
-func (w *Worker) handleName(opts NameOptions?) {}
-
-func (Worker).handle = (
-	(Worker).handleCount
-	(Worker).handleName
-)
-
-onStart => {
-	worker.handle cou = 1
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 22, Character: 18},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-		assert.True(t, containsCompletionItemLabel(items, "name"))
-	})
-
-	t.Run("SpxStepToWithKwargNameCompletion", func(t *testing.T) {
-		for _, tt := range []struct {
-			name      string
-			code      string
-			character uint32
-		}{
-			{
-				name: "BareIdent",
-				code: `
-onStart => {
-	stepToWith "Red", s
-}
-`,
-				character: 20,
-			},
-			{
-				name: "KwargExpr",
-				code: `
-onStart => {
-	stepToWith "Red", spe = 2
-}
-`,
-				character: 21,
-			},
-		} {
-			t.Run(tt.name, func(t *testing.T) {
-				m := map[string][]byte{
-					"main.spx":                           []byte(``),
-					"MySprite.spx":                       []byte(tt.code),
-					"Red.spx":                            []byte(``),
-					"assets/index.json":                  []byte(`{}`),
-					"assets/sprites/MySprite/index.json": []byte(`{}`),
-					"assets/sprites/Red/index.json":      []byte(`{}`),
-				}
-				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-					TextDocumentPositionParams: TextDocumentPositionParams{
-						TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
-						Position:     Position{Line: 2, Character: tt.character},
-					},
-				})
-				require.NoError(t, err)
-				items := itemsResult.([]CompletionItem)
-				require.NotNil(t, items)
-				assert.True(t, containsKwargCompletionItem(items, "speed", SpxDefinitionIdentifier{
-					Package: ToPtr(SpxPkgPath),
-					Name:    ToPtr("MotionOptions.Speed"),
-				}))
-				assert.True(t, containsKwargCompletionItem(items, "animation", SpxDefinitionIdentifier{
-					Package: ToPtr(SpxPkgPath),
-					Name:    ToPtr("MotionOptions.Animation"),
-				}))
-			})
-		}
-	})
-
-	t.Run("OverloadKwargNameCompletionFiltersByPositionalArg", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Worker struct{}
-
-type CountOptions struct {
-	Count int
-}
-
-type NameOptions struct {
-	Name string
-}
-
-var worker Worker
-
-func (w *Worker) handleCount(prefix int, opts CountOptions?) {}
-func (w *Worker) handleName(prefix string, opts NameOptions?) {}
-
-func (Worker).handle = (
-	(Worker).handleCount
-	(Worker).handleName
-)
-
-onStart => {
-	worker.handle "prefix", na = "x"
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 22, Character: 27},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.False(t, containsCompletionItemLabel(items, "count"))
-		assert.True(t, containsCompletionItemLabel(items, "name"))
-	})
-
-	t.Run("OverloadKwargPositionalValueCompletionWithVariadicKwargParam", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Worker struct{}
-
-type Options struct {
-	Name string
-}
-
-var worker Worker
-
-func (w *Worker) handleNumbers(opts Options?, values ...int) {}
-func (w *Worker) handleString(prefix string, opts Options?) {}
-
-func (Worker).handle = (
-	(Worker).handleNumbers
-	(Worker).handleString
-)
-
-onStart => {
-	var count int
-	var title string
-	worker.handle co, name = "x"
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 20, Character: 17},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-		assert.True(t, containsCompletionItemLabel(items, "title"))
-	})
-
-	t.Run("OverloadKwargValueCompletion", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Worker struct{}
-
-type CountOptions struct {
-	Count int
-}
-
-type NameOptions struct {
-	Name string
-}
-
-var worker Worker
-
-func (w *Worker) handleCount(opts CountOptions?) {}
-func (w *Worker) handleName(opts NameOptions?) {}
-
-func (Worker).handle = (
-	(Worker).handleCount
-	(Worker).handleName
-)
-
-onStart => {
-	var count int
-	var title string
-	worker.handle count = cou
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 24, Character: 27},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-		assert.False(t, containsCompletionItemLabel(items, "title"))
-	})
-
-	t.Run("EmptyKwargValueCompletion", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Options struct {
-	Count int
-}
-
-func configure(opts Options?) {}
-
-onStart => {
-	var count int
-	var title string
-	configure count =
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 10, Character: 18},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-		assert.False(t, containsCompletionItemLabel(items, "title"))
-	})
-
-	t.Run("PositionalValueCompletionWithKwargs", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-func configure(opts map[string]string, values ...int) {}
-
-onStart => {
-	var count int
-	var title string
-	configure cou, name = "x"
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 6, Character: 14},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, containsCompletionItemLabel(items, "count"))
-		assert.False(t, containsCompletionItemLabel(items, "title"))
-	})
-
-	t.Run("InterfaceKwargNameCompletion", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Client struct{}
-
-type Params interface {
-	MaxTokens(n int64) Params
-	Temperature(v float64) Params
-}
-
-var client Client
-
-func (c Client) Params() Params { return nil }
-
-func (c Client) complete(prompt string, params Params?) {}
-
-onStart => {
-	client.complete "hi", maxT = 1
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 15, Character: 27},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		require.NotNil(t, items)
-		assert.True(t, slices.ContainsFunc(items, func(item CompletionItem) bool {
-			return item.Label == "maxTokens" &&
-				item.InsertText == "maxTokens = ${1:}" &&
-				item.InsertTextFormat != nil &&
-				*item.InsertTextFormat == SnippetTextFormat
-		}))
-		assert.True(t, containsCompletionItemLabel(items, "temperature"))
-	})
-
-	t.Run("InterfaceKwargNameCompletionWithoutFactory", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Client struct{}
-
-type Params interface {
-	MaxTokens(n int64) Params
-	Temperature(v float64) Params
-}
-
-var client Client
-
-func (c Client) complete(prompt string, params Params?) {}
-
-onStart => {
-	client.complete "hi", maxT = 1
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 13, Character: 27},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		assert.False(t, containsCompletionItemLabel(items, "maxTokens"))
-		assert.False(t, containsCompletionItemLabel(items, "temperature"))
-	})
-
-	t.Run("FreeFunctionInterfaceKwargNameCompletion", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Params interface {
-	MaxTokens(n int64) Params
-	Temperature(v float64) Params
-}
-
-func complete(prompt string, params Params?) {}
-
-onStart => {
-	complete "hi", maxT = 1
-}
-`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-			TextDocumentPositionParams: TextDocumentPositionParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-				Position:     Position{Line: 9, Character: 20},
-			},
-		})
-		require.NoError(t, err)
-		items := itemsResult.([]CompletionItem)
-		assert.False(t, containsCompletionItemLabel(items, "maxTokens"))
-		assert.False(t, containsCompletionItemLabel(items, "temperature"))
-	})
-
-	t.Run("XGoUnits", func(t *testing.T) {
-		t.Run("CallArguments", func(t *testing.T) {
-			s := newXGoUnitTestServer(xgoUnitCompletionSource)
-			result, _, _, err := s.compileAndGetASTFileForDocumentURI("file:///main.spx")
-			require.NoError(t, err)
-			require.Falsef(t, result.hasErrorSeverityDiagnostic, "%#v", result.diagnostics)
-
-			durationItemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 14, Character: 7},
-				},
-			})
-			require.NoError(t, err)
-			durationItems := durationItemsResult.(CompletionList).Items
-			assert.True(t, containsCompletionItemLabel(durationItems, "ms"))
-			assert.True(t, containsCompletionItemLabel(durationItems, "s"))
-			assert.True(t, containsCompletionItemLabel(durationItems, "m"))
-			assert.True(t, containsCompletionItemLabel(durationItems, "\u00b5s"))
-			assert.False(t, containsCompletionItemLabel(durationItems, "wait"))
-			assertCompletionItemTextEdit(t, durationItems, "s", TextEdit{
-				Range: Range{
-					Start: Position{Line: 14, Character: 7},
-					End:   Position{Line: 14, Character: 7},
-				},
-				NewText: "s",
-			})
-			assert.Equal(t, "1s", completionItemByLabel(durationItems, "s").FilterText)
-
-			durationPartialItemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 15, Character: 8},
-				},
-			})
-			require.NoError(t, err)
-			durationPartialItems := durationPartialItemsResult.(CompletionList).Items
-			assert.True(t, containsCompletionItemLabel(durationPartialItems, "ms"))
-			assertCompletionItemTextEdit(t, durationPartialItems, "ms", TextEdit{
-				Range: Range{
-					Start: Position{Line: 15, Character: 7},
-					End:   Position{Line: 15, Character: 8},
-				},
-				NewText: "ms",
-			})
-			assert.Equal(t, "1ms", completionItemByLabel(durationPartialItems, "ms").FilterText)
-
-			distanceItemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 16, Character: 8},
-				},
-			})
-			require.NoError(t, err)
-			distanceItems := distanceItemsResult.(CompletionList).Items
-			assert.Truef(t, containsCompletionItemLabel(distanceItems, "mm"), "%v", completionItemLabels(distanceItems))
-			assert.Truef(t, containsCompletionItemLabel(distanceItems, "cm"), "%v", completionItemLabels(distanceItems))
-			assert.False(t, containsCompletionItemLabel(distanceItems, "s"))
-			assertCompletionItemTextEdit(t, distanceItems, "cm", TextEdit{
-				Range: Range{
-					Start: Position{Line: 16, Character: 7},
-					End:   Position{Line: 16, Character: 8},
-				},
-				NewText: "cm",
-			})
-		})
-
-		t.Run("FuncDecoratorArgument", func(t *testing.T) {
-			s := newXGoUnitTestServer(`import "example.com/unit"
-
-func withDistance(distance unit.Distance, fn func()) {}
-
-@withDistance(1)
-func run() {}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 4, Character: 15},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.(CompletionList).Items
-			assert.True(t, containsCompletionItemLabel(items, "mm"))
-			assert.True(t, containsCompletionItemLabel(items, "cm"))
-			assert.False(t, containsCompletionItemLabel(items, "s"))
-		})
-
-		t.Run("StructKwargUnsupported", func(t *testing.T) {
-			s := newXGoUnitTestServer(xgoUnitCompletionSource)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 17, Character: 20},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.([]CompletionItem)
-			assert.False(t, containsCompletionItemKind(items, UnitCompletion))
-			assert.False(t, containsCompletionItemLabel(items, "s"))
-		})
-
-		t.Run("InterfaceKwarg", func(t *testing.T) {
-			s := newXGoUnitTestServer(`import "time"
-
-type Params interface {
-	Delay(time.Duration) Params
-}
-
-type Client struct{}
-
-var c Client
-
-func (c *Client) Params() Params { return nil }
-func (c *Client) Run(params Params) {}
-
-onStart => {
-	c.Run delay = 1
-}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 14, Character: 16},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.(CompletionList).Items
-			assert.True(t, containsCompletionItemLabel(items, "ms"))
-			assert.True(t, containsCompletionItemLabel(items, "s"))
-			assert.False(t, containsCompletionItemLabel(items, "delay"))
-		})
-
-		t.Run("UnsupportedContexts", func(t *testing.T) {
-			s := newXGoUnitTestServer(`import "time"
-
-type Options struct {
-	Delay time.Duration
-}
-
-func duration() time.Duration {
-	return 1
-}
-
-onStart => {
-	var delay time.Duration = 1
-	delay = 1
-	_ = Options{Delay: 1}
-}
-`)
-
-			for _, tt := range []struct {
-				name     string
-				position Position
-			}{
-				{name: "Return", position: Position{Line: 7, Character: 9}},
-				{name: "Var", position: Position{Line: 11, Character: 28}},
-				{name: "Assign", position: Position{Line: 12, Character: 10}},
-				{name: "StructField", position: Position{Line: 13, Character: 21}},
-			} {
-				t.Run(tt.name, func(t *testing.T) {
-					itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-						TextDocumentPositionParams: TextDocumentPositionParams{
-							TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-							Position:     tt.position,
-						},
-					})
-					require.NoError(t, err)
-					items := itemsResult.([]CompletionItem)
-					assert.Falsef(t, containsCompletionItemKind(items, UnitCompletion), "%v", completionItemLabels(items))
-				})
-			}
-		})
-
-		t.Run("PointerUnsupported", func(t *testing.T) {
-			s := newXGoUnitTestServer(`import "time"
-
-func waitPtr(d *time.Duration) {}
-
-onStart => {
-	waitPtr 1
-}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 5, Character: 10},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.([]CompletionItem)
-			assert.False(t, containsCompletionItemKind(items, UnitCompletion))
-			assert.False(t, containsCompletionItemLabel(items, "s"))
-		})
-
-		t.Run("CurrentPackageUnsupported", func(t *testing.T) {
-			s := newXGoUnitTestServer(`type Distance int
-
-const XGou_Distance = "mm=1,cm=10,m=1000"
-
-func move(d Distance) {}
-
-onStart => {
-	move 1
-}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 7, Character: 7},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.([]CompletionItem)
-			assert.False(t, containsCompletionItemKind(items, UnitCompletion))
-			assert.False(t, containsCompletionItemLabel(items, "m"))
-		})
-
-		t.Run("CurrentPackageAliasUnsupported", func(t *testing.T) {
-			s := newXGoUnitTestServer(`type Seconds = float64
-
-const XGou_Seconds = "s=1,ms=0.001"
-
-func glide(s Seconds) {}
-
-onStart => {
-	glide 1
-}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 7, Character: 8},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.([]CompletionItem)
-			assert.False(t, containsCompletionItemKind(items, UnitCompletion))
-			assert.False(t, containsCompletionItemLabel(items, "ms"))
-		})
-
-		t.Run("ImportedAlias", func(t *testing.T) {
-			s := newXGoUnitTestServer(`import "example.com/unit"
-
-func glide(s unit.Seconds) {}
-
-onStart => {
-	glide 1
-}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 5, Character: 8},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.(CompletionList).Items
-			assert.True(t, containsCompletionItemLabel(items, "s"))
-			assert.True(t, containsCompletionItemLabel(items, "ms"))
-			assert.False(t, containsCompletionItemLabel(items, "m"))
-		})
-
-		t.Run("SpxSeconds", func(t *testing.T) {
-			m := map[string][]byte{
-				"main.spx": []byte(`onStart => {
-	wait 1
-}
-`),
-				"assets/index.json": []byte(`{}`),
-			}
-			s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 7},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.(CompletionList).Items
-			assert.Truef(t, containsCompletionItemLabel(items, "s"), "%v", completionItemLabels(items))
-			assert.Truef(t, containsCompletionItemLabel(items, "ms"), "%v", completionItemLabels(items))
-			assert.Equal(t, "1s", completionItemByLabel(items, "s").FilterText)
-			assert.Equal(t, "1ms", completionItemByLabel(items, "ms").FilterText)
-			assert.False(t, containsCompletionItemLabel(items, "m"))
-		})
-
-		t.Run("ImportedAliasFallback", func(t *testing.T) {
-			s := newXGoUnitTestServer(`import "example.com/unit"
-
-func wait(d unit.Delay) {}
-
-onStart => {
-	wait 1
-}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 5, Character: 7},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.(CompletionList).Items
-			assert.True(t, containsCompletionItemLabel(items, "ms"))
-			assert.True(t, containsCompletionItemLabel(items, "s"))
-			assert.False(t, containsCompletionItemLabel(items, "km"))
-		})
-
-		t.Run("ImportedAliasOverloads", func(t *testing.T) {
-			s := newXGoUnitTestServer(`import "example.com/unit"
-
-type Worker struct{}
-
-var worker Worker
-
-func (w *Worker) handleSeconds(v unit.Seconds) {}
-func (w *Worker) handleMeters(v unit.Meters) {}
-
-func (Worker).handle = (
-	(Worker).handleSeconds
-	(Worker).handleMeters
-)
-
-onStart => {
-	worker.handle 1
-}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 15, Character: 16},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.(CompletionList).Items
-			labels := completionItemLabels(items)
-			assert.Truef(t, containsCompletionItemLabel(items, "ms"), "%v", labels)
-			assert.Truef(t, containsCompletionItemLabel(items, "km"), "%v", labels)
-		})
-
-		t.Run("DoesNotSwallowGeneralItems", func(t *testing.T) {
-			s := newXGoUnitTestServer(`func plain(n int) {}
-
-onStart => {
-	count := 1
-	plain 1
-}
-`)
-
-			itemsResult, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 4, Character: 8},
-				},
-			})
-			require.NoError(t, err)
-			items := itemsResult.([]CompletionItem)
-			assert.False(t, containsCompletionItemKind(items, UnitCompletion))
-			assert.True(t, containsCompletionItemLabel(items, "count"))
-		})
-	})
-
-	t.Run("LSPResultShape", func(t *testing.T) {
-		t.Run("CompleteArray", func(t *testing.T) {
-			m := map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
-			}
-			s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-			result, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
-				},
-			})
-			require.NoError(t, err)
-
-			items := result.([]CompletionItem)
-			assert.NotEmpty(t, items)
-		})
-
-		t.Run("IncompleteUnitList", func(t *testing.T) {
-			s := newXGoUnitTestServer(xgoUnitCompletionSource)
-
-			result, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 14, Character: 7},
-				},
-			})
-			require.NoError(t, err)
-
-			list := result.(CompletionList)
-			assert.True(t, list.IsIncomplete)
-			assert.True(t, containsCompletionItemLabel(list.Items, "s"))
-			assert.Equal(t, "1s", completionItemByLabel(list.Items, "s").FilterText)
-			assertCompletionItemTextEdit(t, list.Items, "s", TextEdit{
-				Range: Range{
-					Start: Position{Line: 14, Character: 7},
-					End:   Position{Line: 14, Character: 7},
-				},
-				NewText: "s",
-			})
-		})
-
-		t.Run("IncompleteUnitListUsesCurrentText", func(t *testing.T) {
-			s := newXGoUnitTestServer(`import "time"
-
-func wait(d time.Duration) {}
-
-onStart => {
-	wait 12
-}
-`)
-
-			result, err := s.textDocumentCompletion(&CompletionParams{
-				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 5, Character: 8},
-				},
-			})
-			require.NoError(t, err)
-
-			list := result.(CompletionList)
-			assert.True(t, list.IsIncomplete)
-			assert.Equal(t, "12s", completionItemByLabel(list.Items, "s").FilterText)
-			assertCompletionItemTextEdit(t, list.Items, "s", TextEdit{
-				Range: Range{
-					Start: Position{Line: 5, Character: 8},
-					End:   Position{Line: 5, Character: 8},
-				},
-				NewText: "s",
-			})
-		})
+		assert.Contains(t, completionItemLabels(items), "onStart")
 	})
 }
 

--- a/internal/server/completion_unit_test.go
+++ b/internal/server/completion_unit_test.go
@@ -1,0 +1,395 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const xgoUnitCompletionSource = `import (
+	"time"
+	"example.com/unit"
+)
+
+type Options struct {
+	Delay time.Duration
+}
+
+func wait(d time.Duration) {}
+func move(d unit.Distance) {}
+func configure(opts Options?) {}
+
+func run() {
+	wait 1
+	wait 1m
+	move 1m
+	configure delay = 1
+}
+`
+
+func TestServerTextDocumentCompletionUnits(t *testing.T) {
+	t.Run("ClassfileCallbacks", func(t *testing.T) {
+		for _, tt := range []struct {
+			name     string
+			filename string
+			callback string
+		}{
+			{name: "Project", filename: "main_fixture.gox", callback: "onStart => {"},
+			{name: "Work", filename: "Worker_fixture.gox", callback: "onValue value => {"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				const line = "\t/* \U0001f600 */ move 1m"
+				files := map[string][]byte{"main_fixture.gox": nil}
+				files[tt.filename] = []byte("import \"example.com/unit\"\r\nfunc move(d unit.Distance) {}\r\n" + tt.callback + "\r\n" + line + "\r\n}\r\n")
+				s := newTestServer(t, files)
+				s.workspaceRootFS.Importer = xgoUnitTestImporter{fallback: s.workspaceRootFS.Importer}
+				_, err := s.workspaceRootFS.TypeInfo()
+				require.NoError(t, err)
+
+				position := Position{Line: 3, Character: uint32(UTF16Len(line))}
+				list := completionListAt(t, s, tt.filename, position)
+				assert.True(t, list.IsIncomplete)
+				assert.NotContains(t, completionItemLabels(list.Items), "s")
+				assertCompletionItemTextEdit(t, list.Items, "cm", TextEdit{
+					Range: Range{
+						Start: Position{Line: 3, Character: position.Character - 1},
+						End:   position,
+					},
+					NewText: "cm",
+				})
+				item := completionItemByLabel(list.Items, "cm")
+				require.NotNil(t, item)
+				assert.Equal(t, "1cm", item.FilterText)
+			})
+		}
+	})
+
+	t.Run("CallArguments", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, xgoUnitCompletionSource)
+		_, err := s.workspaceRootFS.TypeInfo()
+		require.NoError(t, err)
+
+		durationItems := completionListAt(t, s, "main.xgo", Position{Line: 14, Character: 7}).Items
+		durationLabels := completionItemLabels(durationItems)
+		assert.Contains(t, durationLabels, "ms")
+		assert.Contains(t, durationLabels, "s")
+		assert.Contains(t, durationLabels, "m")
+		assert.Contains(t, durationLabels, "\u00b5s")
+		assert.NotContains(t, durationLabels, "wait")
+		assertCompletionItemTextEdit(t, durationItems, "s", TextEdit{
+			Range: Range{
+				Start: Position{Line: 14, Character: 7},
+				End:   Position{Line: 14, Character: 7},
+			},
+			NewText: "s",
+		})
+		durationItem := completionItemByLabel(durationItems, "s")
+		require.NotNil(t, durationItem)
+		assert.Equal(t, "1s", durationItem.FilterText)
+
+		durationPartialItems := completionListAt(t, s, "main.xgo", Position{Line: 15, Character: 8}).Items
+		assert.Contains(t, completionItemLabels(durationPartialItems), "ms")
+		assertCompletionItemTextEdit(t, durationPartialItems, "ms", TextEdit{
+			Range: Range{
+				Start: Position{Line: 15, Character: 7},
+				End:   Position{Line: 15, Character: 8},
+			},
+			NewText: "ms",
+		})
+		durationPartialItem := completionItemByLabel(durationPartialItems, "ms")
+		require.NotNil(t, durationPartialItem)
+		assert.Equal(t, "1ms", durationPartialItem.FilterText)
+
+		distanceItems := completionListAt(t, s, "main.xgo", Position{Line: 16, Character: 8}).Items
+		distanceLabels := completionItemLabels(distanceItems)
+		assert.Contains(t, distanceLabels, "mm")
+		assert.Contains(t, distanceLabels, "cm")
+		assert.NotContains(t, distanceLabels, "s")
+		assertCompletionItemTextEdit(t, distanceItems, "cm", TextEdit{
+			Range: Range{
+				Start: Position{Line: 16, Character: 7},
+				End:   Position{Line: 16, Character: 8},
+			},
+			NewText: "cm",
+		})
+	})
+
+	t.Run("FuncDecoratorArgument", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `import "example.com/unit"
+
+func withDistance(distance unit.Distance, fn func()) {}
+
+@withDistance(1)
+func run() {}
+`)
+
+		items := completionListAt(t, s, "main.xgo", Position{Line: 4, Character: 15}).Items
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "mm")
+		assert.Contains(t, labels, "cm")
+		assert.NotContains(t, labels, "s")
+	})
+
+	t.Run("StructKwargUnsupported", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, xgoUnitCompletionSource)
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 17, Character: 20})
+		assert.False(t, containsCompletionItemKind(items, UnitCompletion))
+		assert.NotContains(t, completionItemLabels(items), "s")
+	})
+
+	t.Run("InterfaceKwarg", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `import "time"
+
+type Params interface {
+	Delay(time.Duration) Params
+}
+
+type Client struct{}
+
+var c Client
+
+func (c *Client) Params() Params { return nil }
+func (c *Client) Run(params Params) {}
+
+func run() {
+	c.Run delay = 1
+}
+`)
+
+		items := completionListAt(t, s, "main.xgo", Position{Line: 14, Character: 16}).Items
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "ms")
+		assert.Contains(t, labels, "s")
+		assert.NotContains(t, labels, "delay")
+	})
+
+	t.Run("UnsupportedContexts", func(t *testing.T) {
+		source := `import "time"
+
+type Options struct {
+	Delay time.Duration
+}
+
+func duration() time.Duration {
+	return 1
+}
+
+func run() {
+	var delay time.Duration = 1
+	delay = 1
+	_ = Options{Delay: 1}
+}
+`
+
+		for _, tt := range []struct {
+			name     string
+			position Position
+		}{
+			{name: "Return", position: Position{Line: 7, Character: 9}},
+			{name: "Var", position: Position{Line: 11, Character: 28}},
+			{name: "Assign", position: Position{Line: 12, Character: 10}},
+			{name: "StructField", position: Position{Line: 13, Character: 21}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := newXGoUnitTestServer(t, source)
+				itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+						Position:     tt.position,
+					},
+				})
+				require.NoError(t, err)
+				items := requireValueAs[[]CompletionItem](t, itemsResult)
+				assert.Falsef(t, containsCompletionItemKind(items, UnitCompletion), "%v", completionItemLabels(items))
+			})
+		}
+	})
+
+	t.Run("PointerUnsupported", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `import "time"
+
+func waitPtr(d *time.Duration) {}
+
+func run() {
+	waitPtr 1
+}
+`)
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 5, Character: 10})
+		assert.False(t, containsCompletionItemKind(items, UnitCompletion))
+		assert.NotContains(t, completionItemLabels(items), "s")
+	})
+
+	t.Run("CurrentPackageUnsupported", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `type Distance int
+
+const XGou_Distance = "mm=1,cm=10,m=1000"
+
+func move(d Distance) {}
+
+func run() {
+	move 1
+}
+`)
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 7, Character: 7})
+		assert.False(t, containsCompletionItemKind(items, UnitCompletion))
+		assert.NotContains(t, completionItemLabels(items), "m")
+	})
+
+	t.Run("CurrentPackageAliasUnsupported", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `type Seconds = float64
+
+const XGou_Seconds = "s=1,ms=0.001"
+
+func glide(s Seconds) {}
+
+func run() {
+	glide 1
+}
+`)
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 7, Character: 8})
+		assert.False(t, containsCompletionItemKind(items, UnitCompletion))
+		assert.NotContains(t, completionItemLabels(items), "ms")
+	})
+
+	t.Run("ImportedAlias", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `import "example.com/unit"
+
+func glide(s unit.Seconds) {}
+
+func run() {
+	glide 1
+}
+`)
+
+		items := completionListAt(t, s, "main.xgo", Position{Line: 5, Character: 8}).Items
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "s")
+		assert.Contains(t, labels, "ms")
+		assert.NotContains(t, labels, "m")
+	})
+
+	t.Run("ImportedAliasFallback", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `import "example.com/unit"
+
+func wait(d unit.Delay) {}
+
+func run() {
+	wait 1
+}
+`)
+
+		items := completionListAt(t, s, "main.xgo", Position{Line: 5, Character: 7}).Items
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "ms")
+		assert.Contains(t, labels, "s")
+		assert.NotContains(t, labels, "km")
+	})
+
+	t.Run("ImportedAliasOverloads", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `import "example.com/unit"
+
+type Worker struct{}
+
+var worker Worker
+
+func (w *Worker) handleSeconds(v unit.Seconds) {}
+func (w *Worker) handleMeters(v unit.Meters) {}
+
+func (Worker).handle = (
+	(Worker).handleSeconds
+	(Worker).handleMeters
+)
+
+func run() {
+	worker.handle 1
+}
+`)
+
+		items := completionListAt(t, s, "main.xgo", Position{Line: 15, Character: 16}).Items
+		labels := completionItemLabels(items)
+		assert.Contains(t, labels, "ms")
+		assert.Contains(t, labels, "km")
+	})
+
+	t.Run("DoesNotSwallowGeneralItems", func(t *testing.T) {
+		s := newXGoUnitTestServer(t, `func plain(n int) {}
+
+func run() {
+	count := 1
+	plain 1
+}
+`)
+
+		items := completionItemsAt(t, s, "main.xgo", Position{Line: 4, Character: 8})
+		assert.False(t, containsCompletionItemKind(items, UnitCompletion))
+		assert.Contains(t, completionItemLabels(items), "count")
+	})
+
+	t.Run("LSPResultShape", func(t *testing.T) {
+		t.Run("CompleteArray", func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{
+				"main.xgo": []byte("var x = 100\necho x"),
+			})
+
+			items := completionItemsAt(t, s, "main.xgo", Position{Line: 1, Character: 5})
+			assert.NotEmpty(t, items)
+		})
+
+		t.Run("IncompleteUnitList", func(t *testing.T) {
+			s := newXGoUnitTestServer(t, xgoUnitCompletionSource)
+
+			list := completionListAt(t, s, "main.xgo", Position{Line: 14, Character: 7})
+			assert.True(t, list.IsIncomplete)
+			assert.True(t, containsCompletionItemLabel(list.Items, "s"))
+			listItem := completionItemByLabel(list.Items, "s")
+			require.NotNil(t, listItem)
+			assert.Equal(t, "1s", listItem.FilterText)
+			assertCompletionItemTextEdit(t, list.Items, "s", TextEdit{
+				Range: Range{
+					Start: Position{Line: 14, Character: 7},
+					End:   Position{Line: 14, Character: 7},
+				},
+				NewText: "s",
+			})
+		})
+
+		t.Run("IncompleteUnitListUsesCurrentText", func(t *testing.T) {
+			s := newXGoUnitTestServer(t, `import "time"
+
+func wait(d time.Duration) {}
+
+func run() {
+	wait 12
+}
+`)
+
+			list := completionListAt(t, s, "main.xgo", Position{Line: 5, Character: 8})
+			assert.True(t, list.IsIncomplete)
+			listItem := completionItemByLabel(list.Items, "s")
+			require.NotNil(t, listItem)
+			assert.Equal(t, "12s", listItem.FilterText)
+			assertCompletionItemTextEdit(t, list.Items, "s", TextEdit{
+				Range: Range{
+					Start: Position{Line: 5, Character: 8},
+					End:   Position{Line: 5, Character: 8},
+				},
+				NewText: "s",
+			})
+		})
+	})
+}
+
+func completionListAt(t *testing.T, s *Server, filename string, position Position) CompletionList {
+	t.Helper()
+
+	result, err := s.textDocumentCompletion(&CompletionParams{TextDocumentPositionParams: TextDocumentPositionParams{
+		TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(filename)}, Position: position,
+	}})
+	require.NoError(t, err)
+	return requireValueAs[CompletionList](t, result)
+}

--- a/internal/server/kwarg_test.go
+++ b/internal/server/kwarg_test.go
@@ -2,10 +2,89 @@ package server
 
 import (
 	gotypes "go/types"
+	"slices"
 	"testing"
 
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgolsw/xgo/xgoutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestResolvedCallExprArgs(t *testing.T) {
+	t.Run("UnresolvedOverloadKwargs", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo": []byte(`type Worker struct{}
+type Options struct {
+	Count int
+	Name string
+}
+func (w *Worker) handleInt(prefix int, opts Options?, values ...int) {}
+func (w *Worker) handleString(prefix string, opts Options?, values ...int) {}
+func (Worker).handle = (
+	(Worker).handleInt
+	(Worker).handleString
+)
+var worker Worker
+worker.handle missing, unknown, count = unknown, name = "task"
+`),
+		})
+		proj := s.workspaceRootFS
+		typeInfo, err := proj.TypeInfo()
+		require.NotNil(t, typeInfo)
+		require.ErrorContains(t, err, "undefined: missing")
+		astFile, err := proj.ASTFile("main.xgo")
+		require.NoError(t, err)
+		var call *ast.CallExpr
+		ast.Inspect(astFile, func(node ast.Node) bool {
+			if expr, ok := node.(*ast.CallExpr); ok {
+				call = expr
+				return false
+			}
+			return true
+		})
+		require.NotNil(t, call)
+		assert.Empty(t, slices.Collect(xgoutil.ResolvedCallExprArgs(typeInfo, call)))
+
+		args := slices.Collect(resolvedCallExprArgs(proj, typeInfo, call))
+		require.Len(t, args, 8)
+		for overloadIndex, prefixType := range []gotypes.Type{gotypes.Typ[gotypes.Int], gotypes.Typ[gotypes.String]} {
+			for i, tt := range []struct {
+				paramIndex int
+				paramName  string
+				kind       xgoutil.ResolvedCallExprArgKind
+				valueType  gotypes.Type
+				fieldName  string
+			}{
+				{0, "prefix", xgoutil.ResolvedCallExprArgPositional, prefixType, ""},
+				{2, "values", xgoutil.ResolvedCallExprArgPositional, gotypes.Typ[gotypes.Int], ""},
+				{1, "opts", xgoutil.ResolvedCallExprArgKeyword, gotypes.Typ[gotypes.Int], "Count"},
+				{1, "opts", xgoutil.ResolvedCallExprArgKeyword, gotypes.Typ[gotypes.String], "Name"},
+			} {
+				arg := args[overloadIndex*4+i]
+				assert.Equal(t, i, arg.ArgIndex)
+				assert.Equal(t, tt.paramIndex, arg.ParamIndex)
+				require.NotNil(t, arg.Param)
+				assert.Equal(t, tt.paramName, arg.Param.Name())
+				assert.Equal(t, tt.kind, arg.Kind)
+				assert.Equal(t, tt.valueType, arg.ExpectedType)
+				if i < len(call.Args) {
+					assert.Same(t, call.Args[i], arg.Arg)
+					assert.Nil(t, arg.Kwarg)
+					assert.Nil(t, arg.KwargTarget)
+					continue
+				}
+				kwarg := call.Kwargs[i-len(call.Args)]
+				assert.Same(t, kwarg, arg.Kwarg)
+				assert.Same(t, kwarg.Value, arg.Arg)
+				require.NotNil(t, arg.KwargTarget)
+				assert.Equal(t, kwarg.Name.Name, arg.KwargTarget.Name)
+				require.NotNil(t, arg.KwargTarget.Field)
+				assert.Equal(t, tt.fieldName, arg.KwargTarget.Field.Name())
+			}
+		}
+	})
+}
 
 func TestKwargRenameText(t *testing.T) {
 	pkg := gotypes.NewPackage("main", "main")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,6 +52,7 @@ type Server struct {
 	analyzers          []*analysis.Analyzer
 	fileMapGetter      FileMapGetter // TODO(wyvern): Remove this field.
 	cancelCauseFuncs   sync.Map      // Map of request IDs to cancel functions (with cause).
+	listPkgs           func() ([]string, error)
 	lookupPkgDoc       func(string) (*pkgdoc.PkgDoc, error)
 	scheduler          Scheduler
 	language           i18n.Language // Current language for error message translation
@@ -87,6 +88,7 @@ func New(proj *xgo.Project, replier MessageReplier, fileMapGetter FileMapGetter,
 		analyzers:        initAnalyzers(true),
 		fileMapGetter:    fileMapGetter,
 		scheduler:        scheduler,
+		listPkgs:         pkgdata.ListPkgs,
 		lookupPkgDoc:     pkgdata.GetPkgDoc,
 		language:         i18n.LanguageEN, // Default to English until initialize is called
 	}

--- a/internal/server/spx_completion_test.go
+++ b/internal/server/spx_completion_test.go
@@ -8,6 +8,18 @@ import (
 )
 
 func TestServerTextDocumentCompletionSpx(t *testing.T) {
+	t.Run("ImportFrameworkPackage", func(t *testing.T) {
+		files := map[string][]byte{"main.spx": []byte("import \"github.com/goplus/spx\n")}
+		s := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+		items := completionItemsAt(t, s, "main.spx", Position{Character: 28})
+		item := completionItemByLabel(items, SpxPkgPath)
+		require.NotNil(t, item)
+		assert.Equal(t, ModuleCompletion, item.Kind)
+		assert.Equal(t, SpxPkgPath, item.InsertText)
+		data := requireValueAs[*CompletionItemData](t, item.Data)
+		assert.Equal(t, ToPtr(SpxPkgPath), data.Definition.Package)
+	})
+
 	t.Run("ResourceNames", func(t *testing.T) {
 		for _, tt := range []struct {
 			name     string
@@ -115,5 +127,609 @@ func test() {
 		assert.Equal(t, "Runner", item.InsertText)
 		data := requireValueAs[*CompletionItemData](t, item.Data)
 		assert.Equal(t, "xgo:main?Game.Runner", data.Definition.String())
+	})
+
+	t.Run("StepToWithKwargNameCompletion", func(t *testing.T) {
+		for _, tt := range []struct {
+			name      string
+			code      string
+			character uint32
+		}{
+			{
+				name: "BareIdent",
+				code: `
+onStart => {
+	stepToWith "Red", s
+}
+`,
+				character: 20,
+			},
+			{
+				name: "KwargExpr",
+				code: `
+onStart => {
+	stepToWith "Red", spe = 2
+}
+`,
+				character: 21,
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				m := map[string][]byte{
+					"main.spx":                           []byte(``),
+					"MySprite.spx":                       []byte(tt.code),
+					"Red.spx":                            []byte(``),
+					"assets/index.json":                  []byte(`{}`),
+					"assets/sprites/MySprite/index.json": []byte(`{}`),
+					"assets/sprites/Red/index.json":      []byte(`{}`),
+				}
+				s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+				items := completionItemsAt(t, s, "MySprite.spx", Position{Line: 2, Character: tt.character})
+				assert.True(t, containsKwargCompletionItem(items, "speed", SpxDefinitionIdentifier{
+					Package: ToPtr(SpxPkgPath),
+					Name:    ToPtr("MotionOptions.Speed"),
+				}))
+				assert.True(t, containsKwargCompletionItem(items, "animation", SpxDefinitionIdentifier{
+					Package: ToPtr(SpxPkgPath),
+					Name:    ToPtr("MotionOptions.Animation"),
+				}))
+			})
+		}
+	})
+
+	t.Run("Normal", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+
+MySprite.
+`),
+			"MySprite.spx": []byte(`
+onStart => {
+	MySprite.turn Right
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		emptyLineItems := completionItemsAt(t, s, "main.spx", Position{Line: 1, Character: 0})
+		assert.NotEmpty(t, emptyLineItems)
+		assert.Contains(t, completionItemLabels(emptyLineItems), "println")
+		assert.True(t, containsCompletionSpxDefinitionID(emptyLineItems, SpxDefinitionIdentifier{
+			Package: ToPtr("main"),
+			Name:    ToPtr("MySprite"),
+		}))
+
+		assert.Contains(t, emptyLineItems, SpxDefinition{
+			ID: SpxDefinitionIdentifier{
+				Package: ToPtr(SpxPkgPath),
+				Name:    ToPtr("Game.getWidget"),
+			},
+			Overview: "func getWidget(T Type, name WidgetName) *T",
+			Detail:   "GetWidget returns the widget instance (in given type) with given name. It panics if not found.\n",
+
+			CompletionItemLabel:            "getWidget",
+			CompletionItemKind:             FunctionCompletion,
+			CompletionItemInsertText:       "getWidget",
+			CompletionItemInsertTextFormat: PlainTextTextFormat,
+		}.CompletionItem())
+
+		mySpriteDotItems := completionItemsAt(t, s, "main.spx", Position{Line: 2, Character: 9})
+		assert.NotEmpty(t, mySpriteDotItems)
+		assert.NotContains(t, completionItemLabels(mySpriteDotItems), "println")
+		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
+			Package:    ToPtr(SpxPkgPath),
+			Name:       ToPtr("Sprite.turn"),
+			OverloadID: ToPtr("0"),
+		}))
+		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
+			Package:    ToPtr(SpxPkgPath),
+			Name:       ToPtr("Sprite.turn"),
+			OverloadID: ToPtr("0"),
+		}))
+		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
+			Package:    ToPtr(SpxPkgPath),
+			Name:       ToPtr("Sprite.turn"),
+			OverloadID: ToPtr("1"),
+		}))
+		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
+			Package:    ToPtr(SpxPkgPath),
+			Name:       ToPtr("Sprite.clone"),
+			OverloadID: ToPtr("0"),
+		}))
+		assert.True(t, containsCompletionSpxDefinitionID(mySpriteDotItems, SpxDefinitionIdentifier{
+			Package:    ToPtr(SpxPkgPath),
+			Name:       ToPtr("Sprite.clone"),
+			OverloadID: ToPtr("1"),
+		}))
+	})
+
+	t.Run("InSpxEventHandler", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 2, Character: 1})
+		assert.NotEmpty(t, items)
+		assert.False(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
+			Package: ToPtr(SpxPkgPath),
+			Name:    ToPtr("Sprite.onStart"),
+		}))
+		assert.False(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
+			Package: ToPtr(SpxPkgPath),
+			Name:    ToPtr("Sprite.onClick"),
+		}))
+	})
+
+	t.Run("VarDeclAndAssign", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	var x SpriteName = "m"
+}
+`),
+			"MySprite.spx": []byte(`
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 2, Character: 22})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "MySprite")
+	})
+
+	t.Run("VarDeclAndAssignWithAlias", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+type MySpriteName = SpriteName
+
+onStart => {
+	var x MySpriteName = "m"
+}
+`),
+			"MySprite.spx":                       []byte(``),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 4, Character: 24})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "MySprite")
+	})
+
+	t.Run("SpxSoundResourceStringLit", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+play "r"
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sounds/recording/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 1, Character: 7})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "recording")
+	})
+
+	t.Run("FuncOverloads", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+play r
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sounds/recording/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 1, Character: 6})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), `"recording"`)
+	})
+
+	t.Run("WithImplicitSpxSpriteResource", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+`),
+			"MySprite.spx": []byte(`
+onClick => {
+	setCostume "c"
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{"costumes":[{"name":"costume"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "MySprite.spx", Position{Line: 2, Character: 14})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "costume")
+	})
+
+	t.Run("WithExplicitSpxSpriteResource", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+MySprite.setCostume "c"
+`),
+			"MySprite.spx":                       []byte(``),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{"costumes":[{"name":"costume"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 1, Character: 22})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "costume")
+	})
+
+	t.Run("WithCrossSpxSpriteResource", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+`),
+			"Sprite1.spx": []byte(`
+onClick => {
+	Sprite2.setCostume "c"
+}
+`),
+			"Sprite2.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Sprite1Costume"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Sprite2Costume"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "Sprite1.spx", Position{Line: 2, Character: 22})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "Sprite2Costume")
+	})
+
+	t.Run("WithCrossSpxSpriteResourceInGoStmt", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(``),
+			"Sprite1.spx": []byte(`
+onClick => {
+	go Sprite2.setCostume("c")
+}
+`),
+			"Sprite2.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Sprite1Costume"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Sprite2Costume"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "Sprite1.spx", Position{Line: 2, Character: 25})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "Sprite2Costume")
+	})
+
+	t.Run("WithCrossSpxSpriteResourceInDeferStmt", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(``),
+			"Sprite1.spx": []byte(`
+onClick => {
+	defer Sprite2.setCostume("c")
+}
+`),
+			"Sprite2.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Sprite1Costume"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Sprite2Costume"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "Sprite1.spx", Position{Line: 2, Character: 28})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "Sprite2Costume")
+	})
+
+	t.Run("SpriteCostumeNameInImplicitCallUsesCurrentSprite", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(``),
+			"Sprite1.spx": []byte(`
+onStart => {
+	setCostume C
+}
+`),
+			"Sprite2.spx":                       []byte(``),
+			"Sprite3.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Crab2"},{"name":"Crab3"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
+			"assets/sprites/Sprite3/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "Sprite1.spx", Position{Line: 2, Character: 13})
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
+	})
+
+	t.Run("SpriteCostumeNameInDeclDeduplicatesCrossSpriteNames", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	var costume SpriteCostumeName = C
+}
+`),
+			"Sprite1.spx":                       []byte(``),
+			"Sprite2.spx":                       []byte(``),
+			"Sprite3.spx":                       []byte(``),
+			"assets/index.json":                 []byte(`{}`),
+			"assets/sprites/Sprite1/index.json": []byte(`{"costumes":[{"name":"Crab2"},{"name":"Crab3"}]}`),
+			"assets/sprites/Sprite2/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
+			"assets/sprites/Sprite3/index.json": []byte(`{"costumes":[{"name":"Crab2"}]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 2, Character: 34})
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
+	})
+
+	t.Run("StepToOverloadsDeduplicateSpriteNameSuggestions", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(``),
+			"Runner.spx": []byte(`
+onStart => {
+	stepTo C
+}
+`),
+			"Crab2.spx":                        []byte(``),
+			"Crab3.spx":                        []byte(``),
+			"assets/index.json":                []byte(`{}`),
+			"assets/sprites/Runner/index.json": []byte(`{"costumes":[]}`),
+			"assets/sprites/Crab2/index.json":  []byte(`{"costumes":[]}`),
+			"assets/sprites/Crab3/index.json":  []byte(`{"costumes":[]}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "Runner.spx", Position{Line: 2, Character: 10})
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab2"`))
+		assert.Equal(t, 1, countCompletionItemLabel(items, `"Crab3"`))
+	})
+
+	t.Run("AtLineStartWithAMemberAccessExpression", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+MySprite.setCo`), // Cursor at EOF.
+			"MySprite.spx": []byte(`
+onClick => {
+	MySprite.setCo
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items1 := completionItemsAt(t, s, "main.spx", Position{Line: 1, Character: 14})
+		assert.NotEmpty(t, items1)
+		assert.Contains(t, completionItemLabels(items1), "setCostume")
+
+		items2 := completionItemsAt(t, s, "MySprite.spx", Position{Line: 2, Character: 15})
+		assert.NotEmpty(t, items2)
+		assert.Contains(t, completionItemLabels(items2), "setCostume")
+	})
+
+	t.Run("MathPackage", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	n := ab
+}
+`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 2, Character: 8})
+		assert.NotEmpty(t, items)
+		assert.Contains(t, completionItemLabels(items), "abs")
+	})
+
+	t.Run("SpriteInterfaceEmbedding", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+type MyInterface interface {
+	Sprite
+	methodOne()
+}
+
+onStart => {
+	var iface MyInterface = MySprite
+	iface.on
+}
+`),
+			"MySprite.spx": []byte(`
+func methodOne() {}
+onStart => {}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 8, Character: 9}) // After "n"
+		assert.Contains(t, completionItemLabels(items), "onClick")
+		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
+			Package: ToPtr("github.com/goplus/spx/v3"),
+			Name:    ToPtr("Sprite.onClick"),
+		}))
+		assert.Contains(t, completionItemLabels(items), "methodOne")
+		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
+			Package: ToPtr("main"),
+			Name:    ToPtr("MyInterface.methodOne"),
+		}))
+	})
+
+	t.Run("PropertyNameCompletionInMainSpx", func(t *testing.T) {
+		// showVar in main.spx makes getPropertyTarget return "Game"
+		// → collectPropertyNames("Game") → property methods from embedded spx.Game appear
+		m := map[string][]byte{
+			"main.spx": []byte(`
+var score int
+onStart => {
+	showVar(x)
+}
+`),
+			"MySprite.spx":                       []byte(`onStart => {}`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 3, Character: 10}) // inside 'x' arg of showVar
+		// score is declared in main.spx and becomes a Game field.
+		assert.Contains(t, completionItemLabels(items), `"score"`)
+		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
+			Package: ToPtr("main"),
+			Name:    ToPtr("Game.score"),
+		}))
+		// Property method from embedded spx.Game.
+		assert.Contains(t, completionItemLabels(items), `"volume"`)
+	})
+
+	t.Run("PropertyNameCompletionInSpriteSpx", func(t *testing.T) {
+		// showVar in MySprite.spx → getPropertyTarget returns "MySprite" (not "Game").
+		// hp is a field of MySprite, so its appearance confirms the correct target is used.
+		m := map[string][]byte{
+			"main.spx": []byte(`
+`),
+			"MySprite.spx": []byte(`
+var hp int
+
+onStart => {
+	showVar(x)
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///MySprite.spx"},
+				// Line 4: "\tshowVar(x)" — tab(0)+showVar(1-7)+(8)+x(9)
+				Position: Position{Line: 4, Character: 10},
+			},
+		})
+		require.NoError(t, err)
+		items := requireValueAs[[]CompletionItem](t, itemsResult)
+		require.NotNil(t, items)
+		// hp is a direct field of MySprite — confirms target is "MySprite", not "Game".
+		assert.Contains(t, completionItemLabels(items), `"hp"`)
+	})
+
+	t.Run("PropertyNameCompletionExplicitReceiver", func(t *testing.T) {
+		// MySprite.showVar(x) in main.spx makes getPropertyTarget return "MySprite"
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onStart => {
+	MySprite.showVar(x)
+}
+`),
+			"MySprite.spx": []byte(`
+var hp int
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				// Line 3: "\tMySprite.showVar(x)" — tab(0)+MySprite(1-8)+.(9)+showVar(10-16)+(17)+x(18)
+				Position: Position{Line: 2, Character: 19},
+			},
+		})
+		require.NoError(t, err)
+		items := requireValueAs[[]CompletionItem](t, itemsResult)
+		require.NotNil(t, items)
+		assert.Contains(t, completionItemLabels(items), `"hp"`)
+		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
+			Package: ToPtr("main"),
+			Name:    ToPtr("MySprite.hp"),
+		}))
+	})
+
+	t.Run("PropertyNameCompletionEmbeddedMethod", func(t *testing.T) {
+		// SpriteImpl is embedded in MySprite; its property methods should appear.
+		m := map[string][]byte{
+			"main.spx": []byte(`
+`),
+			"MySprite.spx": []byte(`
+var hp int
+
+showVar(
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "MySprite.spx", Position{Line: 3, Character: 8})
+		// Direct field of MySprite.
+		assert.Contains(t, completionItemLabels(items), `"hp"`)
+		// Property method from embedded spx.SpriteImpl (e.g. "xpos" → "Xpos").
+		assert.Contains(t, completionItemLabels(items), `"xpos"`)
+		assert.True(t, containsCompletionSpxDefinitionID(items, SpxDefinitionIdentifier{
+			Package: ToPtr("github.com/goplus/spx/v3"),
+			Name:    ToPtr("Sprite.xpos"),
+		}))
+	})
+
+	t.Run("PropertyNameCompletionInsideStringLit", func(t *testing.T) {
+		// When cursor is inside a string literal, insert text should NOT be quoted.
+		m := map[string][]byte{
+			"main.spx": []byte(`
+var score int
+
+showVar("s
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		items := completionItemsAt(t, s, "main.spx", Position{Line: 3, Character: 10})
+		// Inside string literal: label/insertText is unquoted.
+		assert.Contains(t, completionItemLabels(items), "score")
+		assert.NotContains(t, completionItemLabels(items), `"score"`)
+	})
+
+	t.Run("SpxSeconds", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`onStart => {
+	wait 1
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		itemsResult, err := s.textDocumentCompletion(&CompletionParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				Position:     Position{Line: 1, Character: 7},
+			},
+		})
+		require.NoError(t, err)
+		items := requireValueAs[CompletionList](t, itemsResult).Items
+		assert.Truef(t, containsCompletionItemLabel(items, "s"), "%v", completionItemLabels(items))
+		assert.Truef(t, containsCompletionItemLabel(items, "ms"), "%v", completionItemLabels(items))
+		assert.Equal(t, "1s", completionItemByLabel(items, "s").FilterText)
+		assert.Equal(t, "1ms", completionItemByLabel(items, "ms").FilterText)
+		assert.NotContains(t, completionItemLabels(items), "m")
 	})
 }

--- a/internal/server/spx_document_test.go
+++ b/internal/server/spx_document_test.go
@@ -12,6 +12,27 @@ import (
 )
 
 func TestServerTextDocumentDocumentLinkSpx(t *testing.T) {
+	t.Run("UnresolvedCallKeepsResourceReferences", func(t *testing.T) {
+		files := map[string][]byte{
+			"main.spx": []byte(`func resource() SoundName { return "KnownSound" }
+func broken() { missing "UnusedSound" }
+`),
+			"assets/index.json":                    []byte(`{}`),
+			"assets/sounds/KnownSound/index.json":  []byte(`{}`),
+			"assets/sounds/UnusedSound/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+		_, err := s.workspaceRootFS.TypeInfo()
+		require.ErrorContains(t, err, "undefined: missing")
+		links, err := s.textDocumentDocumentLink(&DocumentLinkParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		targets := documentLinkTargets(t, links)
+		assert.Contains(t, targets, "spx://resources/sounds/KnownSound")
+		assert.NotContains(t, targets, "spx://resources/sounds/UnusedSound")
+	})
+
 	t.Run("OtherFramework", func(t *testing.T) {
 		s := newTestServer(t, map[string][]byte{"main.spx": []byte("var Count = 1\nCount = 2\n")})
 		proj := s.workspaceRootFS

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -17,6 +17,7 @@ func newTestServer(t *testing.T, files map[string][]byte) *Server {
 	s := New(proj, nil, fileMapGetter(files), &MockScheduler{})
 	proj.Mod = testframework.NewModule(t)
 	proj.Importer = testframework.NewImporter(t, proj.Fset)
+	s.listPkgs = func() ([]string, error) { return []string{testframework.PkgPath}, nil }
 	frameworkDoc := testframework.NewPkgDoc(t)
 	s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
 		t.Helper()

--- a/internal/server/unit_test.go
+++ b/internal/server/unit_test.go
@@ -10,34 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const xgoUnitCompletionSource = `import (
-	"time"
-	"example.com/unit"
-)
-
-type Options struct {
-	Delay time.Duration
-}
-
-func wait(d time.Duration) {}
-func move(d unit.Distance) {}
-func configure(opts Options?) {}
-
-onStart => {
-	wait 1
-	wait 1m
-	move 1m
-	configure delay = 1
-}
-`
-
-func newXGoUnitTestServer(source string) *Server {
-	m := map[string][]byte{
-		"main.spx":          []byte(source),
-		"assets/index.json": []byte(`{}`),
-	}
-	proj := newProjectWithoutModTime(m)
-	s := New(proj, nil, fileMapGetter(m), &MockScheduler{})
+func newXGoUnitTestServer(t *testing.T, source string) *Server {
+	t.Helper()
+	s := newTestServer(t, map[string][]byte{"main.xgo": []byte(source)})
 	s.workspaceRootFS.Importer = xgoUnitTestImporter{fallback: s.workspaceRootFS.Importer}
 	return s
 }


### PR DESCRIPTION
Move kwargs, units, decorators, autoclosures, and other general completion tests to plain XGo and the isolated classfile framework. Keep spx completion regressions together in their dedicated test file.

Allow tests to supply import package lists while preserving the default package data provider. Cover listing errors and missing documentation without loading embedded package data.

Cover cross-file kwargs, classfile callbacks, UTF-16 positions, overload metadata, embedded interfaces, and multiple implicit packages. Preserve unit completion result shapes and text edits. Retain coverage for unresolved overload arguments and partial spx type information with focused regressions.