### PR TITLE
fix(server): use project data for diagnostics

### DIFF
--- a/internal/server/compile.go
+++ b/internal/server/compile.go
@@ -3,20 +3,13 @@ package server
 import (
 	"fmt"
 	gotypes "go/types"
-	"iter"
 	"path"
 	"slices"
 	"strings"
 	"sync"
 
-	"github.com/goplus/gogen"
 	"github.com/goplus/xgo/ast"
-	"github.com/goplus/xgo/scanner"
 	"github.com/goplus/xgo/token"
-	"github.com/goplus/xgo/x/typesutil"
-	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
-	"github.com/goplus/xgolsw/internal/analysis/passes/inspect"
-	"github.com/goplus/xgolsw/internal/analysis/protocol"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/goplus/xgolsw/xgo"
 	"github.com/goplus/xgolsw/xgo/types"
@@ -32,6 +25,7 @@ var errNoMainSpxFile = errors.New("no valid main.spx file found in main package"
 // the compile process.
 type compileResult struct {
 	definitionContext
+	diagnosticResult
 
 	// mainSpxFile is the main.spx file path.
 	mainSpxFile string
@@ -51,16 +45,6 @@ type compileResult struct {
 
 	// spxSpriteResourceAutoBindings stores spx sprite resource auto-bindings.
 	spxSpriteResourceAutoBindings map[gotypes.Object]struct{}
-
-	// diagnostics stores diagnostic messages for each document.
-	diagnostics map[DocumentURI][]Diagnostic
-
-	// seenDiagnostics stores already reported diagnostics to avoid duplicates.
-	seenDiagnostics map[DocumentURI]map[string]struct{}
-
-	// hasErrorSeverityDiagnostic is true if the compile result has any
-	// diagnostics with error severity.
-	hasErrorSeverityDiagnostic bool
 }
 
 // newCompileResult creates a new [compileResult].
@@ -73,7 +57,7 @@ func newCompileResult(proj *xgo.Project, lookupPkgDoc func(string) (*pkgdoc.PkgD
 		},
 		spxSpriteTypes:                make(map[gotypes.Type]struct{}),
 		spxSpriteResourceAutoBindings: make(map[gotypes.Object]struct{}),
-		diagnostics:                   make(map[DocumentURI][]Diagnostic),
+		diagnosticResult:              newDiagnosticResult(),
 	}
 }
 
@@ -165,32 +149,6 @@ func (r *compileResult) addSpxResourceRef(ref SpxResourceRef) {
 	r.spxResourceRefs = append(r.spxResourceRefs, ref)
 }
 
-// addDiagnostics adds diagnostics to the compile result.
-func (r *compileResult) addDiagnostics(documentURI DocumentURI, diags ...Diagnostic) {
-	if r.seenDiagnostics == nil {
-		r.seenDiagnostics = make(map[DocumentURI]map[string]struct{})
-	}
-	seenDiagnostics := r.seenDiagnostics[documentURI]
-	if seenDiagnostics == nil {
-		seenDiagnostics = make(map[string]struct{})
-		r.seenDiagnostics[documentURI] = seenDiagnostics
-	}
-
-	r.diagnostics[documentURI] = slices.Grow(r.diagnostics[documentURI], len(diags))
-	for _, diag := range diags {
-		fingerprint := fmt.Sprintf("%d\n%v\n%s", diag.Severity, diag.Range, diag.Message)
-		if _, ok := seenDiagnostics[fingerprint]; ok {
-			continue
-		}
-		seenDiagnostics[fingerprint] = struct{}{}
-
-		r.diagnostics[documentURI] = append(r.diagnostics[documentURI], diag)
-		if diag.Severity == SeverityError {
-			r.hasErrorSeverityDiagnostic = true
-		}
-	}
-}
-
 // compile compiles spx source files and returns compile result. It uses cached
 // result if available.
 func (s *Server) compile() (*compileResult, error) {
@@ -205,56 +163,28 @@ func (s *Server) compile() (*compileResult, error) {
 // compileAt compiles spx source files at the given snapshot and returns the
 // compile result.
 func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
-	var spxFiles []string
+	var hasSpxFile bool
 	for file := range snapshot.Files() {
 		if path.Ext(file) == ".spx" {
-			spxFiles = append(spxFiles, file)
+			hasSpxFile = true
+			break
 		}
 	}
-	if len(spxFiles) == 0 {
+	if !hasSpxFile {
 		return nil, errNoMainSpxFile
 	}
 
 	result := newCompileResult(snapshot, s.lookupPkgDoc)
-	for _, spxFile := range spxFiles {
-		documentURI := s.toDocumentURI(spxFile)
-		result.diagnostics[documentURI] = []Diagnostic{}
-
-		astFile, err := snapshot.ASTFile(spxFile)
-		if err != nil {
-			var (
-				errorList scanner.ErrorList
-				codeError *gogen.CodeError
-			)
-			if errors.As(err, &errorList) && astFile.Pos().IsValid() {
-				// Handle parse errors.
-				for _, e := range errorList {
-					result.addDiagnostics(documentURI, Diagnostic{
-						Severity: SeverityError,
-						Range:    RangeForASTFilePosition(result.proj, astFile, e.Pos),
-						Message:  s.translate(e.Msg),
-					})
-				}
-			} else if errors.As(err, &codeError) {
-				// Handle code generation errors.
-				result.addDiagnostics(documentURI, Diagnostic{
-					Severity: SeverityError,
-					Range:    RangeForPosEnd(result.proj, codeError.Pos, codeError.End),
-					Message:  codeError.Error(),
-				})
-			} else {
-				// Handle unknown errors (including recovered panics).
-				result.addDiagnostics(documentURI, Diagnostic{
-					Severity: SeverityError,
-					Message:  s.translate(fmt.Sprintf("failed to parse spx file: %v", err)),
-				})
-			}
-		}
-		if astFile == nil {
+	astPkg, err := s.collectPackageSyntaxDiagnostics(snapshot, &result.diagnosticResult)
+	if err != nil {
+		return nil, err
+	}
+	for filename, astFile := range astPkg.Files {
+		if path.Ext(filename) != ".spx" {
 			continue
 		}
 		if astFile.Name.Name != "main" && astFile.Pos().IsValid() {
-			result.addDiagnostics(documentURI, Diagnostic{
+			result.addDiagnostics(s.toDocumentURI(filename), Diagnostic{
 				Severity: SeverityError,
 				Range:    RangeForASTFileNode(result.proj, astFile, astFile.Name),
 				Message:  s.translate("package name must be main"),
@@ -262,8 +192,8 @@ func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
 			continue
 		}
 
-		if spxFileBaseName := path.Base(spxFile); spxFileBaseName == "main.spx" {
-			result.mainSpxFile = spxFile
+		if path.Base(filename) == "main.spx" {
+			result.mainSpxFile = filename
 		}
 	}
 	if result.mainSpxFile == "" {
@@ -273,33 +203,7 @@ func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
 		return result, nil
 	}
 
-	handleErr := func(err error) {
-		if typeErr, ok := err.(typesutil.Error); ok {
-			if !typeErr.Pos.IsValid() {
-				panic(fmt.Sprintf("unexpected nopos error: %s", typeErr.Msg))
-			}
-			position := typeErr.Fset.Position(typeErr.Pos)
-			documentURI := s.toDocumentURI(position.Filename)
-			result.addDiagnostics(documentURI, Diagnostic{
-				Severity: SeverityError,
-				Range:    RangeForPosEnd(result.proj, typeErr.Pos, typeErr.End),
-				Message:  typeErr.Msg,
-			})
-		}
-	}
-
-	typeInfo, err := snapshot.TypeInfo()
-	if err != nil {
-		switch err := err.(type) {
-		case errors.List:
-			for _, e := range err {
-				handleErr(e)
-			}
-		default:
-			handleErr(err)
-		}
-	}
-	astPkg, _ := snapshot.ASTPackage()
+	typeInfo := s.collectTypeDiagnostics(snapshot, &result.diagnosticResult)
 	result.enumInfo = newEnumInfo(astPkg, typeInfo)
 	pkg := typeInfo.Pkg
 
@@ -324,7 +228,7 @@ func (s *Server) compileAt(snapshot *xgo.Project) (*compileResult, error) {
 
 	s.inspectForSpxResourceSet(snapshot, result)
 	s.inspectForSpxResourceRefs(result)
-	s.inspectDiagnosticsAnalyzers(result)
+	s.inspectDiagnosticsAnalyzers(snapshot, &result.diagnosticResult, spxDiagnosticPass(result))
 
 	return result, nil
 }
@@ -362,89 +266,6 @@ func (s *Server) inspectForSpxResourceSet(snapshot *xgo.Project, result *compile
 		return
 	}
 	result.spxResourceSet = *spxResourceSet
-}
-
-// inspectDiagnosticsAnalyzers runs registered analyzers on each spx source file
-// and collects diagnostics.
-//
-// For each spx file in the main package, it:
-//  1. Creates an analysis pass with file-specific information
-//  2. Runs all registered analyzers on the file
-//  3. Collects diagnostics from analyzers
-//  4. Reports any analyzer errors as diagnostics
-//
-// Parameters:
-//   - result: The compilation result containing AST and type information
-//
-// The function updates result.diagnostics with any issues found by analyzers.
-// Diagnostic severity levels include:
-//   - Error: For analyzer failures or serious code issues
-//   - Warning: For potential problems that don't prevent compilation
-func (s *Server) inspectDiagnosticsAnalyzers(result *compileResult) {
-	proj := result.proj
-	fset := proj.Fset
-	typeInfo, _ := proj.TypeInfo()
-	if typeInfo == nil {
-		return
-	}
-	astPkg, _ := proj.ASTPackage()
-	if astPkg == nil {
-		return
-	}
-	propertyNamesCache := make(map[*gotypes.Named]map[string]struct{})
-	for spxFile, astFile := range astPkg.Files {
-		var diagnostics []Diagnostic
-		pass := &protocol.Pass{
-			Fset:      fset,
-			Files:     []*ast.File{astFile},
-			Pkg:       typeInfo.Pkg,
-			TypesInfo: typeInfo,
-			Report: func(d protocol.Diagnostic) {
-				diagnostics = append(diagnostics, Diagnostic{
-					Range:    RangeForPosEnd(proj, d.Pos, d.End),
-					Severity: SeverityError,
-					Message:  s.translate(d.Message),
-				})
-			},
-			ResultOf: map[*protocol.Analyzer]any{
-				inspect.Analyzer: inspector.New([]*ast.File{astFile}),
-			},
-			IsPropertyNameType: IsSpxPropertyNameType,
-			GetPropertyNamesForCall: func(call *ast.CallExpr) map[string]struct{} {
-				named := PropertyTargetNamedTypeForCall(typeInfo, call, spxFile, result.mainSpxFile)
-				if named == nil {
-					return nil
-				}
-				if names, ok := propertyNamesCache[named]; ok {
-					return names
-				}
-				names := make(map[string]struct{})
-				for property := range propertyObjects(named) {
-					names[property.Name] = struct{}{}
-				}
-				propertyNamesCache[named] = names
-				return names
-			},
-			ResolvedCallExprArgs: func(call *ast.CallExpr) iter.Seq[xgoutil.ResolvedCallExprArg] {
-				return resolvedCallExprArgs(result.proj, typeInfo, call)
-			},
-		}
-
-		for _, analyzer := range s.analyzers {
-			an := analyzer.Analyzer()
-			if _, err := an.Run(pass); err != nil {
-				diagnostics = append(diagnostics, Diagnostic{
-					Severity: SeverityError,
-					Message:  s.translate(fmt.Sprintf("analyzer %q failed: %v", an.Name, err)),
-				})
-			}
-		}
-
-		if len(diagnostics) > 0 {
-			documentURI := s.toDocumentURI(spxFile)
-			result.addDiagnostics(documentURI, diagnostics...)
-		}
-	}
 }
 
 // inspectForSpxResourceRefs inspects for spx resource references in the code.

--- a/internal/server/compile_test.go
+++ b/internal/server/compile_test.go
@@ -15,6 +15,23 @@ import (
 	"github.com/goplus/xgolsw/xgo/types"
 )
 
+func TestServerCompileAt(t *testing.T) {
+	t.Run("UnregisteredClassfile", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{"main.spx": []byte("println 1\n")})
+		result, err := s.compileAt(s.getProj())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Empty(t, result.mainSpxFile)
+		assert.True(t, result.hasErrorSeverityDiagnostic)
+		assert.Equal(t, map[DocumentURI][]Diagnostic{
+			"file:///main.spx": {{
+				Severity: SeverityError,
+				Message:  "failed to parse source file: unknown file kind",
+			}},
+		}, result.diagnostics)
+	})
+}
+
 func TestSpxResourceReturnTypes(t *testing.T) {
 	fset := token.NewFileSet()
 	astFile, err := parser.ParseFile(fset, "main.spx", `
@@ -157,4 +174,36 @@ configure target = "OtherSprite", unknown = 9
 		require.Len(t, result.spxResourceRefs, 1)
 		assert.Equal(t, SpxResourceURI("spx://resources/sprites/OtherSprite"), result.spxResourceRefs[0].ID.URI())
 	})
+}
+
+func TestCompileResultIsInSpxEventHandler(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		content  string
+		position Position
+		want     bool
+	}{
+		{
+			name:     "OrdinaryCallback",
+			content:  "func invoke(fn func()) { fn() }\ninvoke => {\n    println 1\n}\n",
+			position: Position{Line: 2, Character: 8},
+		},
+		{
+			name:     "NestedOrdinaryCallback",
+			content:  "func invoke(fn func()) { fn() }\nonStart => {\n    invoke => {\n        println 1\n    }\n}\n",
+			position: Position{Line: 3, Character: 12},
+			want:     true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			files := map[string][]byte{"main.spx": []byte(tt.content), "assets/index.json": []byte(`{}`)}
+			s := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+			result, err := s.compile()
+			require.NoError(t, err)
+			require.Empty(t, result.diagnostics["file:///main.spx"])
+			astFile, err := result.proj.ASTFile("main.spx")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result.isInSpxEventHandler(PosAt(result.proj, astFile, tt.position)))
+		})
+	}
 }

--- a/internal/server/diagnostic.go
+++ b/internal/server/diagnostic.go
@@ -1,8 +1,161 @@
 package server
 
+import (
+	"fmt"
+	"iter"
+	"slices"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/scanner"
+	"github.com/goplus/xgo/x/typesutil"
+	"github.com/goplus/xgolsw/internal/analysis/ast/inspector"
+	"github.com/goplus/xgolsw/internal/analysis/passes/inspect"
+	"github.com/goplus/xgolsw/internal/analysis/protocol"
+	"github.com/goplus/xgolsw/xgo"
+	"github.com/goplus/xgolsw/xgo/types"
+	"github.com/goplus/xgolsw/xgo/xgoutil"
+	"github.com/qiniu/x/errors"
+)
+
+// diagnosticResult contains diagnostic messages for project documents.
+type diagnosticResult struct {
+	// diagnostics stores diagnostic messages for each document.
+	diagnostics map[DocumentURI][]Diagnostic
+
+	// seenDiagnostics stores already reported diagnostics to avoid duplicates.
+	seenDiagnostics map[DocumentURI]map[string]struct{}
+
+	// hasErrorSeverityDiagnostic is true if the result has any
+	// diagnostics with error severity.
+	hasErrorSeverityDiagnostic bool
+}
+
+// newDiagnosticResult creates an empty diagnostic result.
+func newDiagnosticResult() diagnosticResult {
+	return diagnosticResult{diagnostics: make(map[DocumentURI][]Diagnostic)}
+}
+
+// addDiagnostics adds diagnostics to the diagnostic result.
+func (r *diagnosticResult) addDiagnostics(documentURI DocumentURI, diags ...Diagnostic) {
+	if r.seenDiagnostics == nil {
+		r.seenDiagnostics = make(map[DocumentURI]map[string]struct{})
+	}
+	seenDiagnostics := r.seenDiagnostics[documentURI]
+	if seenDiagnostics == nil {
+		seenDiagnostics = make(map[string]struct{})
+		r.seenDiagnostics[documentURI] = seenDiagnostics
+	}
+
+	r.diagnostics[documentURI] = slices.Grow(r.diagnostics[documentURI], len(diags))
+	for _, diag := range diags {
+		fingerprint := fmt.Sprintf("%d\n%v\n%s", diag.Severity, diag.Range, diag.Message)
+		if _, ok := seenDiagnostics[fingerprint]; ok {
+			continue
+		}
+		seenDiagnostics[fingerprint] = struct{}{}
+
+		r.diagnostics[documentURI] = append(r.diagnostics[documentURI], diag)
+		if diag.Severity == SeverityError {
+			r.hasErrorSeverityDiagnostic = true
+		}
+	}
+}
+
+// diagnosticsAt collects pull diagnostics from project syntax, types, analyzers,
+// and framework-specific checks.
+func (s *Server) diagnosticsAt(proj *xgo.Project) (*diagnosticResult, error) {
+	if result, err := s.diagnosticsForSpx(proj); result != nil || err != nil {
+		return result, err
+	}
+	result := newDiagnosticResult()
+	if _, err := s.collectPackageSyntaxDiagnostics(proj, &result); err != nil {
+		return nil, err
+	}
+	s.collectTypeDiagnostics(proj, &result)
+	s.inspectDiagnosticsAnalyzers(proj, &result, nil)
+	return &result, nil
+}
+
+// collectPackageSyntaxDiagnostics collects parse errors, including those from
+// files without an AST, and returns the possibly incomplete AST package.
+func (s *Server) collectPackageSyntaxDiagnostics(proj *xgo.Project, result *diagnosticResult) (*ast.Package, error) {
+	astPkg, err := proj.ASTPackage()
+	if astPkg == nil {
+		return nil, err
+	}
+	for filename := range astPkg.Files {
+		s.collectSyntaxDiagnostics(proj, filename, result)
+	}
+	var errorList scanner.ErrorList
+	if errors.As(err, &errorList) {
+		for _, e := range errorList {
+			if _, ok := result.diagnostics[s.toDocumentURI(e.Pos.Filename)]; !ok {
+				s.collectSyntaxDiagnostics(proj, e.Pos.Filename, result)
+			}
+		}
+	}
+	return astPkg, nil
+}
+
+// collectSyntaxDiagnostics collects parse errors and returns the possibly incomplete AST.
+func (s *Server) collectSyntaxDiagnostics(proj *xgo.Project, filename string, result *diagnosticResult) *ast.File {
+	uri := s.toDocumentURI(filename)
+	result.diagnostics[uri] = []Diagnostic{}
+	astFile, err := proj.ASTFile(filename)
+	if err == nil {
+		return astFile
+	}
+	var errorList scanner.ErrorList
+	if errors.As(err, &errorList) && astFile != nil && astFile.Pos().IsValid() {
+		for _, e := range errorList {
+			result.addDiagnostics(uri, Diagnostic{
+				Severity: SeverityError,
+				Range:    RangeForASTFilePosition(proj, astFile, e.Pos),
+				Message:  s.translate(e.Msg),
+			})
+		}
+	} else {
+		result.addDiagnostics(uri, Diagnostic{
+			Severity: SeverityError,
+			Message:  s.translate(fmt.Sprintf("failed to parse source file: %v", err)),
+		})
+	}
+	return astFile
+}
+
+// collectTypeDiagnostics collects type errors and returns the project's type information.
+func (s *Server) collectTypeDiagnostics(proj *xgo.Project, result *diagnosticResult) *types.Info {
+	handleErr := func(err error) {
+		if typeErr, ok := err.(typesutil.Error); ok {
+			if !typeErr.Pos.IsValid() {
+				// Implicit import failures may have no source position to report.
+				return
+			}
+			position := typeErr.Fset.Position(typeErr.Pos)
+			result.addDiagnostics(s.toDocumentURI(position.Filename), Diagnostic{
+				Severity: SeverityError,
+				Range:    RangeForPosEnd(proj, typeErr.Pos, typeErr.End),
+				Message:  typeErr.Msg,
+			})
+		}
+	}
+	typeInfo, err := proj.TypeInfo()
+	if err != nil {
+		switch err := err.(type) {
+		case errors.List:
+			for _, e := range err {
+				handleErr(e)
+			}
+		default:
+			handleErr(err)
+		}
+	}
+	return typeInfo
+}
+
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification#textDocument_diagnostic
 func (s *Server) textDocumentDiagnostic(params *DocumentDiagnosticParams) (*DocumentDiagnosticReport, error) {
-	result, err := s.compile()
+	result, err := s.diagnosticsAt(s.getProjWithFile())
 	if err != nil {
 		return nil, err
 	}
@@ -10,29 +163,83 @@ func (s *Server) textDocumentDiagnostic(params *DocumentDiagnosticParams) (*Docu
 	return &DocumentDiagnosticReport{Value: RelatedFullDocumentDiagnosticReport{
 		FullDocumentDiagnosticReport: FullDocumentDiagnosticReport{
 			Kind:  string(DiagnosticFull),
-			Items: result.diagnostics[params.TextDocument.URI],
+			Items: append([]Diagnostic{}, result.diagnostics[params.TextDocument.URI]...),
 		},
 	}}, nil
 }
 
 // See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification#workspace_diagnostic
 func (s *Server) workspaceDiagnostic(params *WorkspaceDiagnosticParams) (*WorkspaceDiagnosticReport, error) {
-	result, err := s.compile()
+	result, err := s.diagnosticsAt(s.getProjWithFile())
 	if err != nil {
 		return nil, err
 	}
 
 	items := make([]WorkspaceDocumentDiagnosticReport, 0, len(result.diagnostics))
-	for file, fileDiags := range result.diagnostics {
+	for uri, diagnostics := range result.diagnostics {
 		items = append(items, WorkspaceDocumentDiagnosticReport{
 			Value: WorkspaceFullDocumentDiagnosticReport{
-				URI: DocumentURI(file),
+				URI: uri,
 				FullDocumentDiagnosticReport: FullDocumentDiagnosticReport{
 					Kind:  string(DiagnosticFull),
-					Items: fileDiags,
+					Items: diagnostics,
 				},
 			},
 		})
 	}
 	return &WorkspaceDiagnosticReport{Items: items}, nil
+}
+
+// inspectDiagnosticsAnalyzers runs registered analyzers on project source files.
+func (s *Server) inspectDiagnosticsAnalyzers(proj *xgo.Project, result *diagnosticResult, configurePass func(string, *protocol.Pass)) {
+	fset := proj.Fset
+	typeInfo, _ := proj.TypeInfo()
+	if typeInfo == nil {
+		return
+	}
+	astPkg, _ := proj.ASTPackage()
+	if astPkg == nil {
+		return
+	}
+	for filename, astFile := range astPkg.Files {
+		var diagnostics []Diagnostic
+		pass := &protocol.Pass{
+			Fset:      fset,
+			Files:     []*ast.File{astFile},
+			Pkg:       typeInfo.Pkg,
+			TypesInfo: typeInfo,
+			Report: func(d protocol.Diagnostic) {
+				diagnostics = append(diagnostics, Diagnostic{
+					Range:    RangeForPosEnd(proj, d.Pos, d.End),
+					Severity: SeverityError,
+					Message:  s.translate(d.Message),
+				})
+			},
+			ResultOf: map[*protocol.Analyzer]any{
+				inspect.Analyzer: inspector.New([]*ast.File{astFile}),
+			},
+			ResolvedCallExprArgs: func(call *ast.CallExpr) iter.Seq[xgoutil.ResolvedCallExprArg] {
+				return resolvedCallExprArgs(proj, typeInfo, call)
+			},
+		}
+
+		if configurePass != nil {
+			configurePass(filename, pass)
+		}
+
+		for _, analyzer := range s.analyzers {
+			an := analyzer.Analyzer()
+			if _, err := an.Run(pass); err != nil {
+				diagnostics = append(diagnostics, Diagnostic{
+					Severity: SeverityError,
+					Message:  s.translate(fmt.Sprintf("analyzer %q failed: %v", an.Name, err)),
+				})
+			}
+		}
+
+		if len(diagnostics) > 0 {
+			documentURI := s.toDocumentURI(filename)
+			result.addDiagnostics(documentURI, diagnostics...)
+		}
+	}
 }

--- a/internal/server/diagnostic_test.go
+++ b/internal/server/diagnostic_test.go
@@ -1,49 +1,21 @@
 package server
 
 import (
+	"io/fs"
 	"testing"
+
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/mod/modload"
+	"github.com/goplus/mod/xgomod"
+	"github.com/goplus/xgo/parser"
+	"github.com/goplus/xgo/x/typesutil"
+	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/goplus/xgolsw/protocol"
+	"github.com/goplus/xgolsw/xgo"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func newTestFileMap() map[string][]byte {
-	return map[string][]byte{
-		"main.spx": []byte(`
-`),
-		"MyAircraft.spx": []byte(`
-onStart => {
-	for {
-		wait 0.1
-		Bullet.clone
-		play "biu"
-		setXYpos mouseX, mouseY
-	}
-}
-`),
-		"Bullet.spx": []byte(`
-onCloned => {
-	setXYpos MyAircraft.xpos, MyAircraft.ypos+5
-	show
-	for {
-		wait 0.04
-		step 10
-		if touching(Edge) {
-			destroy
-		}
-	}
-}
-`),
-		"assets/index.json":                    []byte(`{"backdrops":[{"x":0,"y":0,"faceRight":0,"bitmapResolution":2,"name":"backdrop1","path":"backdrop1.png"}],"backdropIndex":0,"map":{"width":480,"height":360,"mode":"fillRatio"},"run":{"width":480,"height":360},"zorder":["MyAircraft","Bullet"]}`),
-		"assets/backdrop1.png":                 nil,
-		"assets/sprites/MyAircraft/index.json": []byte(`{"heading":90,"x":-14.502367071209733,"y":-151.76923076923077,"size":0.45,"rotationStyle":"normal","costumeIndex":0,"visible":true,"isDraggable":false,"pivot":{"x":0,"y":0},"costumes":[{"x":98,"y":122,"faceRight":0,"bitmapResolution":2,"name":"hero","path":"hero.png"}],"fAnimations":{},"animBindings":{}}`),
-		"assets/sprites/MyAircraft/hero.png":   nil,
-		"assets/sprites/Bullet/index.json":     []byte(`{"heading":0,"x":230,"y":185,"size":0.65,"rotationStyle":"normal","costumeIndex":0,"visible":false,"isDraggable":false,"pivot":{"x":0,"y":0},"costumes":[{"x":8,"y":20,"faceRight":90,"bitmapResolution":2,"name":"bullet","path":"bullet.png"}],"fAnimations":{},"animBindings":{}}`),
-		"assets/sprites/Bullet/bullet.png":     nil,
-		"assets/sounds/biu/index.json":         []byte(`{"rate":0,"sampleCount":0,"path":"biu.wav"}`),
-		"assets/sounds/biu/biu.wav":            nil,
-	}
-}
 
 func requireRelatedFullDocumentDiagnosticReport(t *testing.T, report *DocumentDiagnosticReport) RelatedFullDocumentDiagnosticReport {
 	t.Helper()
@@ -63,9 +35,13 @@ func requireWorkspaceFullDocumentDiagnosticReport(t *testing.T, item WorkspaceDo
 
 func TestServerTextDocumentDiagnostic(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		s := New(newProjectWithoutModTime(newTestFileMap()), nil, fileMapGetter(newTestFileMap()), &MockScheduler{})
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo":   []byte(`println "hello"`),
+			"first.xgo":  []byte(`var first = 1`),
+			"second.xgo": []byte(`var second = 2`),
+		})
 		params := &DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 		}
 
 		report, err := s.textDocumentDiagnostic(params)
@@ -79,17 +55,17 @@ func TestServerTextDocumentDiagnostic(t *testing.T) {
 
 	t.Run("EmbeddedWorkClassFieldInitializer", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(``),
-			"Bar.spx":  []byte(``),
-			"Foo.spx": []byte(`var (
+			"main_fixture.gox": []byte(``),
+			"Bar_fixture.gox":  []byte(``),
+			"Foo_fixture.gox": []byte(`var (
 	others = [Bar]
 )
 `),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///Foo.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///Foo_fixture.gox"},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, report)
@@ -100,7 +76,7 @@ func TestServerTextDocumentDiagnostic(t *testing.T) {
 
 	t.Run("LocalEnum", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`func check() {
+			"main.xgo": []byte(`func check() {
 	type Permission const (
 		Read = 1 << iota
 		Write
@@ -109,12 +85,11 @@ func TestServerTextDocumentDiagnostic(t *testing.T) {
 	println(permission)
 }
 `),
-			"assets/index.json": []byte(`{}`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, report)
@@ -123,47 +98,16 @@ func TestServerTextDocumentDiagnostic(t *testing.T) {
 		assert.Empty(t, fullReport.Items)
 	})
 
-	t.Run("FuncDecoratorResourceArgument", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`func withSound(sound SoundName, fn func()) {
-	fn()
-}
-
-@withSound("Missing")
-func run() {
-}
-`),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-
-		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
-		assert.Contains(t, fullReport.Items, Diagnostic{
-			Severity: SeverityError,
-			Message:  `sound resource "Missing" not found`,
-			Range: Range{
-				Start: Position{Line: 4, Character: 11},
-				End:   Position{Line: 4, Character: 20},
-			},
-		})
-	})
-
 	t.Run("ParseError", func(t *testing.T) {
-		fileMap := newTestFileMap()
-		fileMap["main.spx"] = []byte(`
+		fileMap := map[string][]byte{}
+		fileMap["main.xgo"] = []byte(`
 // Invalid syntax, missing closing parenthesis
 var (
 	Foobar string
 `)
-		s := New(newProjectWithoutModTime(fileMap), nil, fileMapGetter(fileMap), &MockScheduler{})
+		s := newTestServer(t, fileMap)
 		params := &DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 		}
 
 		report, err := s.textDocumentDiagnostic(params)
@@ -192,9 +136,9 @@ var (
 	})
 
 	t.Run("TypeError", func(t *testing.T) {
-		fileMap := newTestFileMap()
+		fileMap := map[string][]byte{}
 		// case for https://github.com/goplus/xgolsw/issues/163
-		fileMap["main.spx"] = []byte(`
+		fileMap["main_fixture.gox"] = []byte(`
 func calcPos() (posX float64, posY float64) {
 	return 1.0, 1.0
 }
@@ -204,9 +148,9 @@ onStart => {
 	x, y = calcPos()
 }
 `)
-		s := New(newProjectWithoutModTime(fileMap), nil, fileMapGetter(fileMap), &MockScheduler{})
+		s := newTestServer(t, fileMap)
 		params := &DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
 
 		report, err := s.textDocumentDiagnostic(params)
@@ -226,16 +170,16 @@ onStart => {
 	})
 
 	t.Run("MissingReturn", func(t *testing.T) {
-		fileMap := newTestFileMap()
-		fileMap["main.spx"] = []byte(`
+		fileMap := map[string][]byte{}
+		fileMap["main.xgo"] = []byte(`
 func getValue() int {
 	var x = 1
 	x++
 }
 `)
-		s := New(newProjectWithoutModTime(fileMap), nil, fileMapGetter(fileMap), &MockScheduler{})
+		s := newTestServer(t, fileMap)
 		params := &DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 		}
 
 		report, err := s.textDocumentDiagnostic(params)
@@ -254,10 +198,10 @@ func getValue() int {
 		})
 	})
 
-	t.Run("NonSpxFile", func(t *testing.T) {
-		fileMap := newTestFileMap()
-		fileMap["main.xgo"] = []byte(`echo "Hello, XGo!"`)
-		s := New(newProjectWithoutModTime(fileMap), nil, fileMapGetter(fileMap), &MockScheduler{})
+	t.Run("PlainXGo", func(t *testing.T) {
+		fileMap := map[string][]byte{}
+		fileMap["main.xgo"] = []byte(`println "Hello, XGo!"`)
+		s := newTestServer(t, fileMap)
 		params := &DocumentDiagnosticParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 		}
@@ -271,35 +215,14 @@ func getValue() int {
 		assert.Empty(t, fullReport.Items)
 	})
 
-	t.Run("NonMainPackageDecl", func(t *testing.T) {
-		fileMap := newTestFileMap()
-		fileMap["main.spx"] = []byte("package nonmain")
-		s := New(newProjectWithoutModTime(fileMap), nil, fileMapGetter(fileMap), &MockScheduler{})
-		params := &DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-		}
-
-		report, err := s.textDocumentDiagnostic(params)
-		require.NoError(t, err)
-		require.NotNil(t, report)
-
-		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
-		assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-		require.Len(t, fullReport.Items, 1)
-		assert.Contains(t, fullReport.Items, Diagnostic{
-			Severity: SeverityError,
-			Message:  "package name must be main",
-			Range: Range{
-				Start: Position{Line: 0, Character: 8},
-				End:   Position{Line: 0, Character: 15},
-			},
-		})
-	})
-
 	t.Run("FileNotFound", func(t *testing.T) {
-		s := New(newProjectWithoutModTime(newTestFileMap()), nil, fileMapGetter(newTestFileMap()), &MockScheduler{})
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo":   []byte(`println "hello"`),
+			"first.xgo":  []byte(`var first = 1`),
+			"second.xgo": []byte(`var second = 2`),
+		})
 		params := &DocumentDiagnosticParams{
-			TextDocument: TextDocumentIdentifier{URI: "file:///notexist.spx"},
+			TextDocument: TextDocumentIdentifier{URI: "file:///notexist.xgo"},
 		}
 
 		report, err := s.textDocumentDiagnostic(params)
@@ -314,7 +237,11 @@ func getValue() int {
 
 func TestServerWorkspaceDiagnostic(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
-		s := New(newProjectWithoutModTime(newTestFileMap()), nil, fileMapGetter(newTestFileMap()), &MockScheduler{})
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo":   []byte(`println "hello"`),
+			"first.xgo":  []byte(`var first = 1`),
+			"second.xgo": []byte(`var second = 2`),
+		})
 
 		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
 		require.NoError(t, err)
@@ -329,23 +256,21 @@ func TestServerWorkspaceDiagnostic(t *testing.T) {
 			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
 			assert.Empty(t, fullReport.Items)
 		}
-		assert.Contains(t, foundFiles, "main.spx")
-		assert.Contains(t, foundFiles, "MyAircraft.spx")
-		assert.Contains(t, foundFiles, "Bullet.spx")
+		assert.Contains(t, foundFiles, "main.xgo")
+		assert.Contains(t, foundFiles, "first.xgo")
+		assert.Contains(t, foundFiles, "second.xgo")
 	})
 
 	t.Run("ParseError", func(t *testing.T) {
 		m := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 // Invalid syntax, missing closing parenthesis
 var (
 	Foobar string
 `),
-			"MyAircraft.spx":                       []byte(`var x int`),
-			"assets/index.json":                    []byte(`{}`),
-			"assets/sprites/MyAircraft/index.json": []byte(`{}`),
+			"first.xgo": []byte(`var x int`),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, m)
 
 		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
 		require.NoError(t, err)
@@ -353,7 +278,7 @@ var (
 		assert.Len(t, report.Items, 2)
 		for _, item := range report.Items {
 			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			if fullReport.URI == "file:///main.spx" {
+			if fullReport.URI == "file:///main.xgo" {
 				require.Len(t, fullReport.Items, 2)
 				assert.Contains(t, fullReport.Items, Diagnostic{
 					Severity: SeverityError,
@@ -378,563 +303,287 @@ var (
 	})
 
 	t.Run("EmptyWorkspace", func(t *testing.T) {
-		s := New(newProjectWithoutModTime(map[string][]byte{}), nil, fileMapGetter(map[string][]byte{}), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.EqualError(t, err, "no valid main.spx file found in main package")
-		require.Nil(t, report)
-	})
-
-	t.Run("SoundResourceNotFound", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-play "Sound1"
-`),
-			"MySprite.spx": []byte(`
-const ConstSoundName = "ConstSoundName"
-var (
-	VarSoundName string
-)
-VarSoundName = "VarSoundName"
-onStart => {
-	play ""
-	play ConstSoundName
-	play "LiteralSoundName"
-	play VarSoundName
-	play "Sound1"
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, nil)
 
 		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
 		require.NoError(t, err)
 		require.NotNil(t, report)
-		assert.Len(t, report.Items, 2)
-		for _, item := range report.Items {
-			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-			switch fullReport.URI {
-			case "file:///main.spx":
-				require.Len(t, fullReport.Items, 1)
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `sound resource "Sound1" not found`,
-					Range: Range{
-						Start: Position{Line: 1, Character: 5},
-						End:   Position{Line: 1, Character: 13},
-					},
-				})
-			case "file:///MySprite.spx":
-				require.Len(t, fullReport.Items, 4)
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  "sound resource name cannot be empty",
-					Range: Range{
-						Start: Position{Line: 7, Character: 6},
-						End:   Position{Line: 7, Character: 8},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `sound resource "ConstSoundName" not found`,
-					Range: Range{
-						Start: Position{Line: 8, Character: 6},
-						End:   Position{Line: 8, Character: 20},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `sound resource "LiteralSoundName" not found`,
-					Range: Range{
-						Start: Position{Line: 9, Character: 6},
-						End:   Position{Line: 9, Character: 24},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `sound resource "Sound1" not found`,
-					Range: Range{
-						Start: Position{Line: 11, Character: 6},
-						End:   Position{Line: 11, Character: 14},
-					},
-				})
-			default:
-				assert.Empty(t, fullReport.Items)
-			}
-		}
+		assert.Equal(t, []WorkspaceDocumentDiagnosticReport{}, report.Items)
 	})
-
-	t.Run("SoundResourceNotFoundInKwargs", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Options struct {
-	Sound SoundName
 }
 
-var client Client
+func TestServerGetDiagnostics(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		content string
+		want    []Diagnostic
+	}{
 
-func configure(opts Options?) {}
-
-func configureMap(opts map[string]SoundName?) {}
-
-type Player interface {
-	Sound(sound SoundName) Player
-}
-
-type Client struct{}
-
-func (c Client) Player() Player { return nil }
-
-func (c Client) play(params Player?) {}
-
-onStart => {
-	configure sound = "MissingStructSound"
-	configureMap sound = "MissingMapSound"
-	client.play sound = "MissingInterfaceSound"
-}
-`),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-		require.Len(t, report.Items, 1)
-		fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, report.Items[0])
-		require.Len(t, fullReport.Items, 3)
-		assert.Contains(t, fullReport.Items, Diagnostic{
+		{name: "IncompletePackage", content: "package", want: []Diagnostic{{
 			Severity: SeverityError,
-			Message:  `sound resource "MissingStructSound" not found`,
-			Range: Range{
-				Start: Position{Line: 22, Character: 19},
-				End:   Position{Line: 22, Character: 39},
-			},
+			Message:  "failed to parse source file: main.xgo:1:8: expected ';', found 'EOF' (and 1 more errors)",
+		}}},
+		{name: "NoError", content: "println 1\n", want: []Diagnostic{}},
+		{name: "UndefinedImport", content: "fmt.println \"hello\"\n", want: []Diagnostic{{
+			Severity: SeverityError, Message: "undefined: fmt",
+			Range: Range{Start: Position{}, End: Position{Character: 3}},
+		}}},
+		{name: "SyntaxError", content: "var (\n    x int\n", want: []Diagnostic{
+			{Severity: SeverityError, Message: "expected ')', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+			{Severity: SeverityError, Message: "expected ';', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+		}},
+		{name: "UTF16SyntaxError", content: "var (\n    x int // \U0001f600\n", want: []Diagnostic{
+			{Severity: SeverityError, Message: "expected ')', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 15}, End: Position{Line: 1, Character: 15}}},
+			{Severity: SeverityError, Message: "expected ';', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 15}, End: Position{Line: 1, Character: 15}}},
+		}},
+		{name: "MultipleTypeErrors", content: "var x int = \"string\"\nvar y bool = 42\n", want: []Diagnostic{
+			{Severity: SeverityError, Message: "cannot use \"string\" (type untyped string) as type int in assignment", Range: Range{Start: Position{Character: 12}, End: Position{Character: 20}}},
+			{Severity: SeverityError, Message: "cannot use 42 (type untyped int) as type bool in assignment", Range: Range{Start: Position{Line: 1, Character: 13}, End: Position{Line: 1, Character: 15}}},
+		}},
+		{name: "UTF16", content: "println \"\U0001f600\", missing\n", want: []Diagnostic{{
+			Severity: SeverityError, Message: "undefined: missing",
+			Range: Range{Start: Position{Character: 14}, End: Position{Character: 21}},
+		}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.content)})
+			diagnostics := s.getDiagnostics("main.xgo")
+			assert.ElementsMatch(t, tt.want, diagnostics)
+			report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}})
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, requireRelatedFullDocumentDiagnosticReport(t, report).Items)
 		})
-		assert.Contains(t, fullReport.Items, Diagnostic{
-			Severity: SeverityError,
-			Message:  `sound resource "MissingMapSound" not found`,
-			Range: Range{
-				Start: Position{Line: 23, Character: 22},
-				End:   Position{Line: 23, Character: 39},
-			},
-		})
-		assert.Contains(t, fullReport.Items, Diagnostic{
-			Severity: SeverityError,
-			Message:  `sound resource "MissingInterfaceSound" not found`,
-			Range: Range{
-				Start: Position{Line: 24, Character: 21},
-				End:   Position{Line: 24, Character: 44},
-			},
-		})
-	})
-
-	t.Run("SoundResourceNotFoundInOverloadKwargs", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Worker struct{}
-
-type Options struct {
-	Sound SoundName
+	}
 }
 
-var worker Worker
-
-func (w *Worker) playSound(opts Options?) {}
-
-func (Worker).play = (
-	(Worker).playSound
-)
-
-onStart => {
-	worker.play sound = "MissingOverloadSound"
-}
-`),
-			"assets/index.json": []byte(`{}`),
+func TestServerDiagnosticsAt(t *testing.T) {
+	t.Run("UnavailableFramework", func(t *testing.T) {
+		files := map[string][]byte{
+			"main_fixture.gox": []byte("println 1\n"),
+			"broken.xgo":       []byte("var (\n    x int\n"),
 		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+		s := newTestServer(t, files)
+		proj := s.getProj()
+		importer := proj.Importer
+		proj.Importer = completionTestImporter{Importer: importer, unavailablePath: testframework.PkgPath}
+		_, err := proj.TypeInfo()
+		var typeErr typesutil.Error
+		require.ErrorAs(t, err, &typeErr)
+		require.False(t, typeErr.Pos.IsValid())
+		require.Equal(t, fs.ErrNotExist.Error(), typeErr.Msg)
 
+		want := map[DocumentURI][]Diagnostic{
+			"file:///main_fixture.gox": {},
+			"file:///broken.xgo": {
+				{Severity: SeverityError, Message: "expected ')', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+				{Severity: SeverityError, Message: "expected ';', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+			},
+		}
+		for filename := range files {
+			assert.Equal(t, want[s.toDocumentURI(filename)], s.getDiagnostics(filename))
+		}
+		replier := newMockReplier()
+		s.replier = replier
+		require.NoError(t, s.didOpen(&DidOpenTextDocumentParams{
+			TextDocument: protocol.TextDocumentItem{
+				URI: "file:///main_fixture.gox", Version: 1, Text: string(files["main_fixture.gox"]),
+			},
+		}))
+		assert.Equal(t, []Diagnostic{}, requirePublishedDiagnostics(t, replier, "file:///main_fixture.gox"))
+		for uri, diagnostics := range want {
+			report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: uri}})
+			require.NoError(t, err)
+			assert.Equal(t, diagnostics, requireRelatedFullDocumentDiagnosticReport(t, report).Items)
+		}
 		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
 		require.NoError(t, err)
-		require.NotNil(t, report)
-		require.Len(t, report.Items, 1)
-		fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, report.Items[0])
-		require.Len(t, fullReport.Items, 1)
-		assert.Contains(t, fullReport.Items, Diagnostic{
-			Severity: SeverityError,
-			Message:  `sound resource "MissingOverloadSound" not found`,
-			Range: Range{
-				Start: Position{Line: 16, Character: 21},
-				End:   Position{Line: 16, Character: 43},
-			},
-		})
-	})
-
-	t.Run("PropertyNameNotFoundInOverloadKwargs", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-type Worker struct{}
-
-type Options struct {
-	Name PropertyName
-}
-
-var worker Worker
-
-func (w *Worker) configureOptions(opts Options?) {}
-
-func (Worker).configure = (
-	(Worker).configureOptions
-)
-
-onStart => {
-	worker.configure name = "unknownProperty"
-}
-`),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-		require.Len(t, report.Items, 1)
-		fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, report.Items[0])
-		require.Len(t, fullReport.Items, 1)
-		assert.Contains(t, fullReport.Items, Diagnostic{
-			Severity: SeverityError,
-			Message:  `unknown property "unknownProperty"`,
-			Range: Range{
-				Start: Position{Line: 16, Character: 25},
-				End:   Position{Line: 16, Character: 42},
-			},
-		})
-	})
-
-	t.Run("BackdropResourceNotFound", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onBackdrop "", func() {}
-onBackdrop "NonExistentBackdrop", func() {}
-`),
-			"MySprite.spx": []byte(`
-const ConstBackdropName = "ConstBackdropName"
-var VarBackdropName string
-VarBackdropName = "VarBackdropName"
-onStart => {
-	onBackdrop ConstBackdropName, func() {}
-	onBackdrop "LiteralBackdropName", func() {}
-	onBackdrop VarBackdropName, func() {}
-}
-`),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-		assert.Len(t, report.Items, 2)
+		require.Len(t, report.Items, len(want))
+		got := make(map[DocumentURI][]Diagnostic)
 		for _, item := range report.Items {
-			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-			switch fullReport.URI {
-			case "file:///main.spx":
-				require.Len(t, fullReport.Items, 2)
-				assert.Contains(t, fullReport.Items, Diagnostic{
+			full := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			got[full.URI] = full.Items
+		}
+		assert.Equal(t, want, got)
+
+		// A later edit must refresh diagnostics after the framework becomes available.
+		proj.Importer = importer
+		require.NoError(t, s.didChange(&DidChangeTextDocumentParams{
+			TextDocument: protocol.VersionedTextDocumentIdentifier{
+				TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///broken.xgo"}, Version: 1,
+			},
+			ContentChanges: []protocol.TextDocumentContentChangeEvent{{Text: "var value int = \"bad\"\n"}},
+		}))
+		wantTypeError := []Diagnostic{{
+			Severity: SeverityError, Message: "cannot use \"bad\" (type untyped string) as type int in assignment",
+			Range: Range{Start: Position{Character: 16}, End: Position{Character: 21}},
+		}}
+		assert.Equal(t, wantTypeError, requirePublishedDiagnostics(t, replier, "file:///broken.xgo"))
+		documentReport, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: "file:///broken.xgo"}})
+		require.NoError(t, err)
+		assert.Equal(t, wantTypeError, requireRelatedFullDocumentDiagnosticReport(t, documentReport).Items)
+	})
+
+	t.Run("NoAST", func(t *testing.T) {
+		for _, tt := range []struct {
+			name            string
+			withParsedFiles bool
+		}{
+			{name: "OnlyFailedFiles"},
+			{name: "MixedFiles", withParsedFiles: true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				files := map[string][]byte{
+					"main.spx":           []byte("println 1\n"),
+					"nested/Unknown.spx": []byte("println 2\n"),
+					"notes.txt":          []byte("not source code"),
+				}
+				parseFailure := []Diagnostic{{
 					Severity: SeverityError,
-					Message:  "backdrop resource name cannot be empty",
-					Range: Range{
-						Start: Position{Line: 1, Character: 11},
-						End:   Position{Line: 1, Character: 13},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `backdrop resource "NonExistentBackdrop" not found`,
-					Range: Range{
-						Start: Position{Line: 2, Character: 11},
-						End:   Position{Line: 2, Character: 32},
-					},
-				})
-			case "file:///MySprite.spx":
-				require.Len(t, fullReport.Items, 2)
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `backdrop resource "ConstBackdropName" not found`,
-					Range: Range{
-						Start: Position{Line: 5, Character: 12},
-						End:   Position{Line: 5, Character: 29},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `backdrop resource "LiteralBackdropName" not found`,
-					Range: Range{
-						Start: Position{Line: 6, Character: 12},
-						End:   Position{Line: 6, Character: 33},
-					},
-				})
+					Message:  "failed to parse source file: unknown file kind",
+				}}
+				want := map[DocumentURI][]Diagnostic{
+					"file:///main.spx":           parseFailure,
+					"file:///nested/Unknown.spx": parseFailure,
+				}
+				if tt.withParsedFiles {
+					files["helper.xgo"] = []byte("var value = 1\n")
+					files["broken.xgo"] = []byte("var (\n    x int\n")
+					want["file:///helper.xgo"] = []Diagnostic{}
+					want["file:///broken.xgo"] = []Diagnostic{
+						{Severity: SeverityError, Message: "expected ')', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+						{Severity: SeverityError, Message: "expected ';', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+					}
+				}
+				s := newTestServer(t, files)
+				replier := newMockReplier()
+				s.replier = replier
+				for _, filename := range []string{"main.spx", "nested/Unknown.spx"} {
+					astFile, err := s.getProj().ASTFile(filename)
+					require.ErrorIs(t, err, parser.ErrUnknownFileKind)
+					require.Nil(t, astFile)
+					uri := s.toDocumentURI(filename)
+					require.NoError(t, s.didOpen(&DidOpenTextDocumentParams{
+						TextDocument: protocol.TextDocumentItem{URI: uri, Version: 1, Text: string(files[filename])},
+					}))
+					assert.Equal(t, parseFailure, requirePublishedDiagnostics(t, replier, uri))
+				}
+				for uri, diagnostics := range want {
+					report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: uri}})
+					require.NoError(t, err)
+					full := requireRelatedFullDocumentDiagnosticReport(t, report)
+					assert.Equal(t, string(DiagnosticFull), full.Kind)
+					assert.Equal(t, diagnostics, full.Items)
+				}
+				report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+				require.NoError(t, err)
+				require.Len(t, report.Items, len(want))
+				got := make(map[DocumentURI][]Diagnostic)
+				for _, item := range report.Items {
+					full := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+					assert.Equal(t, string(DiagnosticFull), full.Kind)
+					got[full.URI] = full.Items
+				}
+				assert.Equal(t, want, got)
+			})
+		}
+	})
+
+	t.Run("UnavailableAST", func(t *testing.T) {
+		s := newTestServer(t, nil)
+		s.workspaceRootFS = xgo.NewProject(nil, nil, 0)
+		documentReport, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}})
+		require.ErrorIs(t, err, xgo.ErrUnknownCacheKind)
+		assert.Nil(t, documentReport)
+		workspaceReport, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.ErrorIs(t, err, xgo.ErrUnknownCacheKind)
+		assert.Nil(t, workspaceReport)
+	})
+
+	t.Run("Classfiles", func(t *testing.T) {
+		for _, tt := range []struct {
+			name         string
+			filename     string
+			projectFile  string
+			spxExtension bool
+		}{
+			{name: "PlainXGo", filename: "main.xgo"},
+			{name: "LegacyXGo", filename: "main.gop"},
+			{name: "StandaloneClass", filename: "Record.gox"},
+			{name: "ProjectClass", filename: "main_fixture.gox"},
+			{name: "WorkClass", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox"},
+			{name: "OtherFrameworkWithSpxExtension", filename: "main.spx", spxExtension: true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				files := map[string][]byte{tt.filename: []byte("println missing\n")}
+				if tt.projectFile != "" {
+					files[tt.projectFile] = nil
+				}
+				s := newTestServer(t, files)
+				if tt.spxExtension {
+					s.workspaceRootFS.Mod = xgomod.New(modload.Module{
+						Opt: &modfile.File{Projects: []*modfile.Project{{
+							Ext: ".spx", FullExt: "main.spx", Class: "App", PkgPaths: []string{testframework.PkgPath},
+							Works: []*modfile.Class{{Ext: ".spx", Class: "Item", Embedded: true}},
+						}}},
+					})
+					require.NoError(t, s.workspaceRootFS.Mod.ImportClasses())
+				}
+				report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+				require.NoError(t, err)
+				require.Len(t, report.Items, len(files))
+				for _, item := range report.Items {
+					full := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+					assert.Equal(t, string(DiagnosticFull), full.Kind)
+					if full.URI == s.toDocumentURI(tt.filename) {
+						assert.Equal(t, []Diagnostic{{
+							Severity: SeverityError, Message: "undefined: missing",
+							Range: Range{Start: Position{Character: 8}, End: Position{Character: 15}},
+						}}, full.Items)
+					} else {
+						assert.Equal(t, []Diagnostic{}, full.Items)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("CrossFileTypeError", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{
+			"main.xgo":   []byte("println value()\n"),
+			"values.xgo": []byte("func value() int {\n    var number int = \"bad\"\n    return 1\n}\n"),
+			"notes.txt":  []byte("not source code"),
+		})
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.Len(t, report.Items, 2)
+		want := []Diagnostic{{
+			Severity: SeverityError, Message: "cannot use \"bad\" (type untyped string) as type int in assignment",
+			Range: Range{Start: Position{Line: 1, Character: 21}, End: Position{Line: 1, Character: 26}},
+		}}
+		for _, item := range report.Items {
+			full := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			switch full.URI {
+			case "file:///values.xgo":
+				assert.Equal(t, want, full.Items)
+			case "file:///main.xgo":
+				assert.Equal(t, []Diagnostic{}, full.Items)
 			default:
-				assert.Empty(t, fullReport.Items)
+				assert.Fail(t, "unexpected diagnostic document", "%s", full.URI)
 			}
 		}
+		diagnostics := s.getDiagnostics("main.xgo")
+		assert.Empty(t, diagnostics)
+		diagnostics = s.getDiagnostics("values.xgo")
+		assert.Equal(t, want, diagnostics)
 	})
 
-	t.Run("SpriteResourceNotFound", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-MySprite.say "hi"
-MySprite.touching "OtherSprite"
-`),
-			"MySprite.spx": []byte(`
-onStart => {
-	say "hi"
-	touching "OtherSprite"
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+	t.Run("Analyzer", func(t *testing.T) {
+		s := newTestServer(t, map[string][]byte{"main.xgo": []byte("values := [1, 2]\nvalues = append(values)\n")})
+		report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}})
 		require.NoError(t, err)
-		require.NotNil(t, report)
-		assert.Len(t, report.Items, 2)
-		for _, item := range report.Items {
-			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-			switch fullReport.URI {
-			case "file:///main.spx":
-				require.Len(t, fullReport.Items, 1)
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `sprite resource "OtherSprite" not found`,
-					Range: Range{
-						Start: Position{Line: 2, Character: 18},
-						End:   Position{Line: 2, Character: 31},
-					},
-				})
-			case "file:///MySprite.spx":
-				require.Len(t, fullReport.Items, 1)
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `sprite resource "OtherSprite" not found`,
-					Range: Range{
-						Start: Position{Line: 3, Character: 10},
-						End:   Position{Line: 3, Character: 23},
-					},
-				})
-			default:
-				assert.Empty(t, fullReport.Items)
-			}
-		}
-	})
-
-	t.Run("SpriteCostumeResourceNotFound", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-`),
-			"MySprite.spx": []byte(`
-onStart => {
-	setCostume ""
-	setCostume "NonExistentCostume"
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-		assert.Len(t, report.Items, 2)
-		for _, item := range report.Items {
-			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-			switch fullReport.URI {
-			case "file:///MySprite.spx":
-				require.Len(t, fullReport.Items, 2)
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  "sprite costume resource name cannot be empty",
-					Range: Range{
-						Start: Position{Line: 2, Character: 12},
-						End:   Position{Line: 2, Character: 14},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `costume resource "NonExistentCostume" not found in sprite "MySprite"`,
-					Range: Range{
-						Start: Position{Line: 3, Character: 12},
-						End:   Position{Line: 3, Character: 32},
-					},
-				})
-			default:
-				assert.Empty(t, fullReport.Items)
-			}
-		}
-	})
-
-	t.Run("SpriteAnimationResourceNotFound", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-`),
-			"MySprite.spx": []byte(`
-onStart => {
-	animate ""
-	animate "roll-in"
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-		assert.Len(t, report.Items, 2)
-		for _, item := range report.Items {
-			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-			switch fullReport.URI {
-			case "file:///MySprite.spx":
-				require.Len(t, fullReport.Items, 2)
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  "sprite animation resource name cannot be empty",
-					Range: Range{
-						Start: Position{Line: 2, Character: 9},
-						End:   Position{Line: 2, Character: 11},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `animation resource "roll-in" not found in sprite "MySprite"`,
-					Range: Range{
-						Start: Position{Line: 3, Character: 9},
-						End:   Position{Line: 3, Character: 18},
-					},
-				})
-			default:
-				assert.Empty(t, fullReport.Items)
-			}
-		}
-	})
-
-	t.Run("WidgetResourceNotFound", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-`),
-			"MySprite.spx": []byte(`
-const ConstWidgetName = "ConstWidgetName"
-var VarWidgetName string
-VarWidgetName = "VarWidgetName"
-onStart => {
-	getWidget Monitor, ""
-	getWidget Monitor, ConstWidgetName
-	getWidget Monitor, "LiteralWidgetName"
-	getWidget Monitor, VarWidgetName
-}
-`),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-		assert.Len(t, report.Items, 2)
-		for _, item := range report.Items {
-			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-			switch fullReport.URI {
-			case "file:///MySprite.spx":
-				require.Len(t, fullReport.Items, 3)
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  "widget resource name cannot be empty",
-					Range: Range{
-						Start: Position{Line: 5, Character: 20},
-						End:   Position{Line: 5, Character: 22},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `widget resource "ConstWidgetName" not found`,
-					Range: Range{
-						Start: Position{Line: 6, Character: 20},
-						End:   Position{Line: 6, Character: 35},
-					},
-				})
-				assert.Contains(t, fullReport.Items, Diagnostic{
-					Severity: SeverityError,
-					Message:  `widget resource "LiteralWidgetName" not found`,
-					Range: Range{
-						Start: Position{Line: 7, Character: 20},
-						End:   Position{Line: 7, Character: 39},
-					},
-				})
-			default:
-				assert.Empty(t, fullReport.Items)
-			}
-		}
-	})
-
-	t.Run("WithNonBasicTypeAliases", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-`),
-			"MySprite.spx": []byte(`
-import "image/color"
-
-onStart => {
-	touchingColor HSBA(0, 0, 0, 0)
-}
-`),
-			"assets/index.json":                  []byte(`{}`),
-			"assets/sprites/MySprite/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-		assert.Len(t, report.Items, 2)
-		for _, item := range report.Items {
-			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-			assert.Empty(t, fullReport.Items)
-		}
-	})
-
-	t.Run("OnKey", func(t *testing.T) {
-		m := map[string][]byte{
-			"main.spx": []byte(`
-onKey KeyLeft, => {}
-
-onKey [KeyRight, KeyUp, KeyDown], => {}
-
-`),
-			"assets/index.json": []byte(`{}`),
-		}
-		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
-
-		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
-		require.NoError(t, err)
-		require.NotNil(t, report)
-		assert.Len(t, report.Items, 1)
-		for _, item := range report.Items {
-			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
-			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
-			assert.Empty(t, fullReport.Items)
-		}
+		assert.Equal(t, []Diagnostic{{
+			Severity: SeverityError, Message: "append with no values",
+			Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 23}},
+		}}, requireRelatedFullDocumentDiagnosticReport(t, report).Items)
 	})
 }

--- a/internal/server/initialize_test.go
+++ b/internal/server/initialize_test.go
@@ -45,7 +45,8 @@ func stringsAsAny(values []string) []any {
 func TestServerInitialize(t *testing.T) {
 	t.Run("Capabilities", func(t *testing.T) {
 		replier := newMockReplier()
-		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		server := newTestServer(t, nil)
+		server.replier = replier
 		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{
 			XInitializeParams: protocol.XInitializeParams{
 				RootURI: "file:///workspace",
@@ -253,7 +254,8 @@ func TestServerInitialize(t *testing.T) {
 
 	t.Run("WorkspaceFolderRoot", func(t *testing.T) {
 		replier := newMockReplier()
-		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		server := newTestServer(t, nil)
+		server.replier = replier
 		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{
 			XInitializeParams: protocol.XInitializeParams{
 				RootURI: "file:///root-uri",
@@ -283,24 +285,25 @@ func TestServerInitialize(t *testing.T) {
 				name:        "UnixPath",
 				rootPath:    "/legacy-root",
 				wantRootURI: "file:///legacy-root/",
-				documentURI: "file:///legacy-root/main.spx",
+				documentURI: "file:///legacy-root/main.xgo",
 			},
 			{
 				name:        "WindowsDrivePath",
 				rootPath:    `C:\Users\me\proj`,
 				wantRootURI: "file:///C:/Users/me/proj/",
-				documentURI: "file:///C:/Users/me/proj/main.spx",
+				documentURI: "file:///C:/Users/me/proj/main.xgo",
 			},
 			{
 				name:        "WindowsUNCPath",
 				rootPath:    `\\server\share\proj`,
 				wantRootURI: "file://server/share/proj/",
-				documentURI: "file://server/share/proj/main.spx",
+				documentURI: "file://server/share/proj/main.xgo",
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				replier := newMockReplier()
-				server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+				server := newTestServer(t, nil)
+				server.replier = replier
 				call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{
 					XInitializeParams: protocol.XInitializeParams{
 						RootPath: tt.rootPath,
@@ -314,7 +317,7 @@ func TestServerInitialize(t *testing.T) {
 
 				path, err := server.fromDocumentURI(tt.documentURI)
 				require.NoError(t, err)
-				assert.Equal(t, "main.spx", path)
+				assert.Equal(t, "main.xgo", path)
 			})
 		}
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -460,6 +460,9 @@ func (s *Server) sendTelemetryEvent(data map[string]any) error {
 
 // publishDiagnostics sends diagnostic notifications to the client.
 func (s *Server) publishDiagnostics(uri DocumentURI, diagnostics []Diagnostic) error {
+	if diagnostics == nil {
+		diagnostics = []Diagnostic{}
+	}
 	params := &PublishDiagnosticsParams{
 		URI:         uri,
 		Diagnostics: diagnostics,

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -262,7 +262,8 @@ func requireResponseForID(t *testing.T, messages []jsonrpc2.Message, id jsonrpc2
 func TestHandleMessageInitialization(t *testing.T) {
 	t.Run("RequestBeforeInitialize", func(t *testing.T) {
 		replier := newMockReplier()
-		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		server := newTestServer(t, nil)
+		server.replier = replier
 		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("hover"), "textDocument/hover", HoverParams{})
 		require.NoError(t, err)
 		require.NoError(t, server.HandleMessage(call))
@@ -277,7 +278,8 @@ func TestHandleMessageInitialization(t *testing.T) {
 
 	t.Run("NotificationBeforeInitialize", func(t *testing.T) {
 		replier := newMockReplier()
-		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		server := newTestServer(t, nil)
+		server.replier = replier
 		notification, err := jsonrpc2.NewNotification("textDocument/didOpen", DidOpenTextDocumentParams{})
 		require.NoError(t, err)
 		require.NoError(t, server.HandleMessage(notification))
@@ -286,7 +288,8 @@ func TestHandleMessageInitialization(t *testing.T) {
 
 	t.Run("CancelRequestBeforeInitialize", func(t *testing.T) {
 		replier := newMockReplier()
-		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		server := newTestServer(t, nil)
+		server.replier = replier
 		notification, err := jsonrpc2.NewNotification("$/cancelRequest", CancelParams{ID: "initialize"})
 		require.NoError(t, err)
 		require.NoError(t, server.HandleMessage(notification))
@@ -296,7 +299,9 @@ func TestHandleMessageInitialization(t *testing.T) {
 	t.Run("CancelNotificationDuringInitialize", func(t *testing.T) {
 		replier := newMockReplier()
 		scheduler := newBlockingScheduler()
-		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), scheduler)
+		server := newTestServer(t, nil)
+		server.replier = replier
+		server.scheduler = scheduler
 		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize"), "initialize", InitializeParams{})
 		require.NoError(t, err)
 		require.NoError(t, server.HandleMessage(call))
@@ -320,7 +325,8 @@ func TestHandleMessageInitialization(t *testing.T) {
 
 	t.Run("ExitBeforeInitialize", func(t *testing.T) {
 		replier := newMockReplier()
-		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		server := newTestServer(t, nil)
+		server.replier = replier
 		notification, err := jsonrpc2.NewNotification("exit", nil)
 		require.NoError(t, err)
 		require.NoError(t, server.HandleMessage(notification))
@@ -329,7 +335,8 @@ func TestHandleMessageInitialization(t *testing.T) {
 
 	t.Run("InitializeOnlyOnce", func(t *testing.T) {
 		replier := newMockReplier()
-		server := New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		server := newTestServer(t, nil)
+		server.replier = replier
 		initializeServerForTest(t, server, replier)
 
 		call, err := jsonrpc2.NewCall(jsonrpc2.NewStringID("initialize-again"), "initialize", InitializeParams{})
@@ -354,7 +361,8 @@ func TestHandleMessageInitialization(t *testing.T) {
 			}
 			return server.HandleMessage(shutdownCall)
 		})
-		server = New(newProjectWithoutModTime(nil), replier, fileMapGetter(nil), &MockScheduler{})
+		server = newTestServer(t, nil)
+		server.replier = replier
 		initializeCall, err := jsonrpc2.NewCall(initializeID, "initialize", InitializeParams{})
 		require.NoError(t, err)
 		require.NoError(t, server.HandleMessage(initializeCall))
@@ -373,13 +381,14 @@ func TestHandleMessageInitialization(t *testing.T) {
 func TestServerCancellation(t *testing.T) {
 	t.Run("CancelRequest", func(t *testing.T) {
 		files := map[string][]byte{
-			"main.spx": []byte(`
+			"main.xgo": []byte(`
 var x = 100
-echo x
+println x
 `),
 		}
 		replier := newMockReplier()
-		s := New(newProjectWithoutModTime(files), replier, fileMapGetter(files), &MockScheduler{})
+		s := newTestServer(t, files)
+		s.replier = replier
 
 		call1, _ := jsonrpc2.NewCall(jsonrpc2.NewStringID("test-request-1"), "$/cancelRequest", &CancelParams{ID: "test-request-1"})
 		call2, _ := jsonrpc2.NewCall(jsonrpc2.NewStringID("test-request-2"), "$/cancelRequest", &CancelParams{ID: "test-request-2"})
@@ -426,10 +435,11 @@ echo x
 
 	t.Run("CancelRequestWithInvalidID", func(t *testing.T) {
 		files := map[string][]byte{
-			"main.spx": []byte(`var x = 100`),
+			"main.xgo": []byte(`var x = 100`),
 		}
-		replier := &mockReplier{}
-		s := New(newProjectWithoutModTime(files), replier, fileMapGetter(files), &MockScheduler{})
+		replier := newMockReplier()
+		s := newTestServer(t, files)
+		s.replier = replier
 
 		for _, tc := range []struct {
 			name string
@@ -449,15 +459,16 @@ echo x
 }
 
 func TestHandleMessageNotificationOrdering(t *testing.T) {
-	files := map[string][]byte{"main.spx": []byte("echo \"a\"\n")}
-	project := newProjectWithoutModTime(files)
-	project.PutFile("main.spx", &xgo.File{Content: files["main.spx"], Version: 1})
+	files := map[string][]byte{"main.xgo": []byte("println \"a\"\n")}
+	server := newTestServer(t, files)
+	project := server.getProj()
+	project.PutFile("main.xgo", &xgo.File{Content: files["main.xgo"], Version: 1})
 	replier := newMockReplier()
-	server := New(project, replier, fileMapGetter(files), &MockScheduler{})
+	server.replier = replier
 	initializeServerForTest(t, server, replier)
 	var changeCount int
 	t.Cleanup(func() {
-		// Finish background diagnostics before another test uses shared imported packages.
+		// Wait for every background diagnostic notification before the test ends.
 		require.Eventually(t, func() bool {
 			var diagnosticCount int
 			for _, message := range replier.getMessages() {
@@ -472,26 +483,26 @@ func TestHandleMessageNotificationOrdering(t *testing.T) {
 	for _, params := range []DidChangeTextDocumentParams{
 		{
 			TextDocument: protocol.VersionedTextDocumentIdentifier{
-				TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Version:                2,
 			},
 			ContentChanges: []protocol.TextDocumentContentChangeEvent{{
 				Range: &protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 7},
-					End:   protocol.Position{Line: 0, Character: 7},
+					Start: protocol.Position{Line: 0, Character: 10},
+					End:   protocol.Position{Line: 0, Character: 10},
 				},
 				Text: "b",
 			}},
 		},
 		{
 			TextDocument: protocol.VersionedTextDocumentIdentifier{
-				TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Version:                3,
 			},
 			ContentChanges: []protocol.TextDocumentContentChangeEvent{{
 				Range: &protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 8},
-					End:   protocol.Position{Line: 0, Character: 8},
+					Start: protocol.Position{Line: 0, Character: 11},
+					End:   protocol.Position{Line: 0, Character: 11},
 				},
 				Text: "c",
 			}},
@@ -503,9 +514,9 @@ func TestHandleMessageNotificationOrdering(t *testing.T) {
 		changeCount++
 	}
 
-	file, ok := project.File("main.spx")
+	file, ok := project.File("main.xgo")
 	require.True(t, ok)
-	assert.Equal(t, "echo \"abc\"\n", string(file.Content))
+	assert.Equal(t, "println \"abc\"\n", string(file.Content))
 	assert.Equal(t, 3, file.Version)
 }
 
@@ -533,12 +544,12 @@ func TestHandleMessageCall(t *testing.T) {
 			method: "textDocument/hover",
 			params: &HoverParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 					Position:     Position{Line: 2, Character: 1},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte(`
+				"main.xgo": []byte(`
 import (
 	"fmt"
 	"image"
@@ -554,12 +565,12 @@ fmt.Println("Hello, World!")
 			method: "textDocument/completion",
 			params: CompletionParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 1, Character: 8},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -568,12 +579,12 @@ fmt.Println("Hello, World!")
 			method: "textDocument/signatureHelp",
 			params: SignatureHelpParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 1, Character: 8},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho(x)"),
+				"main.xgo": []byte("var x = 100\nprintln(x)"),
 			},
 			msgNum: 2,
 		},
@@ -582,12 +593,12 @@ fmt.Println("Hello, World!")
 			method: "textDocument/declaration",
 			params: DeclarationParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 1, Character: 8},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -596,12 +607,12 @@ fmt.Println("Hello, World!")
 			method: "textDocument/definition",
 			params: DefinitionParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 1, Character: 8},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -610,12 +621,12 @@ fmt.Println("Hello, World!")
 			method: "textDocument/typeDefinition",
 			params: TypeDefinitionParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 1, Character: 8},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -624,12 +635,12 @@ fmt.Println("Hello, World!")
 			method: "textDocument/implementation",
 			params: ImplementationParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 1, Character: 8},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -638,15 +649,15 @@ fmt.Println("Hello, World!")
 			method: "textDocument/references",
 			params: ReferenceParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 1, Character: 8},
 				},
 				Context: ReferenceContext{
 					IncludeDeclaration: true,
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -655,12 +666,12 @@ fmt.Println("Hello, World!")
 			method: "textDocument/documentHighlight",
 			params: DocumentHighlightParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
-					Position:     Position{Line: 1, Character: 5},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 1, Character: 8},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -668,10 +679,10 @@ fmt.Println("Hello, World!")
 			name:   "TextDocumentDocumentLink",
 			method: "textDocument/documentLink",
 			params: DocumentLinkParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte(`import "fmt"`),
+				"main.xgo": []byte(`import "fmt"`),
 			},
 			msgNum: 2,
 		},
@@ -679,10 +690,10 @@ fmt.Println("Hello, World!")
 			name:   "TextDocumentDiagnostic",
 			method: "textDocument/diagnostic",
 			params: DocumentDiagnosticParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -691,7 +702,7 @@ fmt.Println("Hello, World!")
 			method: "workspace/diagnostic",
 			params: WorkspaceDiagnosticParams{},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -699,10 +710,10 @@ fmt.Println("Hello, World!")
 			name:   "TextDocumentFormatting",
 			method: "textDocument/formatting",
 			params: DocumentFormattingParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x=100\necho   x"),
+				"main.xgo": []byte("var x=100\nprintln   x"),
 			},
 			msgNum: 2,
 		},
@@ -711,12 +722,12 @@ fmt.Println("Hello, World!")
 			method: "textDocument/prepareRename",
 			params: PrepareRenameParams{
 				TextDocumentPositionParams: TextDocumentPositionParams{
-					TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 					Position:     Position{Line: 0, Character: 5},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -724,12 +735,12 @@ fmt.Println("Hello, World!")
 			name:   "TextDocumentRename",
 			method: "textDocument/rename",
 			params: RenameParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Position:     Position{Line: 0, Character: 5},
 				NewName:      "y",
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -737,10 +748,10 @@ fmt.Println("Hello, World!")
 			name:   "TextDocumentSemanticTokensFull",
 			method: "textDocument/semanticTokens/full",
 			params: SemanticTokensParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
@@ -748,63 +759,22 @@ fmt.Println("Hello, World!")
 			name:   "TextDocumentInlayHint",
 			method: "textDocument/inlayHint",
 			params: InlayHintParams{
-				TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+				TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
 				Range: Range{
 					Start: Position{Line: 0, Character: 0},
-					End:   Position{Line: 1, Character: 6},
+					End:   Position{Line: 1, Character: 9},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
-			},
-			msgNum: 2,
-		},
-		{
-			name:   "WorkspaceExecuteCommand",
-			method: "workspace/executeCommand",
-			params: ExecuteCommandParams{
-				Command: CommandXGoRenameResources,
-				Arguments: func() []json.RawMessage {
-					arg := map[string]any{
-						"resource": map[string]any{
-							"uri": "spx://resources/sprites/sprite1",
-						},
-						"newName": "sprite2",
-					}
-					data, _ := json.Marshal(arg)
-					return []json.RawMessage{data}
-				}(),
-			},
-			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
-			},
-			msgNum: 2,
-		},
-		{
-			name:   "WorkspaceExecuteCommandLegacy",
-			method: "workspace/executeCommand",
-			params: ExecuteCommandParams{
-				Command: CommandSpxRenameResources,
-				Arguments: func() []json.RawMessage {
-					arg := map[string]any{
-						"resource": map[string]any{
-							"uri": "spx://resources/sprites/sprite1",
-						},
-						"newName": "sprite2",
-					}
-					data, _ := json.Marshal(arg)
-					return []json.RawMessage{data}
-				}(),
-			},
-			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			replier := newMockReplier()
-			server := New(newProjectWithoutModTime(tc.files), replier, fileMapGetter(tc.files), &MockScheduler{})
+			server := newTestServer(t, tc.files)
+			server.replier = replier
 			initializeServerForTest(t, server, replier)
 
 			var params json.RawMessage
@@ -825,6 +795,13 @@ fmt.Println("Hello, World!")
 			assert.Len(t, msgs, tc.msgNum,
 				"method %q got %d messages, want %d",
 				tc.method, len(msgs), tc.msgNum)
+			response := requireResponseForID(t, msgs, id)
+			if tc.method == "unknown/method" {
+				require.ErrorIs(t, response.Err(), jsonrpc2.ErrMethodNotFound)
+			} else {
+				require.NoError(t, response.Err())
+				assert.True(t, json.Valid(response.Result()))
+			}
 		})
 	}
 }
@@ -862,14 +839,14 @@ func TestHandleMessageNotification(t *testing.T) {
 			method: "textDocument/didOpen",
 			params: DidOpenTextDocumentParams{
 				TextDocument: protocol.TextDocumentItem{
-					URI:        "file:///main.spx",
-					LanguageID: "spx",
+					URI:        "file:///main.xgo",
+					LanguageID: "xgo",
 					Version:    1,
-					Text:       "var x = 100\necho x",
+					Text:       "var x = 100\nprintln x",
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2, // telemetry event + diagnostics notification
 		},
@@ -879,18 +856,18 @@ func TestHandleMessageNotification(t *testing.T) {
 			params: DidChangeTextDocumentParams{
 				TextDocument: protocol.VersionedTextDocumentIdentifier{
 					TextDocumentIdentifier: TextDocumentIdentifier{
-						URI: "file:///main.spx",
+						URI: "file:///main.xgo",
 					},
 					Version: 2,
 				},
 				ContentChanges: []protocol.TextDocumentContentChangeEvent{
 					{
-						Text: "var y = 200\necho y",
+						Text: "var y = 200\nprintln y",
 					},
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2, // telemetry event + diagnostics notification
 		},
@@ -899,15 +876,15 @@ func TestHandleMessageNotification(t *testing.T) {
 			method: "textDocument/didSave",
 			params: DidSaveTextDocumentParams{
 				TextDocument: TextDocumentIdentifier{
-					URI: "file:///main.spx",
+					URI: "file:///main.xgo",
 				},
 				Text: func() *string {
-					text := "var x = 100\necho x"
+					text := "var x = 100\nprintln x"
 					return &text
 				}(),
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2, // telemetry event + diagnostics notification
 		},
@@ -916,11 +893,11 @@ func TestHandleMessageNotification(t *testing.T) {
 			method: "textDocument/didClose",
 			params: DidCloseTextDocumentParams{
 				TextDocument: TextDocumentIdentifier{
-					URI: "file:///main.spx",
+					URI: "file:///main.xgo",
 				},
 			},
 			files: map[string][]byte{
-				"main.spx": []byte("var x = 100\necho x"),
+				"main.xgo": []byte("var x = 100\nprintln x"),
 			},
 			msgNum: 2, // telemetry event + diagnostics notification
 		},
@@ -933,7 +910,8 @@ func TestHandleMessageNotification(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			replier := newMockReplier()
-			server := New(newProjectWithoutModTime(tc.files), replier, fileMapGetter(tc.files), &MockScheduler{})
+			server := newTestServer(t, tc.files)
+			server.replier = replier
 			initializeServerForTest(t, server, replier)
 
 			var params json.RawMessage
@@ -953,6 +931,21 @@ func TestHandleMessageNotification(t *testing.T) {
 			assert.Len(t, msgs, tc.msgNum,
 				"method %q got %d messages, want %d",
 				tc.method, len(msgs), tc.msgNum)
+			if tc.msgNum == 2 {
+				var diagnostics []jsonrpc2.Message
+				for _, message := range msgs {
+					notification := requireValueAs[*jsonrpc2.Notification](t, message)
+					if notification.Method() == "textDocument/publishDiagnostics" {
+						diagnostics = append(diagnostics, notification)
+					}
+				}
+				require.Len(t, diagnostics, 1)
+				notification := requireValueAs[*jsonrpc2.Notification](t, diagnostics[0])
+				var params PublishDiagnosticsParams
+				require.NoError(t, json.Unmarshal(notification.Params(), &params))
+				assert.Equal(t, DocumentURI("file:///main.xgo"), params.URI)
+				assert.Equal(t, []Diagnostic{}, params.Diagnostics)
+			}
 		})
 	}
 }

--- a/internal/server/spx_diagnostic.go
+++ b/internal/server/spx_diagnostic.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	gotypes "go/types"
+	"path"
+	"slices"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgolsw/internal/analysis/protocol"
+	"github.com/goplus/xgolsw/xgo"
+)
+
+// diagnosticsForSpx collects diagnostics only when the project contains spx classfiles.
+func (s *Server) diagnosticsForSpx(proj *xgo.Project) (*diagnosticResult, error) {
+	class, ok := proj.Mod.LookupClass(".spx")
+	if !ok || !slices.Contains(class.PkgPaths, SpxPkgPath) {
+		return nil, nil
+	}
+	for filename := range proj.Files() {
+		if path.Ext(filename) != ".spx" {
+			continue
+		}
+		result, err := s.compileAt(proj)
+		if err != nil {
+			return nil, err
+		}
+		return &result.diagnosticResult, nil
+	}
+	return nil, nil
+}
+
+// spxDiagnosticPass supplies property information to analyzers for an spx project.
+func spxDiagnosticPass(result *compileResult) func(string, *protocol.Pass) {
+	typeInfo, _ := result.proj.TypeInfo()
+	propertyNamesCache := make(map[*gotypes.Named]map[string]struct{})
+	return func(filename string, pass *protocol.Pass) {
+		pass.IsPropertyNameType = IsSpxPropertyNameType
+		pass.GetPropertyNamesForCall = func(call *ast.CallExpr) map[string]struct{} {
+			named := PropertyTargetNamedTypeForCall(typeInfo, call, filename, result.mainSpxFile)
+			if named == nil {
+				return nil
+			}
+			if names, ok := propertyNamesCache[named]; ok {
+				return names
+			}
+			names := make(map[string]struct{})
+			for property := range propertyObjects(named) {
+				names[property.Name] = struct{}{}
+			}
+			propertyNamesCache[named] = names
+			return names
+		}
+	}
+}

--- a/internal/server/spx_diagnostic_test.go
+++ b/internal/server/spx_diagnostic_test.go
@@ -1,0 +1,723 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/goplus/xgo/x/typesutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerDiagnosticsForSpx(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		files              map[string][]byte
+		unavailablePackage string
+		want               map[DocumentURI][]Diagnostic
+	}{
+		{name: "EmptyWorkspace", want: map[DocumentURI][]Diagnostic{}},
+		{
+			name:  "PlainXGoWithoutClassfiles",
+			files: map[string][]byte{"main.xgo": []byte("println missing\n")},
+			want: map[DocumentURI][]Diagnostic{"file:///main.xgo": {{
+				Severity: SeverityError, Message: "undefined: missing",
+				Range: Range{Start: Position{Character: 8}, End: Position{Character: 15}},
+			}}},
+		},
+		{
+			name:  "WorkClassWithoutMain",
+			files: map[string][]byte{"Worker.spx": []byte("println 1\n")},
+			want:  map[DocumentURI][]Diagnostic{"file:///Worker.spx": {}},
+		},
+		{
+			name:  "SyntaxErrorWithoutMain",
+			files: map[string][]byte{"Worker.spx": []byte("var (\n    x int\n")},
+			want: map[DocumentURI][]Diagnostic{"file:///Worker.spx": {
+				{Severity: SeverityError, Message: "expected ')', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+				{Severity: SeverityError, Message: "expected ';', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+			}},
+		},
+		{
+			name: "UnavailableFramework",
+			files: map[string][]byte{
+				"main.spx":          []byte("println 1\n"),
+				"assets/index.json": []byte(`{}`),
+			},
+			unavailablePackage: SpxPkgPath,
+			want:               map[DocumentURI][]Diagnostic{"file:///main.spx": {}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(newProjectWithoutModTime(tt.files), nil, fileMapGetter(tt.files), &MockScheduler{})
+			proj := s.getProj()
+			class, ok := proj.Mod.LookupClass(".spx")
+			require.True(t, ok)
+			require.Contains(t, class.PkgPaths, SpxPkgPath)
+			if tt.unavailablePackage != "" {
+				proj.Importer = completionTestImporter{Importer: proj.Importer, unavailablePath: tt.unavailablePackage}
+				_, err := proj.TypeInfo()
+				var typeErr typesutil.Error
+				require.ErrorAs(t, err, &typeErr)
+				require.False(t, typeErr.Pos.IsValid())
+			}
+			for uri, diagnostics := range tt.want {
+				report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: uri}})
+				require.NoError(t, err)
+				full := requireRelatedFullDocumentDiagnosticReport(t, report)
+				assert.Equal(t, string(DiagnosticFull), full.Kind)
+				assert.Equal(t, diagnostics, full.Items)
+			}
+			report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+			require.NoError(t, err)
+			require.Len(t, report.Items, len(tt.want))
+			got := make(map[DocumentURI][]Diagnostic)
+			for _, item := range report.Items {
+				full := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+				assert.Equal(t, string(DiagnosticFull), full.Kind)
+				got[full.URI] = full.Items
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestServerTextDocumentDiagnosticSpx(t *testing.T) {
+	t.Run("FuncDecoratorResourceArgument", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`func withSound(sound SoundName, fn func()) {
+	fn()
+}
+
+@withSound("Missing")
+func run() {
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
+		assert.Contains(t, fullReport.Items, Diagnostic{
+			Severity: SeverityError,
+			Message:  `sound resource "Missing" not found`,
+			Range: Range{
+				Start: Position{Line: 4, Character: 11},
+				End:   Position{Line: 4, Character: 20},
+			},
+		})
+	})
+
+	t.Run("NonMainPackageDecl", func(t *testing.T) {
+		fileMap := map[string][]byte{}
+		fileMap["main.spx"] = []byte("package nonmain")
+		s := New(newProjectWithoutModTime(fileMap), nil, fileMapGetter(fileMap), &MockScheduler{})
+		params := &DocumentDiagnosticParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+		}
+
+		report, err := s.textDocumentDiagnostic(params)
+		require.NoError(t, err)
+		require.NotNil(t, report)
+
+		fullReport := requireRelatedFullDocumentDiagnosticReport(t, report)
+		assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+		require.Len(t, fullReport.Items, 1)
+		assert.Contains(t, fullReport.Items, Diagnostic{
+			Severity: SeverityError,
+			Message:  "package name must be main",
+			Range: Range{
+				Start: Position{Line: 0, Character: 8},
+				End:   Position{Line: 0, Character: 15},
+			},
+		})
+	})
+}
+
+func TestServerWorkspaceDiagnosticSpx(t *testing.T) {
+	t.Run("MixedSourceFiles", func(t *testing.T) {
+		files := map[string][]byte{
+			"main.spx":          []byte(`play "Missing"`),
+			"values.xgo":        []byte("var (\n    x int\n"),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(files), nil, fileMapGetter(files), &MockScheduler{})
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.Len(t, report.Items, 2)
+		got := make(map[DocumentURI][]Diagnostic)
+		for _, item := range report.Items {
+			full := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), full.Kind)
+			got[full.URI] = full.Items
+		}
+		assert.Equal(t, map[DocumentURI][]Diagnostic{
+			"file:///main.spx": {{
+				Severity: SeverityError, Message: `sound resource "Missing" not found`,
+				Range: Range{Start: Position{Character: 5}, End: Position{Character: 14}},
+			}},
+			"file:///values.xgo": {
+				{Severity: SeverityError, Message: "expected ')', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+				{Severity: SeverityError, Message: "expected ';', found 'EOF'", Range: Range{Start: Position{Line: 1, Character: 9}, End: Position{Line: 1, Character: 9}}},
+			},
+		}, got)
+	})
+
+	t.Run("SoundResourceNotFound", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+play "Sound1"
+`),
+			"MySprite.spx": []byte(`
+const ConstSoundName = "ConstSoundName"
+var (
+	VarSoundName string
+)
+VarSoundName = "VarSoundName"
+onStart => {
+	play ""
+	play ConstSoundName
+	play "LiteralSoundName"
+	play VarSoundName
+	play "Sound1"
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Len(t, report.Items, 2)
+		for _, item := range report.Items {
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+			switch fullReport.URI {
+			case "file:///main.spx":
+				require.Len(t, fullReport.Items, 1)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `sound resource "Sound1" not found`,
+					Range: Range{
+						Start: Position{Line: 1, Character: 5},
+						End:   Position{Line: 1, Character: 13},
+					},
+				})
+			case "file:///MySprite.spx":
+				require.Len(t, fullReport.Items, 4)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  "sound resource name cannot be empty",
+					Range: Range{
+						Start: Position{Line: 7, Character: 6},
+						End:   Position{Line: 7, Character: 8},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `sound resource "ConstSoundName" not found`,
+					Range: Range{
+						Start: Position{Line: 8, Character: 6},
+						End:   Position{Line: 8, Character: 20},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `sound resource "LiteralSoundName" not found`,
+					Range: Range{
+						Start: Position{Line: 9, Character: 6},
+						End:   Position{Line: 9, Character: 24},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `sound resource "Sound1" not found`,
+					Range: Range{
+						Start: Position{Line: 11, Character: 6},
+						End:   Position{Line: 11, Character: 14},
+					},
+				})
+			default:
+				assert.Empty(t, fullReport.Items)
+			}
+		}
+	})
+
+	t.Run("SoundResourceNotFoundInKwargs", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+type Options struct {
+	Sound SoundName
+}
+
+var client Client
+
+func configure(opts Options?) {}
+
+func configureMap(opts map[string]SoundName?) {}
+
+type Player interface {
+	Sound(sound SoundName) Player
+}
+
+type Client struct{}
+
+func (c Client) Player() Player { return nil }
+
+func (c Client) play(params Player?) {}
+
+onStart => {
+	configure sound = "MissingStructSound"
+	configureMap sound = "MissingMapSound"
+	client.play sound = "MissingInterfaceSound"
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		require.Len(t, report.Items, 1)
+		fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, report.Items[0])
+		require.Len(t, fullReport.Items, 3)
+		assert.Contains(t, fullReport.Items, Diagnostic{
+			Severity: SeverityError,
+			Message:  `sound resource "MissingStructSound" not found`,
+			Range: Range{
+				Start: Position{Line: 22, Character: 19},
+				End:   Position{Line: 22, Character: 39},
+			},
+		})
+		assert.Contains(t, fullReport.Items, Diagnostic{
+			Severity: SeverityError,
+			Message:  `sound resource "MissingMapSound" not found`,
+			Range: Range{
+				Start: Position{Line: 23, Character: 22},
+				End:   Position{Line: 23, Character: 39},
+			},
+		})
+		assert.Contains(t, fullReport.Items, Diagnostic{
+			Severity: SeverityError,
+			Message:  `sound resource "MissingInterfaceSound" not found`,
+			Range: Range{
+				Start: Position{Line: 24, Character: 21},
+				End:   Position{Line: 24, Character: 44},
+			},
+		})
+	})
+
+	t.Run("SoundResourceNotFoundInOverloadKwargs", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+type Worker struct{}
+
+type Options struct {
+	Sound SoundName
+}
+
+var worker Worker
+
+func (w *Worker) playSound(opts Options?) {}
+
+func (Worker).play = (
+	(Worker).playSound
+)
+
+onStart => {
+	worker.play sound = "MissingOverloadSound"
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		require.Len(t, report.Items, 1)
+		fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, report.Items[0])
+		require.Len(t, fullReport.Items, 1)
+		assert.Contains(t, fullReport.Items, Diagnostic{
+			Severity: SeverityError,
+			Message:  `sound resource "MissingOverloadSound" not found`,
+			Range: Range{
+				Start: Position{Line: 16, Character: 21},
+				End:   Position{Line: 16, Character: 43},
+			},
+		})
+	})
+
+	t.Run("PropertyNameNotFoundInOverloadKwargs", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+type Worker struct{}
+
+type Options struct {
+	Name PropertyName
+}
+
+var worker Worker
+
+func (w *Worker) configureOptions(opts Options?) {}
+
+func (Worker).configure = (
+	(Worker).configureOptions
+)
+
+onStart => {
+	worker.configure name = "unknownProperty"
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		require.Len(t, report.Items, 1)
+		fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, report.Items[0])
+		require.Len(t, fullReport.Items, 1)
+		assert.Contains(t, fullReport.Items, Diagnostic{
+			Severity: SeverityError,
+			Message:  `unknown property "unknownProperty"`,
+			Range: Range{
+				Start: Position{Line: 16, Character: 25},
+				End:   Position{Line: 16, Character: 42},
+			},
+		})
+	})
+
+	t.Run("BackdropResourceNotFound", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onBackdrop "", func() {}
+onBackdrop "NonExistentBackdrop", func() {}
+`),
+			"MySprite.spx": []byte(`
+const ConstBackdropName = "ConstBackdropName"
+var VarBackdropName string
+VarBackdropName = "VarBackdropName"
+onStart => {
+	onBackdrop ConstBackdropName, func() {}
+	onBackdrop "LiteralBackdropName", func() {}
+	onBackdrop VarBackdropName, func() {}
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Len(t, report.Items, 2)
+		for _, item := range report.Items {
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+			switch fullReport.URI {
+			case "file:///main.spx":
+				require.Len(t, fullReport.Items, 2)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  "backdrop resource name cannot be empty",
+					Range: Range{
+						Start: Position{Line: 1, Character: 11},
+						End:   Position{Line: 1, Character: 13},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `backdrop resource "NonExistentBackdrop" not found`,
+					Range: Range{
+						Start: Position{Line: 2, Character: 11},
+						End:   Position{Line: 2, Character: 32},
+					},
+				})
+			case "file:///MySprite.spx":
+				require.Len(t, fullReport.Items, 2)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `backdrop resource "ConstBackdropName" not found`,
+					Range: Range{
+						Start: Position{Line: 5, Character: 12},
+						End:   Position{Line: 5, Character: 29},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `backdrop resource "LiteralBackdropName" not found`,
+					Range: Range{
+						Start: Position{Line: 6, Character: 12},
+						End:   Position{Line: 6, Character: 33},
+					},
+				})
+			default:
+				assert.Empty(t, fullReport.Items)
+			}
+		}
+	})
+
+	t.Run("SpriteResourceNotFound", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+MySprite.say "hi"
+MySprite.touching "OtherSprite"
+`),
+			"MySprite.spx": []byte(`
+onStart => {
+	say "hi"
+	touching "OtherSprite"
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Len(t, report.Items, 2)
+		for _, item := range report.Items {
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+			switch fullReport.URI {
+			case "file:///main.spx":
+				require.Len(t, fullReport.Items, 1)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `sprite resource "OtherSprite" not found`,
+					Range: Range{
+						Start: Position{Line: 2, Character: 18},
+						End:   Position{Line: 2, Character: 31},
+					},
+				})
+			case "file:///MySprite.spx":
+				require.Len(t, fullReport.Items, 1)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `sprite resource "OtherSprite" not found`,
+					Range: Range{
+						Start: Position{Line: 3, Character: 10},
+						End:   Position{Line: 3, Character: 23},
+					},
+				})
+			default:
+				assert.Empty(t, fullReport.Items)
+			}
+		}
+	})
+
+	t.Run("SpriteCostumeResourceNotFound", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+`),
+			"MySprite.spx": []byte(`
+onStart => {
+	setCostume ""
+	setCostume "NonExistentCostume"
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Len(t, report.Items, 2)
+		for _, item := range report.Items {
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+			switch fullReport.URI {
+			case "file:///MySprite.spx":
+				require.Len(t, fullReport.Items, 2)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  "sprite costume resource name cannot be empty",
+					Range: Range{
+						Start: Position{Line: 2, Character: 12},
+						End:   Position{Line: 2, Character: 14},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `costume resource "NonExistentCostume" not found in sprite "MySprite"`,
+					Range: Range{
+						Start: Position{Line: 3, Character: 12},
+						End:   Position{Line: 3, Character: 32},
+					},
+				})
+			default:
+				assert.Empty(t, fullReport.Items)
+			}
+		}
+	})
+
+	t.Run("SpriteAnimationResourceNotFound", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+`),
+			"MySprite.spx": []byte(`
+onStart => {
+	animate ""
+	animate "roll-in"
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Len(t, report.Items, 2)
+		for _, item := range report.Items {
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+			switch fullReport.URI {
+			case "file:///MySprite.spx":
+				require.Len(t, fullReport.Items, 2)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  "sprite animation resource name cannot be empty",
+					Range: Range{
+						Start: Position{Line: 2, Character: 9},
+						End:   Position{Line: 2, Character: 11},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `animation resource "roll-in" not found in sprite "MySprite"`,
+					Range: Range{
+						Start: Position{Line: 3, Character: 9},
+						End:   Position{Line: 3, Character: 18},
+					},
+				})
+			default:
+				assert.Empty(t, fullReport.Items)
+			}
+		}
+	})
+
+	t.Run("WidgetResourceNotFound", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+`),
+			"MySprite.spx": []byte(`
+const ConstWidgetName = "ConstWidgetName"
+var VarWidgetName string
+VarWidgetName = "VarWidgetName"
+onStart => {
+	getWidget Monitor, ""
+	getWidget Monitor, ConstWidgetName
+	getWidget Monitor, "LiteralWidgetName"
+	getWidget Monitor, VarWidgetName
+}
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Len(t, report.Items, 2)
+		for _, item := range report.Items {
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+			switch fullReport.URI {
+			case "file:///MySprite.spx":
+				require.Len(t, fullReport.Items, 3)
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  "widget resource name cannot be empty",
+					Range: Range{
+						Start: Position{Line: 5, Character: 20},
+						End:   Position{Line: 5, Character: 22},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `widget resource "ConstWidgetName" not found`,
+					Range: Range{
+						Start: Position{Line: 6, Character: 20},
+						End:   Position{Line: 6, Character: 35},
+					},
+				})
+				assert.Contains(t, fullReport.Items, Diagnostic{
+					Severity: SeverityError,
+					Message:  `widget resource "LiteralWidgetName" not found`,
+					Range: Range{
+						Start: Position{Line: 7, Character: 20},
+						End:   Position{Line: 7, Character: 39},
+					},
+				})
+			default:
+				assert.Empty(t, fullReport.Items)
+			}
+		}
+	})
+
+	t.Run("WithNonBasicTypeAliases", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+`),
+			"MySprite.spx": []byte(`
+import "image/color"
+
+onStart => {
+	touchingColor HSBA(0, 0, 0, 0)
+}
+`),
+			"assets/index.json":                  []byte(`{}`),
+			"assets/sprites/MySprite/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Len(t, report.Items, 2)
+		for _, item := range report.Items {
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+			assert.Empty(t, fullReport.Items)
+		}
+	})
+
+	t.Run("OnKey", func(t *testing.T) {
+		m := map[string][]byte{
+			"main.spx": []byte(`
+onKey KeyLeft, => {}
+
+onKey [KeyRight, KeyUp, KeyDown], => {}
+
+`),
+			"assets/index.json": []byte(`{}`),
+		}
+		s := New(newProjectWithoutModTime(m), nil, fileMapGetter(m), &MockScheduler{})
+
+		report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
+		require.NoError(t, err)
+		require.NotNil(t, report)
+		assert.Len(t, report.Items, 1)
+		for _, item := range report.Items {
+			fullReport := requireWorkspaceFullDocumentDiagnosticReport(t, item)
+			assert.Equal(t, string(DiagnosticFull), fullReport.Kind)
+			assert.Empty(t, fullReport.Items)
+		}
+	})
+}

--- a/internal/server/spx_server_test.go
+++ b/internal/server/spx_server_test.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/goplus/xgolsw/jsonrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleMessageCallSpx(t *testing.T) {
+	for _, command := range []struct {
+		name    string
+		command string
+	}{
+		{name: "RenameResources", command: CommandXGoRenameResources},
+		{name: "LegacyRenameResources", command: CommandSpxRenameResources},
+	} {
+		t.Run(command.name, func(t *testing.T) {
+			for _, tt := range []struct {
+				name     string
+				files    map[string][]byte
+				argument json.RawMessage
+				want     map[DocumentURI][]TextEdit
+			}{
+				{
+					name:     "SoundReference",
+					files:    map[string][]byte{"main.spx": []byte(`play "beep"`), "assets/index.json": []byte(`{}`)},
+					argument: json.RawMessage(`{"resource":{"uri":"spx://resources/sounds/beep"},"newName":"click"}`),
+					want: map[DocumentURI][]TextEdit{
+						"file:///main.spx": {{Range: Range{Start: Position{Character: 6}, End: Position{Character: 10}}, NewText: "click"}},
+					},
+				},
+				{
+					name:     "SpriteWithoutAssets",
+					files:    map[string][]byte{"main.spx": []byte(`var x = 100`)},
+					argument: json.RawMessage(`{"resource":{"uri":"spx://resources/sprites/sprite1"},"newName":"sprite2"}`),
+				},
+			} {
+				t.Run(tt.name, func(t *testing.T) {
+					replier := newMockReplier()
+					s := New(newProjectWithoutModTime(tt.files), replier, fileMapGetter(tt.files), &MockScheduler{})
+					initializeServerForTest(t, s, replier)
+					call, err := jsonrpc2.NewCall(jsonrpc2.NewIntID(1), "workspace/executeCommand", ExecuteCommandParams{
+						Command:   command.command,
+						Arguments: []json.RawMessage{tt.argument},
+					})
+					require.NoError(t, err)
+					require.NoError(t, s.HandleMessage(call))
+					messages := replier.waitForMessages(2, 5*time.Second)
+					require.Len(t, messages, 2)
+					response := requireResponseForID(t, messages, call.ID())
+					require.NoError(t, response.Err())
+					var edit WorkspaceEdit
+					require.NoError(t, json.Unmarshal(response.Result(), &edit))
+					assert.Equal(t, tt.want, edit.Changes)
+				})
+			}
+		})
+	}
+}

--- a/internal/server/text_synchronization.go
+++ b/internal/server/text_synchronization.go
@@ -5,13 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/goplus/gogen"
-	"github.com/goplus/xgo/scanner"
-	"github.com/goplus/xgo/x/typesutil"
 	"github.com/goplus/xgolsw/jsonrpc2"
 	"github.com/goplus/xgolsw/protocol"
 	"github.com/goplus/xgolsw/xgo"
-	"github.com/qiniu/x/errors"
 )
 
 // didOpen handles the textDocument/didOpen notification from the LSP client.
@@ -83,35 +79,16 @@ func (s *Server) didClose(params *DidCloseTextDocumentParams) error {
 	return s.publishDiagnostics(params.TextDocument.URI, nil)
 }
 
-// didModifyFile is a shared implementation for handling document modifications.
-// It updates the project with file changes and asynchronously publishes diagnostics.
-// The function:
-//  1. Updates the project's files with the provided changes
-//  2. Starts a goroutine to generate and publish diagnostics for each changed file
-//  3. Returns immediately after updating files for better responsiveness
+// didModifyFile updates project files synchronously and publishes diagnostics
+// asynchronously so document modifications do not wait for analysis.
 func (s *Server) didModifyFile(changes []FileChange) error {
-	// 1. Update files synchronously
 	s.ModifyFiles(changes)
 
-	// 2. Asynchronously generate and publish diagnostics
-	// This allows for quick response while diagnostics computation happens in background
 	go func() {
 		for _, change := range changes {
-			// Convert path to URI for diagnostics
 			uri := s.toDocumentURI(change.Path)
-
-			// Get diagnostics from AST and type checking
-			diagnostics, err := s.getDiagnostics(change.Path)
-			if err != nil {
-				// Log error but continue processing other files
-				continue
-			}
-
-			// Publish diagnostics
-			if err := s.publishDiagnostics(uri, diagnostics); err != nil {
-				// Log error but continue
-				continue
-			}
+			diagnostics := s.getDiagnostics(change.Path)
+			s.publishDiagnostics(uri, diagnostics)
 		}
 	}()
 
@@ -183,87 +160,15 @@ func (s *Server) applyIncrementalChanges(path string, changes []protocol.TextDoc
 	return content, nil
 }
 
-// getDiagnostics generates diagnostic information for a specific file.
-// It performs two checks:
-//  1. AST parsing - reports syntax errors
-//  2. Type checking - reports type errors
-//
-// If AST parsing fails, only syntax errors are returned as diagnostics.
-// If AST parsing succeeds but type checking fails, type errors are returned.
-// Returns a slice of diagnostics and an error (if diagnostic generation failed).
-func (s *Server) getDiagnostics(path string) ([]Diagnostic, error) {
-	var diagnostics []Diagnostic
-
+// getDiagnostics collects syntax and type errors for a modified document.
+// Analyzers and framework-specific checks run through pull diagnostics.
+func (s *Server) getDiagnostics(path string) []Diagnostic {
 	proj := s.getProj()
-
-	// 1. Get AST diagnostics
-	// Parse the file and check for syntax errors
-	astFile, err := proj.ASTFile(path)
-	if err != nil {
-		var (
-			errorList scanner.ErrorList
-			codeError *gogen.CodeError
-		)
-		if errors.As(err, &errorList) {
-			// Handle parse errors.
-			for _, e := range errorList {
-				diagnostics = append(diagnostics, Diagnostic{
-					Severity: SeverityError,
-					Range:    RangeForASTFilePosition(proj, astFile, e.Pos),
-					Message:  e.Msg,
-				})
-			}
-		} else if errors.As(err, &codeError) {
-			// Handle code generation errors.
-			diagnostics = append(diagnostics, Diagnostic{
-				Severity: SeverityError,
-				Range:    RangeForPosEnd(proj, codeError.Pos, codeError.End),
-				Message:  codeError.Msg,
-			})
-		} else {
-			// Handle unknown errors (including recovered panics).
-			diagnostics = append(diagnostics, Diagnostic{
-				Severity: SeverityError,
-				Message:  fmt.Sprintf("failed to parse spx file: %v", err),
-			})
-		}
+	result := newDiagnosticResult()
+	if astFile := s.collectSyntaxDiagnostics(proj, path, &result); astFile != nil {
+		s.collectTypeDiagnostics(proj, &result)
 	}
-
-	if astFile == nil {
-		return diagnostics, nil
-	}
-
-	astFilePos := proj.Fset.Position(astFile.Pos())
-
-	handleErr := func(err error) {
-		if typeErr, ok := err.(typesutil.Error); ok {
-			position := typeErr.Fset.Position(typeErr.Pos)
-			if position.Filename == astFilePos.Filename {
-				diagnostics = append(diagnostics, Diagnostic{
-					Severity: SeverityError,
-					Range:    RangeForPosEnd(proj, typeErr.Pos, typeErr.End),
-					Message:  typeErr.Msg,
-				})
-			}
-		}
-	}
-
-	// 2. Get type checking diagnostics
-	// Perform type checking on the file
-	_, err = proj.TypeInfo()
-	if err != nil {
-		// Add type checking errors to diagnostics
-		switch err := err.(type) {
-		case errors.List:
-			for _, e := range err {
-				handleErr(e)
-			}
-		default:
-			handleErr(err)
-		}
-	}
-
-	return diagnostics, nil
+	return result.diagnostics[s.toDocumentURI(path)]
 }
 
 // FileChange represents a file change.

--- a/internal/server/text_synchronization_test.go
+++ b/internal/server/text_synchronization_test.go
@@ -1,11 +1,10 @@
 package server
 
 import (
-	"errors"
+	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/jsonrpc2"
 	"github.com/goplus/xgolsw/protocol"
 	"github.com/goplus/xgolsw/xgo"
@@ -13,29 +12,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// MockReplier implements a message replier for testing
-type MockReplier struct {
-	notifications []*jsonrpc2.Notification
-}
-
-// ReplyMessage records notifications for later verification
-func (m *MockReplier) ReplyMessage(msg jsonrpc2.Message) error {
-	if n, ok := msg.(*jsonrpc2.Notification); ok {
-		m.notifications = append(m.notifications, n)
-	}
-	return nil
-}
-
 func file(text string) *xgo.File {
 	return &xgo.File{Content: []byte(text)}
 }
 
-// strPtr returns a pointer to the given string
-func strPtr(s string) *string {
-	return &s
+func requirePublishedDiagnostics(t *testing.T, replier *mockReplier, uri DocumentURI) []Diagnostic {
+	t.Helper()
+
+	messages := replier.waitForMessages(1, 5*time.Second)
+	require.Len(t, messages, 1)
+	notification := requireValueAs[*jsonrpc2.Notification](t, messages[0])
+	require.Equal(t, "textDocument/publishDiagnostics", notification.Method())
+	var params PublishDiagnosticsParams
+	require.NoError(t, json.Unmarshal(notification.Params(), &params))
+	assert.Equal(t, uri, params.URI)
+	require.NotNil(t, params.Diagnostics)
+	replier.clearMessages()
+	return params.Diagnostics
 }
 
-func TestModifyFiles(t *testing.T) {
+func TestServerModifyFiles(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
 		initial map[string]*xgo.File
@@ -47,89 +43,89 @@ func TestModifyFiles(t *testing.T) {
 			initial: map[string]*xgo.File{},
 			changes: []FileChange{
 				{
-					Path:    "new.go",
+					Path:    "new.xgo",
 					Content: []byte("package main"),
 					Version: 100,
 				},
 			},
 			want: map[string]string{
-				"new.go": "package main",
+				"new.xgo": "package main",
 			},
 		},
 		{
 			name: "UpdateExistingFileWithNewerVersion",
 			initial: map[string]*xgo.File{
-				"main.go": {
+				"main.xgo": {
 					Content: []byte("old content"),
 					ModTime: time.UnixMilli(100),
 				},
 			},
 			changes: []FileChange{
 				{
-					Path:    "main.go",
+					Path:    "main.xgo",
 					Content: []byte("new content"),
 					Version: 200,
 				},
 			},
 			want: map[string]string{
-				"main.go": "new content",
+				"main.xgo": "new content",
 			},
 		},
 		{
 			name: "IgnoreOlderVersionUpdate",
 			initial: map[string]*xgo.File{
-				"main.go": {
+				"main.xgo": {
 					Content: []byte("current content"),
 					Version: 200,
 				},
 			},
 			changes: []FileChange{
 				{
-					Path:    "main.go",
+					Path:    "main.xgo",
 					Content: []byte("old content"),
 					Version: 100,
 				},
 			},
 			want: map[string]string{
-				"main.go": "current content",
+				"main.xgo": "current content",
 			},
 		},
 		{
 			name: "MultipleFileChanges",
 			initial: map[string]*xgo.File{
-				"file1.go": {
+				"file1.xgo": {
 					Content: []byte("content1"),
 					ModTime: time.UnixMilli(100),
 				},
-				"file2.go": {
+				"file2.xgo": {
 					Content: []byte("content2"),
 					ModTime: time.UnixMilli(100),
 				},
 			},
 			changes: []FileChange{
 				{
-					Path:    "file1.go",
+					Path:    "file1.xgo",
 					Content: []byte("new content1"),
 					Version: 200,
 				},
 				{
-					Path:    "file3.go",
+					Path:    "file3.xgo",
 					Content: []byte("content3"),
 					Version: 200,
 				},
 			},
 			want: map[string]string{
-				"file1.go": "new content1",
-				"file2.go": "content2",
-				"file3.go": "content3",
+				"file1.xgo": "new content1",
+				"file2.xgo": "content2",
+				"file3.xgo": "content3",
 			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create new project with initial files
-			proj := xgo.NewProject(token.NewFileSet(), tt.initial, xgo.FeatAll)
+			proj := xgo.NewProject(nil, tt.initial, xgo.FeatAll)
 
-			// Create a TestServer that extends the real Server
+			// Create a server with versioned files
 			server := &Server{
 				workspaceRootFS: proj,
 			}
@@ -155,766 +151,204 @@ func TestModifyFiles(t *testing.T) {
 	}
 }
 
-// TestDidOpen tests the didOpen handler functionality
-func TestDidOpen(t *testing.T) {
+func TestServerDocumentSynchronization(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
-		params      *protocol.DidOpenTextDocumentParams
-		wantPath    string
-		wantContent string
-		wantErr     bool
+		filename    string
+		projectFile string
 	}{
-		{
-			name: "BasicOpen",
-			params: &protocol.DidOpenTextDocumentParams{
-				TextDocument: protocol.TextDocumentItem{
-					URI:     "file://workspace/echo.spx",
-					Version: 1,
-					Text:    "echo \"100\"",
-				},
-			},
-			wantPath:    "echo.spx",
-			wantContent: "echo \"100\"",
-			wantErr:     false,
-		},
-		{
-			name: "OpenFileWithFunction",
-			params: &protocol.DidOpenTextDocumentParams{
-				TextDocument: protocol.TextDocumentItem{
-					URI:     "file://workspace/test_func.spx",
-					Version: 2,
-					Text:    "onStart {\n say \"Hello, World!\"\n}",
-				},
-			},
-			wantPath:    "test_func.spx",
-			wantContent: "onStart {\n say \"Hello, World!\"\n}",
-			wantErr:     false,
-		},
-		{
-			name: "OpenFileWithUnicodeContent",
-			params: &protocol.DidOpenTextDocumentParams{
-				TextDocument: protocol.TextDocumentItem{
-					URI:     "file://workspace/i18n.spx",
-					Version: 3,
-					Text:    "onStart {\n say \"你好，世界!\"\n}",
-				},
-			},
-			wantPath:    "i18n.spx",
-			wantContent: "onStart {\n say \"你好，世界!\"\n}",
-			wantErr:     false,
-		},
-		{
-			name: "URIConversionError",
-			params: &protocol.DidOpenTextDocumentParams{
-				TextDocument: protocol.TextDocumentItem{
-					URI:     "file://error_workspace/error.spx",
-					Version: 1,
-					Text:    "onStart {}",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "EmptyFileContent",
-			params: &protocol.DidOpenTextDocumentParams{
-				TextDocument: protocol.TextDocumentItem{
-					URI:     "file://workspace/empty.spx",
-					Version: 1,
-					Text:    "",
-				},
-			},
-			wantPath:    "empty.spx",
-			wantContent: "",
-			wantErr:     false,
-		},
+		{name: "PlainXGo", filename: "main.xgo"},
+		{name: "ProjectClass", filename: "main_fixture.gox"},
+		{name: "WorkClass", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			// Setup test environment with real Project instead of MockProject
-			proj := xgo.NewProject(token.NewFileSet(), make(map[string]*xgo.File), 0)
-			proj.PutFile(tt.wantPath, file("mock content"))
-			mockReplier := &MockReplier{}
-
-			// Create a TestServer that extends the real Server
-			server := &Server{
-				workspaceRootFS:  proj,
-				replier:          mockReplier,
-				workspaceRootURI: "file://workspace/",
+			files := map[string][]byte{tt.filename: nil}
+			if tt.projectFile != "" {
+				files[tt.projectFile] = nil
 			}
+			s := newTestServer(t, files)
+			replier := newMockReplier()
+			s.replier = replier
+			uri := s.toDocumentURI(tt.filename)
+			content := "println \"\U0001f600\", missing\n"
+			want := []Diagnostic{{
+				Severity: SeverityError,
+				Message:  "undefined: missing",
+				Range:    Range{Start: Position{Character: 14}, End: Position{Character: 21}},
+			}}
 
-			// Execute test
-			err := server.didOpen(tt.params)
+			require.NoError(t, s.didOpen(&DidOpenTextDocumentParams{
+				TextDocument: protocol.TextDocumentItem{URI: uri, LanguageID: "xgo", Version: 1, Text: content},
+			}))
+			assert.Equal(t, want, requirePublishedDiagnostics(t, replier, uri))
+			current, ok := s.getProj().File(tt.filename)
+			require.True(t, ok)
+			assert.Equal(t, content, string(current.Content))
+			assert.Equal(t, 1, current.Version)
 
-			// Verify results
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: uri}})
+			require.NoError(t, err)
+			assert.Equal(t, want, requireRelatedFullDocumentDiagnosticReport(t, report).Items)
 
-			if !tt.wantErr {
-				// Verify file was correctly added to the project
-				file, ok := proj.File(tt.wantPath)
-				require.True(t, ok)
-				assert.Equal(t, tt.wantContent, string(file.Content))
-				assert.Equal(t, int(tt.params.TextDocument.Version), file.Version)
-			}
+			require.NoError(t, s.didChange(&DidChangeTextDocumentParams{
+				TextDocument: protocol.VersionedTextDocumentIdentifier{TextDocumentIdentifier: TextDocumentIdentifier{URI: uri}, Version: 2},
+				ContentChanges: []protocol.TextDocumentContentChangeEvent{{
+					Range: &Range{Start: Position{Character: 14}, End: Position{Character: 21}}, Text: "1",
+				}},
+			}))
+			assert.Empty(t, requirePublishedDiagnostics(t, replier, uri))
+			current, ok = s.getProj().File(tt.filename)
+			require.True(t, ok)
+			assert.Equal(t, "println \"\U0001f600\", 1\n", string(current.Content))
+			assert.Equal(t, 2, current.Version)
+			report, err = s.textDocumentDiagnostic(&DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: uri}})
+			require.NoError(t, err)
+			assert.Empty(t, requireRelatedFullDocumentDiagnosticReport(t, report).Items)
+
+			require.NoError(t, s.didChange(&DidChangeTextDocumentParams{
+				TextDocument:   protocol.VersionedTextDocumentIdentifier{TextDocumentIdentifier: TextDocumentIdentifier{URI: uri}, Version: 1},
+				ContentChanges: []protocol.TextDocumentContentChangeEvent{{Text: content}},
+			}))
+			assert.Empty(t, requirePublishedDiagnostics(t, replier, uri))
+			unchanged, ok := s.getProj().File(tt.filename)
+			require.True(t, ok)
+			assert.Same(t, current, unchanged)
+
+			require.NoError(t, s.didSave(&DidSaveTextDocumentParams{TextDocument: TextDocumentIdentifier{URI: uri}}))
+			assert.Empty(t, replier.getMessages())
+			unchanged, ok = s.getProj().File(tt.filename)
+			require.True(t, ok)
+			assert.Same(t, current, unchanged)
+
+			require.NoError(t, s.didSave(&DidSaveTextDocumentParams{TextDocument: TextDocumentIdentifier{URI: uri}, Text: &content}))
+			assert.Equal(t, want, requirePublishedDiagnostics(t, replier, uri))
+			saved, ok := s.getProj().File(tt.filename)
+			require.True(t, ok)
+			assert.Equal(t, content, string(saved.Content))
+			assert.Greater(t, saved.Version, current.Version)
+
+			require.NoError(t, s.didClose(&DidCloseTextDocumentParams{TextDocument: TextDocumentIdentifier{URI: uri}}))
+			assert.Empty(t, requirePublishedDiagnostics(t, replier, uri))
 		})
 	}
 }
 
-// TestDidChange tests the didChange handler functionality
-func TestDidChange(t *testing.T) {
-	for _, tt := range []struct {
-		name           string
-		initialContent string
-		params         *protocol.DidChangeTextDocumentParams
-		convertError   error
-		wantContent    string
-		wantErr        bool
-	}{
-		{
-			name:           "FullDocumentReplacement",
-			initialContent: "package main",
-			params: &protocol.DidChangeTextDocumentParams{
-				TextDocument: protocol.VersionedTextDocumentIdentifier{
-					TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-						URI: "file://workspace/test.xgo",
-					},
-					Version: 2,
-				},
-				ContentChanges: []protocol.TextDocumentContentChangeEvent{
-					{Text: "package main\n\nfunc main() {}"},
-				},
-			},
-			wantContent: "package main\n\nfunc main() {}",
-			wantErr:     false,
-		},
-		{
-			name:           "IncrementalChange",
-			initialContent: "package main\n\nfunc main() {\n\t\n}",
-			params: &protocol.DidChangeTextDocumentParams{
-				TextDocument: protocol.VersionedTextDocumentIdentifier{
-					TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-						URI: "file://workspace/test.xgo",
-					},
-					Version: 2,
-				},
-				ContentChanges: []protocol.TextDocumentContentChangeEvent{
-					{
-						Range: &protocol.Range{
-							Start: protocol.Position{Line: 3, Character: 1},
-							End:   protocol.Position{Line: 3, Character: 1},
-						},
-						Text: "fmt.Println(\"Hello, World!\")",
-					},
-				},
-			},
-			wantContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}",
-			wantErr:     false,
-		},
-		{
-			name:           "MultipleIncrementalChanges",
-			initialContent: "package main\n\nfunc main() {\n\t\n}",
-			params: &protocol.DidChangeTextDocumentParams{
-				TextDocument: protocol.VersionedTextDocumentIdentifier{
-					TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-						URI: "file://workspace/test.xgo",
-					},
-					Version: 3,
-				},
-				ContentChanges: []protocol.TextDocumentContentChangeEvent{
-					{
-						Range: &protocol.Range{
-							Start: protocol.Position{Line: 3, Character: 1},
-							End:   protocol.Position{Line: 3, Character: 1},
-						},
-						Text: "fmt.Print(\"Hello",
-					},
-					{
-						Range: &protocol.Range{
-							Start: protocol.Position{Line: 3, Character: 17},
-							End:   protocol.Position{Line: 3, Character: 17},
-						},
-						Text: ", World!\")",
-					},
-				},
-			},
-			wantContent: "package main\n\nfunc main() {\n\tfmt.Print(\"Hello, World!\")\n}",
-			wantErr:     false,
-		},
-		{
-			name:           "URIConversionError",
-			initialContent: "package main",
-			params: &protocol.DidChangeTextDocumentParams{
-				TextDocument: protocol.VersionedTextDocumentIdentifier{
-					TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-						URI: "file://error/test.xgo",
-					},
-					Version: 2,
-				},
-				ContentChanges: []protocol.TextDocumentContentChangeEvent{
-					{Text: "package main\n\nfunc main() {}"},
-				},
-			},
-			convertError: errors.New("URI conversion failed"),
-			wantErr:      true,
-		},
-		{
-			name:           "EmptyChangesArray",
-			initialContent: "package main",
-			params: &protocol.DidChangeTextDocumentParams{
-				TextDocument: protocol.VersionedTextDocumentIdentifier{
-					TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-						URI: "file://workspace/test.xgo",
-					},
-					Version: 2,
-				},
-				ContentChanges: []protocol.TextDocumentContentChangeEvent{},
-			},
-			wantErr: true,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			// Setup test environment with initial file content
-			files := make(map[string]*xgo.File)
-			path := "test.xgo"
-
-			files[path] = &xgo.File{
-				Content: []byte(tt.initialContent),
-				ModTime: time.Time{},
-			}
-
-			proj := xgo.NewProject(token.NewFileSet(), files, xgo.FeatAll)
-			mockReplier := &MockReplier{}
-
-			// Create a TestServer that extends the real Server
-			server := &Server{
-				workspaceRootFS:  proj,
-				replier:          mockReplier,
-				workspaceRootURI: "file://workspace/",
-			}
-
-			// Execute test
-			err := server.didChange(tt.params)
-
-			// Verify results
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-
-			if !tt.wantErr {
-				// Verify file content was updated
-				file, ok := proj.File(path)
-				require.True(t, ok)
-				assert.Equal(t, tt.wantContent, string(file.Content))
-				assert.Equal(t, int(tt.params.TextDocument.Version), file.Version)
-			}
-		})
-	}
-}
-
-// TestDidSave tests the didSave handler functionality
-func TestDidSave(t *testing.T) {
-	for _, tt := range []struct {
-		name           string
-		initialContent string
-		params         *protocol.DidSaveTextDocumentParams
-		wantContent    string
-		contentChanged bool
-		wantErr        bool
-	}{
-		{
-			name:           "SaveWithText",
-			initialContent: "package main",
-			params: &protocol.DidSaveTextDocumentParams{
-				TextDocument: protocol.TextDocumentIdentifier{
-					URI: "file://workspace/test.xgo",
-				},
-				Text: strPtr("package main\n\nfunc main() {}"),
-			},
-			wantContent:    "package main\n\nfunc main() {}",
-			contentChanged: true,
-			wantErr:        false,
-		},
-		{
-			name:           "SaveWithoutText",
-			initialContent: "package main",
-			params: &protocol.DidSaveTextDocumentParams{
-				TextDocument: protocol.TextDocumentIdentifier{
-					URI: "file://workspace/test.xgo",
-				},
-				Text: nil,
-			},
-			wantContent:    "package main", // Content should not change
-			contentChanged: false,
-			wantErr:        false,
-		},
-		{
-			name:           "URIConversionError",
-			initialContent: "package main",
-			params: &protocol.DidSaveTextDocumentParams{
-				TextDocument: protocol.TextDocumentIdentifier{
-					URI: "file://error/test.xgo",
-				},
-				Text: strPtr("package main\n\nfunc main() {}"),
-			},
-			contentChanged: false,
-			wantErr:        true,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			// Setup test environment
-			fset := token.NewFileSet()
-			files := make(map[string]*xgo.File)
-			path := "test.xgo"
-
-			files[path] = &xgo.File{
-				Content: []byte(tt.initialContent),
-				ModTime: time.Time{},
-			}
-
-			proj := xgo.NewProject(fset, files, xgo.FeatASTCache)
-			mockReplier := &MockReplier{}
-
-			// Create a TestServer
-			server := &Server{
-				workspaceRootFS:  proj,
-				replier:          mockReplier,
-				workspaceRootURI: "file://workspace/",
-			}
-
-			// Execute test
-			err := server.didSave(tt.params)
-
-			// Verify results
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-
-			if !tt.wantErr {
-				// Verify file content
-				file, ok := proj.File(path)
-				require.True(t, ok)
-				assert.Equal(t, tt.wantContent, string(file.Content))
-			}
-		})
-	}
-}
-
-// TestDidClose tests the didClose handler functionality
-func TestDidClose(t *testing.T) {
+func TestServerDidOpen(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
-		params  *protocol.DidCloseTextDocumentParams
-		wantErr bool
+		content string
 	}{
-		{
-			name: "CloseDocument",
-			params: &protocol.DidCloseTextDocumentParams{
-				TextDocument: protocol.TextDocumentIdentifier{
-					URI: "file://workspace/test.xgo",
-				},
-			},
-			wantErr: false,
-		},
+		{name: "Basic", content: "println 100"},
+		{name: "Function", content: "func hello() {\n    println \"hello\"\n}\nhello\n"},
+		{name: "Unicode", content: "println \"\u4f60\u597d\U0001f600\""},
+		{name: "Empty"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			// Setup test environment
-			fset := token.NewFileSet()
-			files := make(map[string]*xgo.File)
-			path := "/test.xgo"
-
-			files[path] = &xgo.File{
-				Content: []byte("package main"),
-				ModTime: time.Time{},
-			}
-
-			proj := xgo.NewProject(fset, files, xgo.FeatASTCache)
-			mockReplier := &MockReplier{}
-
-			// Create a TestServer
-			server := &Server{
-				workspaceRootFS:  proj,
-				replier:          mockReplier,
-				workspaceRootURI: "file://workspace/",
-			}
-
-			// Execute test
-			err := server.didClose(tt.params)
-
-			// Verify results
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			s := newTestServer(t, nil)
+			replier := newMockReplier()
+			s.replier = replier
+			uri := DocumentURI("file:///main.xgo")
+			require.NoError(t, s.didOpen(&DidOpenTextDocumentParams{
+				TextDocument: protocol.TextDocumentItem{URI: uri, LanguageID: "xgo", Version: 2, Text: tt.content},
+			}))
+			assert.Empty(t, requirePublishedDiagnostics(t, replier, uri))
+			opened, ok := s.getProj().File("main.xgo")
+			require.True(t, ok)
+			assert.Equal(t, tt.content, string(opened.Content))
+			assert.Equal(t, 2, opened.Version)
 		})
 	}
 }
 
-// TestChangedText tests the changedText function for processing document content changes
-func TestChangedText(t *testing.T) {
+func TestServerDocumentSynchronizationErrors(t *testing.T) {
 	for _, tt := range []struct {
-		name           string
-		initialContent string
-		changes        []protocol.TextDocumentContentChangeEvent
-		want           string
-		wantErr        bool
+		name string
+		run  func(*Server) error
+		want string
 	}{
-		{
-			name:           "FullDocumentReplacement",
-			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Text: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}",
-				},
-			},
-			want:    "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}",
-			wantErr: false,
-		},
-		{
-			name:           "IncrementalChangeAddComma",
-			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 3, Character: 19},
-						End:   protocol.Position{Line: 3, Character: 19},
-					},
-					Text: ",",
-				},
-			},
-			want:    "package main\n\nfunc main() {\n\tfmt.Println(\"Hello,\")\n}",
-			wantErr: false,
-		},
-		{
-			name:           "IncrementalChangeReplaceWord",
-			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 3, Character: 14},
-						End:   protocol.Position{Line: 3, Character: 19},
-					},
-					Text: "World",
-				},
-			},
-			want:    "package main\n\nfunc main() {\n\tfmt.Println(\"World\")\n}",
-			wantErr: false,
-		},
-		{
-			name:           "MultipleIncrementalChanges",
-			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 3, Character: 14},
-						End:   protocol.Position{Line: 3, Character: 19},
-					},
-					Text: "World",
-				},
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 3, Character: 19},
-						End:   protocol.Position{Line: 3, Character: 19},
-					},
-					Text: "!",
-				},
-			},
-			want:    "package main\n\nfunc main() {\n\tfmt.Println(\"World!\")\n}",
-			wantErr: false,
-		},
-		{
-			name:           "EmptyChangesArray",
-			initialContent: "package main",
-			changes:        []protocol.TextDocumentContentChangeEvent{},
-			want:           "",
-			wantErr:        true,
-		},
-		{
-			name:           "InvalidRangeEndBeforeStart",
-			initialContent: "package main",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 0, Character: 5},
-						End:   protocol.Position{Line: 0, Character: 3},
-					},
-					Text: "invalid",
-				},
-			},
-			want:    "",
-			wantErr: true,
-		},
+		{name: "OpenOutsideWorkspace", run: func(s *Server) error {
+			return s.didOpen(&DidOpenTextDocumentParams{TextDocument: protocol.TextDocumentItem{URI: "file:///outside/main.xgo"}})
+		}, want: "outside"},
+		{name: "ChangeOutsideWorkspace", run: func(s *Server) error {
+			return s.didChange(&DidChangeTextDocumentParams{TextDocument: protocol.VersionedTextDocumentIdentifier{TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///outside/main.xgo"}}})
+		}, want: "outside"},
+		{name: "SaveOutsideWorkspace", run: func(s *Server) error {
+			return s.didSave(&DidSaveTextDocumentParams{TextDocument: TextDocumentIdentifier{URI: "file:///outside/main.xgo"}, Text: ToPtr("println 1")})
+		}, want: "outside"},
+		{name: "EmptyChanges", run: func(s *Server) error {
+			return s.didChange(&DidChangeTextDocumentParams{TextDocument: protocol.VersionedTextDocumentIdentifier{TextDocumentIdentifier: TextDocumentIdentifier{URI: "file:///workspace/main.xgo"}}})
+		}, want: "no content changes provided"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			// Setup test environment
-			fset := token.NewFileSet()
-			files := make(map[string]*xgo.File)
-			path := "/test.xgo"
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte("println 1")})
+			s.workspaceRootURI = "file:///workspace/"
+			replier := newMockReplier()
+			s.replier = replier
+			require.ErrorContains(t, tt.run(s), tt.want)
+			assert.Empty(t, replier.getMessages())
+			current, ok := s.getProj().File("main.xgo")
+			require.True(t, ok)
+			assert.Equal(t, "println 1", string(current.Content))
+		})
+	}
+}
 
-			// Create initial file
-			files[path] = &xgo.File{
-				Content: []byte(tt.initialContent),
-				ModTime: time.Now(),
-			}
-
-			proj := xgo.NewProject(fset, files, xgo.FeatASTCache)
-
-			// For AST parsing to work, we need a real file with content
-			// parsed into the AST before we can apply changes
-			_, err := proj.ASTFile(path)
-			require.NoError(t, err)
-
-			server := &Server{
-				workspaceRootFS: proj,
-			}
-
-			// Execute test
-			got, err := server.changedText(path, tt.changes)
-
-			// Verify results
-			if tt.wantErr {
-				require.Error(t, err)
+func TestServerChangedText(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		changes []protocol.TextDocumentContentChangeEvent
+		want    string
+		wantErr string
+	}{
+		{name: "FullReplacement", changes: []protocol.TextDocumentContentChangeEvent{{Text: "println 2\n"}}, want: "println 2\n"},
+		{name: "EmptyChanges", wantErr: "no content changes provided"},
+		{name: "Incremental", changes: []protocol.TextDocumentContentChangeEvent{{Range: &Range{Start: Position{Character: 8}, End: Position{Character: 9}}, Text: "2"}}, want: "println 2\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte("println 1\n")})
+			got, err := s.changedText("main.xgo", tt.changes)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
-			}
-
-			if !tt.wantErr {
 				assert.Equal(t, tt.want, string(got))
 			}
 		})
 	}
 }
 
-// TestApplyIncrementalChanges tests the applyIncrementalChanges function
-func TestApplyIncrementalChanges(t *testing.T) {
+func TestServerApplyIncrementalChanges(t *testing.T) {
 	for _, tt := range []struct {
-		name           string
-		initialContent string
-		changes        []protocol.TextDocumentContentChangeEvent
-		want           string
-		wantErr        bool
+		name     string
+		filename string
+		changes  []protocol.TextDocumentContentChangeEvent
+		want     string
+		wantErr  string
 	}{
-		{
-			name:           "AddTextAtBeginning",
-			initialContent: "func main() {}",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 0, Character: 0},
-						End:   protocol.Position{Line: 0, Character: 0},
-					},
-					Text: "package main\n\n",
-				},
-			},
-			want:    "package main\n\nfunc main() {}",
-			wantErr: false,
-		},
-		{
-			name:           "AddTextInMiddle",
-			initialContent: "func main() {}",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 0, Character: 13},
-						End:   protocol.Position{Line: 0, Character: 13},
-					},
-					Text: "\n\tfmt.Println(\"Hello\")\n",
-				},
-			},
-			want:    "func main() {\n\tfmt.Println(\"Hello\")\n}",
-			wantErr: false,
-		},
-		{
-			name:           "DeleteText",
-			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 2, Character: 0},
-						End:   protocol.Position{Line: 4, Character: 1},
-					},
-					Text: "",
-				},
-			},
-			want:    "package main\n\n",
-			wantErr: false,
-		},
-		{
-			name:           "ReplaceEntireLine",
-			initialContent: "package main\n\nfunc main() {\n\tfmt.Println(\"Hello\")\n}",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 3, Character: 0},
-						End:   protocol.Position{Line: 3, Character: 21},
-					},
-					Text: "\tfmt.Println(\"Hello, World!\")",
-				},
-			},
-			want:    "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}",
-			wantErr: false,
-		},
-		{
-			name:           "NilRange",
-			initialContent: "package main",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: nil,
-					Text:  "new content",
-				},
-			},
-			want:    "",
-			wantErr: true,
-		},
-		{
-			name:           "NonExistentFile",
-			initialContent: "",
-			changes: []protocol.TextDocumentContentChangeEvent{
-				{
-					Range: &protocol.Range{
-						Start: protocol.Position{Line: 0, Character: 0},
-						End:   protocol.Position{Line: 0, Character: 0},
-					},
-					Text: "package main",
-				},
-			},
-			want:    "",
-			wantErr: true,
-		},
+		{name: "Beginning", changes: []protocol.TextDocumentContentChangeEvent{{Range: &Range{}, Text: "// hello\n"}}, want: "// hello\nprintln \"hello\"\n"},
+		{name: "Middle", changes: []protocol.TextDocumentContentChangeEvent{{Range: &Range{Start: Position{Character: 14}, End: Position{Character: 14}}, Text: ", world"}}, want: "println \"hello, world\"\n"},
+		{name: "Delete", changes: []protocol.TextDocumentContentChangeEvent{{Range: &Range{Start: Position{}, End: Position{Line: 1}}}}, want: ""},
+		{name: "Replace", changes: []protocol.TextDocumentContentChangeEvent{{Range: &Range{Start: Position{Character: 9}, End: Position{Character: 14}}, Text: "world"}}, want: "println \"world\"\n"},
+		{name: "SequentialUTF16", changes: []protocol.TextDocumentContentChangeEvent{
+			{Range: &Range{Start: Position{Character: 9}, End: Position{Character: 14}}, Text: "\U0001f600"},
+			{Range: &Range{Start: Position{Character: 11}, End: Position{Character: 11}}, Text: "!"},
+		}, want: "println \"\U0001f600!\"\n"},
+		{name: "NilRange", changes: []protocol.TextDocumentContentChangeEvent{{Text: "println 2"}}, wantErr: "unexpected nil range"},
+		{name: "ReversedRange", changes: []protocol.TextDocumentContentChangeEvent{{Range: &Range{Start: Position{Character: 4}, End: Position{Character: 2}}}}, wantErr: "invalid range"},
+		{name: "MissingFile", filename: "missing.xgo", wantErr: "file not found"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			// Setup test environment
-			fset := token.NewFileSet()
-			files := make(map[string]*xgo.File)
-			path := "/test.xgo"
-
-			if tt.initialContent != "" {
-				files[path] = &xgo.File{
-					Content: []byte(tt.initialContent),
-					ModTime: time.Now(),
-				}
+			s := newTestServer(t, map[string][]byte{"main.xgo": []byte("println \"hello\"\n")})
+			filename := tt.filename
+			if filename == "" {
+				filename = "main.xgo"
 			}
-
-			proj := xgo.NewProject(fset, files, xgo.FeatASTCache)
-
-			// For tests with content, ensure we have AST
-			if tt.initialContent != "" {
-				_, err := proj.ASTFile(path)
-				require.NoError(t, err)
-			}
-
-			server := &Server{
-				workspaceRootFS: proj,
-			}
-
-			// Execute test
-			got, err := server.applyIncrementalChanges(path, tt.changes)
-
-			// Verify results
-			if tt.wantErr {
-				require.Error(t, err)
+			got, err := s.applyIncrementalChanges(filename, tt.changes)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
-			}
-
-			if !tt.wantErr {
 				assert.Equal(t, tt.want, string(got))
-			}
-		})
-	}
-}
-
-// TestGetDiagnostics tests the getDiagnostics function for generating diagnostic information
-func TestGetDiagnostics(t *testing.T) {
-	for _, tt := range []struct {
-		name           string
-		content        string
-		path           string
-		wantDiagCount  int
-		wantSeverities []protocol.DiagnosticSeverity
-		wantErr        bool
-	}{
-		{
-			name:           "ImportErrors",
-			content:        "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\")\n}",
-			path:           "/test.xgo",
-			wantDiagCount:  1,
-			wantSeverities: []protocol.DiagnosticSeverity{SeverityError},
-			wantErr:        false,
-		},
-		{
-			name:           "SyntaxError",
-			content:        "package main\n\nfunc main() {\n\tfmt.Println(\"Hello, World!\"\n}", // Missing closing parenthesis
-			path:           "/syntax_error.xgo",
-			wantDiagCount:  8,
-			wantSeverities: []protocol.DiagnosticSeverity{SeverityError},
-			wantErr:        false,
-		},
-		{
-			name:           "TypeError",
-			content:        "package main\n\nfunc main() {\n\tvar x int = \"string\"\n}", // Type mismatch
-			path:           "/type_error.xgo",
-			wantDiagCount:  1,
-			wantSeverities: []protocol.DiagnosticSeverity{SeverityError},
-			wantErr:        false,
-		},
-		{
-			name:           "NoError",
-			content:        "package main\n\nfunc main() {\n\t}",
-			path:           "/code_error.xgo",
-			wantDiagCount:  0,
-			wantSeverities: []protocol.DiagnosticSeverity{},
-			wantErr:        false,
-		},
-		{
-			name:           "MultipleTypeErrors",
-			content:        "package main\n\nfunc main() {\n\tvar x int = \"string\"\n\tvar y bool = 42\n}",
-			path:           "/multiple_errors.xgo",
-			wantDiagCount:  2,
-			wantSeverities: []protocol.DiagnosticSeverity{SeverityError},
-			wantErr:        false,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			// Setup test environment
-			fset := token.NewFileSet()
-			files := make(map[string]*xgo.File)
-
-			// Create the test file
-			files[tt.path] = &xgo.File{
-				Content: []byte(tt.content),
-				ModTime: time.Now(),
-			}
-
-			// Create a mock Project that returns our predefined errors
-			server := &Server{
-				workspaceRootFS: xgo.NewProject(fset, files, xgo.FeatAll),
-			}
-
-			// Execute test
-			diagnostics, err := server.getDiagnostics(tt.path)
-
-			// Verify results
-			if tt.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-
-			assert.Len(t, diagnostics, tt.wantDiagCount)
-
-			// Check diagnostic severities
-			for i, diag := range diagnostics {
-				if i >= len(tt.wantSeverities) {
-					break
-				}
-				assert.Equal(t, tt.wantSeverities[i], diag.Severity)
 			}
 		})
 	}

--- a/xgo/ast.go
+++ b/xgo/ast.go
@@ -94,7 +94,7 @@ func buildASTPackageCache(proj *Project) (any, error) {
 				if el, ok := err.(scanner.ErrorList); ok {
 					parserErrs = append(parserErrs, el...)
 				} else {
-					parserErrs.Add(token.Position{}, err.Error())
+					parserErrs.Add(token.Position{Filename: file}, err.Error())
 				}
 			}
 			if astFile != nil {

--- a/xgo/ast_test.go
+++ b/xgo/ast_test.go
@@ -229,6 +229,10 @@ func ValidFunc() {}
 		require.NotNil(t, astPackageCache.astPkg)
 		assert.Error(t, astPackageCache.parserErr)
 		assert.Contains(t, astPackageCache.parserErr.Error(), ErrUnknownCacheKind.Error())
+		var parserErrs scanner.ErrorList
+		require.ErrorAs(t, astPackageCache.parserErr, &parserErrs)
+		require.Len(t, parserErrs, 1)
+		assert.Equal(t, "main.xgo", parserErrs[0].Pos.Filename)
 		assert.Empty(t, astPackageCache.astPkg.Files)
 	})
 }


### PR DESCRIPTION
Collect document and workspace diagnostics from project syntax, types, and analyzers so plain XGo and registered classfiles do not require an spx entry file. Keep spx resource and property analysis in a dedicated path selected by the framework registration.

Share syntax and type diagnostic collection with document updates. Preserve filenames for parse failures without an AST, report those failures through pull diagnostics, and return empty diagnostic arrays when clearing reports. Skip type errors without source positions so failed implicit imports do not panic in asynchronous diagnostics.

Move general diagnostics, document synchronization, initialization, and protocol tests to plain XGo and the isolated classfile framework without loading embedded package data. Cover UTF-16 ranges, cross-file errors, document edits, incomplete source, and framework import failures and recovery. Retain dedicated spx regressions for diagnostics, missing entry files, and resource rename dispatch.
