### PR TITLE
test(pkgdata): cover package data with isolated fixtures

### DIFF
--- a/cmd/pkgdatagen/generate_test.go
+++ b/cmd/pkgdatagen/generate_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	gotypes "go/types"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/goplus/xgolsw/xgo/xgoutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/gcexportdata"
+)
+
+func TestGenerate(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		pkgName string
+	}{
+		{name: "VersionedPackage", pkgName: "fixture"},
+		{name: "DifferentPackageName", pkgName: "sample"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			const pkgPath = "example.com/fixture/v2"
+			t.Chdir(t.TempDir())
+			require.NoError(t, os.WriteFile("go.mod", []byte("module "+pkgPath+"\n\ngo 1.25.0\n"), 0o644))
+			for name, source := range map[string]string{
+				"fixture.go": "// Package " + tt.pkgName + " provides fixture values.\npackage " + tt.pkgName + `
+
+// Limit bounds the number of records.
+const Limit = 7
+
+// Current holds the active record.
+var Current Record
+
+// Record holds a number.
+type Record struct {
+    // Number is the stored number.
+    Number int
+}
+
+// Double returns twice the stored number.
+func (r Record) Double() int { return r.Number * 2 }
+
+// Add returns the sum of its arguments.
+func Add(left, right int) int { return left + right }
+`,
+				"platform_js.go":    "package " + tt.pkgName + "\n\n// WasmOnly belongs to the browser build.\nconst WasmOnly = true\n",
+				"platform_linux.go": "package " + tt.pkgName + "\n\n// NativeOnly belongs to the native build.\nconst NativeOnly = true\n",
+				"fixture_test.go":   "package " + tt.pkgName + "\n\n// TestOnly belongs to the tests.\nconst TestOnly = true\n",
+			} {
+				require.NoError(t, os.WriteFile(name, []byte(source), 0o644))
+			}
+			outputFile := "pkgdata.zip"
+			require.NoError(t, generate([]string{pkgPath}, outputFile))
+			zr, err := zip.OpenReader(outputFile)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, zr.Close()) })
+			require.Len(t, zr.File, 2)
+
+			data := readGeneratedFile(t, zr, pkgPath+".pkgexport")
+			pkg, err := gcexportdata.Read(bytes.NewReader(data), token.NewFileSet(), make(map[string]*gotypes.Package), pkgPath)
+			require.NoError(t, err)
+			assert.True(t, pkg.Complete())
+			assert.Equal(t, tt.pkgName, pkg.Name())
+			assert.Equal(t, pkgPath, pkg.Path())
+			assert.Equal(t, []string{"Add", "Current", "Limit", "Record", "WasmOnly"}, pkg.Scope().Names())
+			limit, ok := pkg.Scope().Lookup("Limit").(*gotypes.Const)
+			require.True(t, ok)
+			assert.Equal(t, "7", limit.Val().ExactString())
+			add, ok := pkg.Scope().Lookup("Add").(*gotypes.Func)
+			require.True(t, ok)
+			require.Equal(t, 2, add.Signature().Params().Len())
+			assert.Equal(t, "left", add.Signature().Params().At(0).Name())
+			assert.Equal(t, gotypes.Typ[gotypes.Int], add.Signature().Params().At(0).Type())
+
+			var doc pkgdoc.PkgDoc
+			require.NoError(t, json.Unmarshal(readGeneratedFile(t, zr, pkgPath+".pkgdoc"), &doc))
+			assert.Equal(t, pkgdoc.PkgDoc{
+				Path: pkgPath, Name: tt.pkgName, Doc: "Package " + tt.pkgName + " provides fixture values.\n",
+				Vars: map[string]string{"Current": "Current holds the active record.\n"},
+				Consts: map[string]string{
+					"Limit":    "Limit bounds the number of records.\n",
+					"WasmOnly": "WasmOnly belongs to the browser build.\n",
+				},
+				Funcs: map[string]string{"Add": "Add returns the sum of its arguments.\n"},
+				Types: map[string]*pkgdoc.TypeDoc{"Record": {
+					Doc:     "Record holds a number.\n",
+					Fields:  map[string]string{"Number": "Number is the stored number.\n"},
+					Methods: map[string]string{"Double": "Double returns twice the stored number.\n"},
+				}},
+			}, doc)
+		})
+	}
+
+	t.Run("ClassfileFramework", func(t *testing.T) {
+		source, err := os.ReadFile(filepath.Join("..", "..", "internal", "testframework", "testdata", "framework.go"))
+		require.NoError(t, err)
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("go.mod", []byte("module "+testframework.PkgPath+"\n\ngo 1.25.0\n"), 0o644))
+		require.NoError(t, os.WriteFile("framework.go", source, 0o644))
+		require.NoError(t, generate([]string{testframework.PkgPath}, "pkgdata.zip"))
+		zr, err := zip.OpenReader("pkgdata.zip")
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, zr.Close()) })
+		require.Len(t, zr.File, 2)
+
+		data := readGeneratedFile(t, zr, testframework.PkgPath+".pkgexport")
+		pkg, err := gcexportdata.Read(bytes.NewReader(data), token.NewFileSet(), make(map[string]*gotypes.Package), testframework.PkgPath)
+		require.NoError(t, err)
+		assert.True(t, pkg.Complete())
+		assert.Equal(t, testframework.PkgPath, pkg.Path())
+		assert.Equal(t, "framework", pkg.Name())
+		assert.True(t, xgoutil.IsMarkedAsXGoPackage(pkg))
+
+		var doc pkgdoc.PkgDoc
+		require.NoError(t, json.Unmarshal(readGeneratedFile(t, zr, testframework.PkgPath+".pkgdoc"), &doc))
+		assert.Equal(t, testframework.PkgPath, doc.Path)
+		assert.Equal(t, "framework", doc.Name)
+		appDoc, itemDoc := doc.Types["App"], doc.Types["Item"]
+		require.NotNil(t, appDoc)
+		require.NotNil(t, itemDoc)
+		assert.Equal(t, "App is the project base class.\n", appDoc.Doc)
+		assert.Equal(t, "Item is the work base class.\n", itemDoc.Doc)
+		assert.Equal(t, "Value stores the work item's value.\n", itemDoc.Fields["Value"])
+
+		app := generatedNamedType(t, pkg, "App")
+		item := generatedNamedType(t, pkg, "Item")
+		itemStruct, ok := item.Underlying().(*gotypes.Struct)
+		require.True(t, ok)
+		require.Equal(t, 1, itemStruct.NumFields())
+		assert.Equal(t, "Value", itemStruct.Field(0).Name())
+		assert.Equal(t, gotypes.Typ[gotypes.Int], itemStruct.Field(0).Type())
+
+		for _, tt := range []struct {
+			name string
+			arg  gotypes.Type
+			doc  string
+		}{
+			{name: "Measure__0", arg: gotypes.Typ[gotypes.Int], doc: "Measure__0 is the integer overload of Measure.\n"},
+			{name: "Measure__1", arg: gotypes.Typ[gotypes.String], doc: "Measure__1 is the string overload of Measure.\n"},
+		} {
+			obj, _, _ := gotypes.LookupFieldOrMethod(gotypes.NewPointer(app), false, pkg, tt.name)
+			method, ok := obj.(*gotypes.Func)
+			require.True(t, ok, tt.name)
+			sig := method.Signature()
+			require.NotNil(t, sig.Recv())
+			assert.True(t, gotypes.Identical(gotypes.NewPointer(app), sig.Recv().Type()))
+			require.Equal(t, 1, sig.Params().Len())
+			assert.Equal(t, "value", sig.Params().At(0).Name())
+			assert.Equal(t, tt.arg, sig.Params().At(0).Type())
+			require.Equal(t, 1, sig.Results().Len())
+			assert.Equal(t, gotypes.Typ[gotypes.Int], sig.Results().At(0).Type())
+			assert.Equal(t, tt.doc, appDoc.Methods[tt.name])
+		}
+
+		create, ok := pkg.Scope().Lookup("XGot_App_XGox_Create").(*gotypes.Func)
+		require.True(t, ok)
+		createSig := create.Signature()
+		require.Equal(t, 1, createSig.TypeParams().Len())
+		require.Equal(t, 2, createSig.Params().Len())
+		assert.True(t, gotypes.Identical(gotypes.NewPointer(app), createSig.Params().At(0).Type()))
+		assert.Equal(t, "name", createSig.Params().At(1).Name())
+		assert.Equal(t, gotypes.Typ[gotypes.String], createSig.Params().At(1).Type())
+		require.Equal(t, 1, createSig.Results().Len())
+		result, ok := createSig.Results().At(0).Type().(*gotypes.Pointer)
+		require.True(t, ok)
+		assert.Same(t, createSig.TypeParams().At(0), result.Elem())
+		assert.True(t, gotypes.Identical(gotypes.Universe.Lookup("any").Type(), createSig.TypeParams().At(0).Constraint()))
+		assert.Equal(t, "XGot_App_XGox_Create provides a method with an explicit type argument.\n", appDoc.Methods["Create"])
+		assert.NotContains(t, appDoc.Methods, "XGox_Create")
+
+		entry, ok := pkg.Scope().Lookup("XGot_App_Main").(*gotypes.Func)
+		require.True(t, ok)
+		entrySig := entry.Signature()
+		require.Equal(t, 2, entrySig.Params().Len())
+		assert.True(t, entrySig.Variadic())
+		appConstraint, ok := entrySig.Params().At(0).Type().(*gotypes.Interface)
+		require.True(t, ok)
+		require.Equal(t, 1, appConstraint.NumMethods())
+		assert.Equal(t, "initApp", appConstraint.Method(0).Name())
+		assert.Same(t, pkg, appConstraint.Method(0).Pkg())
+		assert.True(t, gotypes.Implements(gotypes.NewPointer(app), appConstraint))
+		items, ok := entrySig.Params().At(1).Type().(*gotypes.Slice)
+		require.True(t, ok)
+		itemConstraint, ok := items.Elem().(*gotypes.Interface)
+		require.True(t, ok)
+		require.Equal(t, 1, itemConstraint.NumMethods())
+		assert.Equal(t, "Main", itemConstraint.Method(0).Name())
+		assert.True(t, gotypes.Implements(gotypes.NewPointer(item), itemConstraint))
+		assert.Equal(t, "XGot_App_Main receives the generated project and work classes.\n", appDoc.Methods["Main"])
+		assert.Equal(t, "Main is the work entry point.\n", itemDoc.Methods["Main"])
+	})
+
+	t.Run("Builtin", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "pkgdata.zip")
+		require.NoError(t, generate([]string{"builtin"}, outputFile))
+		zr, err := zip.OpenReader(outputFile)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, zr.Close()) })
+		require.Len(t, zr.File, 1)
+		var doc pkgdoc.PkgDoc
+		require.NoError(t, json.Unmarshal(readGeneratedFile(t, zr, "builtin.pkgdoc"), &doc))
+		assert.Equal(t, "builtin", doc.Path)
+		assert.Equal(t, "builtin", doc.Name)
+		assert.NotEmpty(t, doc.Funcs["len"])
+		assert.NotEmpty(t, doc.Consts["true"])
+		require.Contains(t, doc.Types, "int")
+		assert.NotEmpty(t, doc.Types["int"].Doc)
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "pkgdata.zip")
+		require.NoError(t, generate(nil, outputFile))
+		zr, err := zip.OpenReader(outputFile)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, zr.Close()) })
+		assert.Empty(t, zr.File)
+	})
+
+	t.Run("MissingOutputDirectory", func(t *testing.T) {
+		outputFile := filepath.Join(t.TempDir(), "missing", "pkgdata.zip")
+		assert.ErrorIs(t, generate(nil, outputFile), fs.ErrNotExist)
+	})
+
+	t.Run("InvalidPackage", func(t *testing.T) {
+		const pkgPath = "example.com/invalid"
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("go.mod", []byte("module "+pkgPath+"\n\ngo 1.25.0\n"), 0o644))
+		require.NoError(t, os.WriteFile("invalid.go", []byte("package invalid\nconst Value int = \"invalid\"\n"), 0o644))
+		err := generate([]string{pkgPath}, "pkgdata.zip")
+		require.ErrorContains(t, err, "failed to execute go command")
+		assert.ErrorContains(t, err, "cannot use")
+		assert.NoFileExists(t, "pkgdata.zip")
+	})
+}
+
+func generatedNamedType(t *testing.T, pkg *gotypes.Package, name string) *gotypes.Named {
+	t.Helper()
+
+	obj, ok := pkg.Scope().Lookup(name).(*gotypes.TypeName)
+	require.True(t, ok, name)
+	named, ok := obj.Type().(*gotypes.Named)
+	require.True(t, ok, name)
+	return named
+}
+
+func readGeneratedFile(t *testing.T, zr *zip.ReadCloser, name string) []byte {
+	t.Helper()
+
+	rc, err := zr.Open(name)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, rc.Close()) })
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	return data
+}

--- a/cmd/pkgdatagen/main.go
+++ b/cmd/pkgdatagen/main.go
@@ -34,7 +34,6 @@ import (
 	"slices"
 
 	"github.com/goplus/xgolsw/pkgdoc"
-	"golang.org/x/mod/module"
 	"golang.org/x/tools/go/gcexportdata"
 
 	_ "github.com/goplus/spx/v3"
@@ -170,12 +169,7 @@ func generate(pkgPaths []string, outputFile string) error {
 			continue
 		}
 
-		var pkgName string
-		if prefix, _, ok := module.SplitPathVersion(pkgPath); ok {
-			pkgName = path.Base(prefix)
-		} else {
-			pkgName = path.Base(buildPkg.ImportPath)
-		}
+		pkgName := buildPkg.Name
 
 		var pkgDoc *pkgdoc.PkgDoc
 		if pkgPath == "builtin" {

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,8 @@ declare global {
   function NewXGoLanguageServer(filesProvider: () => Files, messageReplier: (message: ResponseMessage | NotificationMessage) => void): XGoLanguageServer | Error
 
   /**
-   * Sets custom package data that will be used with higher priority than the embedded package data.
+   * Sets custom package data that will be used with higher priority than the embedded package data and clears cached
+   * package documentation. Set export data before creating a language server. Already imported types are not refreshed.
    *
    * @param data - Custom package data as a Uint8Array containing a valid pkgdata.zip file.
    */

--- a/internal/importer.go
+++ b/internal/importer.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	gotypes "go/types"
+	"io"
 	"sync"
 
 	"github.com/goplus/xgo/token"
@@ -10,24 +11,24 @@ import (
 	"golang.org/x/tools/go/gcexportdata"
 )
 
-// importer implements [types.Importer].
+// importer implements [go/types.Importer].
 type importer struct {
-	mu     sync.Mutex
-	fset   *token.FileSet
-	loaded map[string]*gotypes.Package
+	mu         sync.Mutex
+	fset       *token.FileSet
+	loaded     map[string]*gotypes.Package
+	openExport func(string) (io.ReadCloser, error)
 }
 
-// newImporter creates a new instance of [importer].
-func newImporter() *importer {
-	loaded := make(map[string]*gotypes.Package)
-	loaded["unsafe"] = gotypes.Unsafe
+// newImporter creates an importer that reads export data using openExport.
+func newImporter(openExport func(string) (io.ReadCloser, error)) *importer {
 	return &importer{
-		fset:   token.NewFileSet(),
-		loaded: loaded,
+		fset:       token.NewFileSet(),
+		loaded:     map[string]*gotypes.Package{"unsafe": gotypes.Unsafe},
+		openExport: openExport,
 	}
 }
 
-// Import implements [types.Importer].
+// Import implements [go/types.Importer].
 func (imp *importer) Import(path string) (*gotypes.Package, error) {
 	imp.mu.Lock()
 	defer imp.mu.Unlock()
@@ -36,7 +37,7 @@ func (imp *importer) Import(path string) (*gotypes.Package, error) {
 		return pkg, nil
 	}
 
-	export, err := pkgdata.OpenExport(path)
+	export, err := imp.openExport(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open package export file: %w", err)
 	}
@@ -50,4 +51,4 @@ func (imp *importer) Import(path string) (*gotypes.Package, error) {
 }
 
 // Importer is the global instance of [importer].
-var Importer = newImporter()
+var Importer = newImporter(pkgdata.OpenExport)

--- a/internal/importer_test.go
+++ b/internal/importer_test.go
@@ -1,0 +1,239 @@
+package internal
+
+import (
+	"bytes"
+	"errors"
+	goast "go/ast"
+	goparser "go/parser"
+	gotypes "go/types"
+	"io"
+	"io/fs"
+	"sync"
+	"testing"
+	"testing/fstest"
+	"testing/iotest"
+
+	"github.com/goplus/xgo/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/gcexportdata"
+)
+
+func TestImporterImport(t *testing.T) {
+	t.Run("ExportedSymbolsAndCache", func(t *testing.T) {
+		const pkgPath = "example.com/sample"
+		data := exportTestPackage(t, pkgPath, `package sample
+const Limit = 7
+var Current Value
+type Value struct { Number int }
+func (v Value) Double() int { return v.Number * 2 }
+func Read() Value { return Current }
+`, nil)
+		var opened int
+		reader := &exportReadCloser{Reader: bytes.NewReader(data)}
+		imp := newImporter(func(path string) (io.ReadCloser, error) {
+			assert.Equal(t, pkgPath, path)
+			opened++
+			return reader, nil
+		})
+		pkg, err := imp.Import(pkgPath)
+		require.NoError(t, err)
+		require.NotNil(t, pkg)
+		assert.True(t, pkg.Complete())
+		assert.Equal(t, pkgPath, pkg.Path())
+		assert.Equal(t, "sample", pkg.Name())
+		limit, ok := pkg.Scope().Lookup("Limit").(*gotypes.Const)
+		require.True(t, ok)
+		assert.Equal(t, "7", limit.Val().ExactString())
+		valueObj := pkg.Scope().Lookup("Value")
+		require.NotNil(t, valueObj)
+		value, ok := valueObj.Type().(*gotypes.Named)
+		require.True(t, ok)
+		underlying, ok := value.Underlying().(*gotypes.Struct)
+		require.True(t, ok)
+		require.Equal(t, 1, underlying.NumFields())
+		assert.Equal(t, "Number", underlying.Field(0).Name())
+		assert.Equal(t, gotypes.Typ[gotypes.Int], underlying.Field(0).Type())
+		require.Equal(t, 1, value.NumMethods())
+		assert.Equal(t, "Double", value.Method(0).Name())
+		current := pkg.Scope().Lookup("Current")
+		require.NotNil(t, current)
+		assert.Same(t, value, current.Type())
+		read, ok := pkg.Scope().Lookup("Read").(*gotypes.Func)
+		require.True(t, ok)
+		require.Equal(t, 1, read.Signature().Results().Len())
+		assert.Same(t, value, read.Signature().Results().At(0).Type())
+		assert.True(t, reader.closed)
+
+		cached, err := imp.Import(pkgPath)
+		require.NoError(t, err)
+		assert.Same(t, pkg, cached)
+		assert.Equal(t, 1, opened)
+	})
+
+	t.Run("Unsafe", func(t *testing.T) {
+		var opened bool
+		imp := newImporter(func(string) (io.ReadCloser, error) {
+			opened = true
+			return nil, fs.ErrNotExist
+		})
+		pkg, err := imp.Import("unsafe")
+		require.NoError(t, err)
+		assert.Same(t, gotypes.Unsafe, pkg)
+		assert.False(t, opened)
+	})
+
+	t.Run("DependencyIdentity", func(t *testing.T) {
+		const depPath = "example.com/dependency"
+		const consumerPath = "example.com/consumer"
+		depData := exportTestPackage(t, depPath, `package dependency
+type Value struct { Number int }
+func Extra() {}
+`, nil)
+		files := fstest.MapFS{depPath + ".pkgexport": {Data: depData}}
+		consumerData := exportTestPackage(t, consumerPath, `package consumer
+import "example.com/dependency"
+func Read() dependency.Value { return dependency.Value{} }
+`, importerForTestFiles(files))
+		files[consumerPath+".pkgexport"] = &fstest.MapFile{Data: consumerData}
+
+		for _, tt := range []struct {
+			name            string
+			dependencyFirst bool
+		}{
+			{name: "DependencyFirst", dependencyFirst: true},
+			{name: "ConsumerFirst"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				imp := importerForTestFiles(files)
+				if tt.dependencyFirst {
+					_, err := imp.Import(depPath)
+					require.NoError(t, err)
+				}
+				consumer, err := imp.Import(consumerPath)
+				require.NoError(t, err)
+				read, ok := consumer.Scope().Lookup("Read").(*gotypes.Func)
+				require.True(t, ok)
+				require.Equal(t, 1, read.Signature().Results().Len())
+				resultType, ok := read.Signature().Results().At(0).Type().(*gotypes.Named)
+				require.True(t, ok)
+
+				dep, err := imp.Import(depPath)
+				require.NoError(t, err)
+				assert.True(t, dep.Complete())
+				assert.NotNil(t, dep.Scope().Lookup("Extra"))
+				assert.Same(t, dep, resultType.Obj().Pkg())
+				value := dep.Scope().Lookup("Value")
+				require.NotNil(t, value)
+				assert.Same(t, value.Type(), resultType)
+			})
+		}
+	})
+
+	t.Run("MissingExportAndRetry", func(t *testing.T) {
+		const pkgPath = "example.com/retry"
+		files := fstest.MapFS{}
+		imp := importerForTestFiles(files)
+		pkg, err := imp.Import(pkgPath)
+		require.ErrorIs(t, err, fs.ErrNotExist)
+		assert.ErrorContains(t, err, "failed to open package export file")
+		assert.Nil(t, pkg)
+
+		files[pkgPath+".pkgexport"] = &fstest.MapFile{Data: exportTestPackage(t, pkgPath, "package retry\nconst Ready = true\n", nil)}
+		pkg, err = imp.Import(pkgPath)
+		require.NoError(t, err)
+		assert.NotNil(t, pkg.Scope().Lookup("Ready"))
+	})
+
+	for _, tt := range []struct {
+		name    string
+		reader  io.Reader
+		message string
+	}{
+		{name: "EmptyExport", reader: bytes.NewReader(nil), message: "empty export data"},
+		{name: "MalformedExport", reader: bytes.NewBufferString("invalid export"), message: "failed to parse package export data"},
+		{name: "ReadError", reader: iotest.ErrReader(fs.ErrPermission), message: "permission denied"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &exportReadCloser{Reader: tt.reader}
+			imp := newImporter(func(string) (io.ReadCloser, error) { return reader, nil })
+			pkg, err := imp.Import("example.com/invalid")
+			require.ErrorContains(t, err, "failed to parse package export data")
+			assert.ErrorContains(t, err, tt.message)
+			assert.Nil(t, pkg)
+			assert.True(t, reader.closed)
+		})
+	}
+
+	t.Run("MalformedExportAndRetry", func(t *testing.T) {
+		const pkgPath = "example.com/retry"
+		files := fstest.MapFS{pkgPath + ".pkgexport": {Data: []byte("invalid export")}}
+		imp := importerForTestFiles(files)
+		_, err := imp.Import(pkgPath)
+		require.Error(t, err)
+		files[pkgPath+".pkgexport"] = &fstest.MapFile{Data: exportTestPackage(t, pkgPath, "package retry\nconst Ready = true\n", nil)}
+		pkg, err := imp.Import(pkgPath)
+		require.NoError(t, err)
+		assert.NotNil(t, pkg.Scope().Lookup("Ready"))
+	})
+
+	t.Run("ConcurrentImports", func(t *testing.T) {
+		const pkgPath = "example.com/concurrent"
+		data := exportTestPackage(t, pkgPath, "package concurrent\ntype Value struct { Number int }\n", nil)
+		var opened int
+		imp := newImporter(func(string) (io.ReadCloser, error) {
+			opened++
+			return io.NopCloser(bytes.NewReader(data)), nil
+		})
+		const count = 16
+		pkgs := make([]*gotypes.Package, count)
+		errs := make([]error, count)
+		var wg sync.WaitGroup
+		for i := range count {
+			wg.Go(func() { pkgs[i], errs[i] = imp.Import(pkgPath) })
+		}
+		wg.Wait()
+		for i := range count {
+			require.NoError(t, errs[i])
+			require.NotNil(t, pkgs[i])
+			assert.Same(t, pkgs[0], pkgs[i])
+		}
+		assert.Equal(t, 1, opened)
+	})
+
+	t.Run("OpenError", func(t *testing.T) {
+		wantErr := errors.New("export unavailable")
+		imp := newImporter(func(string) (io.ReadCloser, error) { return nil, wantErr })
+		pkg, err := imp.Import("example.com/unavailable")
+		require.ErrorIs(t, err, wantErr)
+		assert.Nil(t, pkg)
+	})
+}
+
+func exportTestPackage(t *testing.T, path, source string, imp gotypes.Importer) []byte {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := goparser.ParseFile(fset, "fixture.go", source, 0)
+	require.NoError(t, err)
+	config := gotypes.Config{Importer: imp}
+	pkg, err := config.Check(path, fset, []*goast.File{file}, nil)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	require.NoError(t, gcexportdata.Write(&buf, fset, pkg))
+	return buf.Bytes()
+}
+
+func importerForTestFiles(files fstest.MapFS) *importer {
+	return newImporter(func(path string) (io.ReadCloser, error) { return files.Open(path + ".pkgexport") })
+}
+
+type exportReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *exportReadCloser) Close() error {
+	r.closed = true
+	return nil
+}

--- a/internal/pkgdata/pkgdata.go
+++ b/internal/pkgdata/pkgdata.go
@@ -22,14 +22,23 @@ var (
 	//go:embed pkgdata.zip
 	pkgdataZip []byte
 
+	// pkgdataMu synchronizes package data replacement with reads and cache updates.
+	pkgdataMu sync.RWMutex
+
 	// customPkgdataZip holds the user-provided package data which has
 	// higher priority than the embedded one.
 	customPkgdataZip []byte
 )
 
-// SetCustomPkgdataZip sets the customPkgdataZip.
+// SetCustomPkgdataZip replaces the custom package data and clears cached documentation.
+// It does not refresh types already loaded by importers. Set export data before
+// importing the affected packages. The caller must not modify data after this call.
 func SetCustomPkgdataZip(data []byte) {
+	pkgdataMu.Lock()
+	defer pkgdataMu.Unlock()
+
 	customPkgdataZip = data
+	pkgDocCache.Clear()
 }
 
 const (
@@ -39,6 +48,9 @@ const (
 
 // ListPkgs lists all packages in the pkgdata.zip file.
 func ListPkgs() ([]string, error) {
+	pkgdataMu.RLock()
+	defer pkgdataMu.RUnlock()
+
 	pkgs, err := listPkgs(pkgdataZip)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list embed packages: %w", err)
@@ -72,6 +84,9 @@ func listPkgs(zipData []byte) ([]string, error) {
 
 // OpenExport opens a package export file.
 func OpenExport(pkgPath string) (io.ReadCloser, error) {
+	pkgdataMu.RLock()
+	defer pkgdataMu.RUnlock()
+
 	if len(customPkgdataZip) > 0 {
 		rc, err := openExport(customPkgdataZip, pkgPath)
 		if err == nil {
@@ -103,6 +118,9 @@ var pkgDocCache sync.Map // map[string]*pkgdoc.PkgDoc
 
 // GetPkgDoc gets the documentation for a package.
 func GetPkgDoc(pkgPath string) (pkgDoc *pkgdoc.PkgDoc, err error) {
+	pkgdataMu.RLock()
+	defer pkgdataMu.RUnlock()
+
 	if pkgDocIface, ok := pkgDocCache.Load(pkgPath); ok {
 		return pkgDocIface.(*pkgdoc.PkgDoc), nil
 	}

--- a/internal/pkgdata/pkgdata_test.go
+++ b/internal/pkgdata/pkgdata_test.go
@@ -1,0 +1,375 @@
+package pkgdata
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/fs"
+	"maps"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListPkgs(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		embedded map[string]string
+		custom   []byte
+		want     []string
+	}{
+		{name: "Empty"},
+		{
+			name: "Embedded",
+			embedded: map[string]string{
+				"example.com/alpha.pkgexport": "export",
+				"example.com/alpha.pkgdoc":    "{}",
+				"example.com/docs.pkgdoc":     "{}",
+				"README.txt":                  "ignored",
+			},
+			want: []string{"example.com/alpha"},
+		},
+		{
+			name:   "CustomOnly",
+			custom: newPkgdataZip(t, map[string]string{"example.com/beta.pkgexport": "export"}),
+			want:   []string{"example.com/beta"},
+		},
+		{
+			name: "MergeAndDeduplicate",
+			embedded: map[string]string{
+				"example.com/beta.pkgexport": "embedded",
+				"example.com/zeta.pkgexport": "export",
+			},
+			custom: newPkgdataZip(t, map[string]string{
+				"example.com/alpha.pkgexport": "export",
+				"example.com/beta.pkgexport":  "custom",
+			}),
+			want: []string{"example.com/alpha", "example.com/beta", "example.com/zeta"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setTestPackageData(t, newPkgdataZip(t, tt.embedded), tt.custom)
+			pkgs, err := ListPkgs()
+			require.NoError(t, err)
+			if len(tt.want) == 0 {
+				assert.Empty(t, pkgs)
+			} else {
+				assert.Equal(t, tt.want, pkgs)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name     string
+		embedded []byte
+		custom   []byte
+		message  string
+	}{
+		{name: "InvalidEmbedded", embedded: []byte("invalid zip"), message: "failed to list embed packages"},
+		{name: "InvalidCustom", embedded: newPkgdataZip(t, nil), custom: []byte("invalid zip"), message: "failed to list custom packages"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setTestPackageData(t, tt.embedded, tt.custom)
+			pkgs, err := ListPkgs()
+			require.ErrorIs(t, err, zip.ErrFormat)
+			assert.ErrorContains(t, err, tt.message)
+			assert.Nil(t, pkgs)
+		})
+	}
+}
+
+func TestOpenExport(t *testing.T) {
+	const pkgPath = "example.com/sample"
+	for _, tt := range []struct {
+		name   string
+		custom []byte
+		want   string
+	}{
+		{name: "Embedded", want: "embedded export"},
+		{name: "CustomOverridesEmbedded", custom: newPkgdataZip(t, map[string]string{pkgPath + ".pkgexport": "custom export"}), want: "custom export"},
+		{name: "MissingCustomFallsBack", custom: newPkgdataZip(t, map[string]string{"example.com/other.pkgexport": "other export"}), want: "embedded export"},
+		{name: "EmptyCustomFallsBack", custom: newPkgdataZip(t, nil), want: "embedded export"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setTestPackageData(t, newPkgdataZip(t, map[string]string{pkgPath + ".pkgexport": "embedded export"}), tt.custom)
+			rc, err := OpenExport(pkgPath)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, rc.Close()) })
+			data, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(data))
+		})
+	}
+
+	for _, tt := range []struct {
+		name     string
+		embedded []byte
+		custom   []byte
+		wantErr  error
+		message  string
+	}{
+		{name: "Missing", embedded: newPkgdataZip(t, nil), custom: newPkgdataZip(t, nil), wantErr: fs.ErrNotExist, message: pkgPath},
+		{name: "InvalidEmbedded", embedded: []byte("invalid zip"), wantErr: zip.ErrFormat, message: "failed to create zip reader"},
+		{
+			name:     "InvalidCustomDoesNotFallBack",
+			embedded: newPkgdataZip(t, map[string]string{pkgPath + ".pkgexport": "embedded export"}),
+			custom:   []byte("invalid zip"), wantErr: zip.ErrFormat, message: "failed to open custom package export file",
+		},
+		{
+			name:     "UnsupportedCompressionDoesNotFallBack",
+			embedded: newPkgdataZip(t, map[string]string{pkgPath + ".pkgexport": "embedded export"}),
+			custom:   unsupportedCompressionZip(t, pkgPath+".pkgexport"), wantErr: zip.ErrAlgorithm, message: "failed to open custom package export file",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setTestPackageData(t, tt.embedded, tt.custom)
+			rc, err := OpenExport(pkgPath)
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.ErrorContains(t, err, tt.message)
+			assert.Nil(t, rc)
+		})
+	}
+}
+
+func TestGetPkgDoc(t *testing.T) {
+	const pkgPath = "example.com/sample"
+	embeddedDoc := &pkgdoc.PkgDoc{
+		Path: pkgPath, Name: "sample", Doc: "Package sample provides test data.\n",
+		Vars:   map[string]string{"Current": "Current holds the value.\n"},
+		Consts: map[string]string{"Limit": "Limit bounds the value.\n"},
+		Funcs:  map[string]string{"Read": "Read returns the value.\n"},
+		Types: map[string]*pkgdoc.TypeDoc{"Value": {
+			Doc:         "Value holds a number.\n",
+			Fields:      map[string]string{"Number": "Number is the value.\n"},
+			Methods:     map[string]string{"Get": "Get returns the number.\n"},
+			EnumMembers: map[string]string{"First": "First is the initial value.\n"},
+		}},
+	}
+	customDoc := &pkgdoc.PkgDoc{Path: pkgPath, Name: "sample", Doc: "Custom documentation.\n"}
+	encodeDoc := func(doc *pkgdoc.PkgDoc) string {
+		t.Helper()
+		data, err := json.Marshal(doc)
+		require.NoError(t, err)
+		return string(data)
+	}
+	for _, tt := range []struct {
+		name   string
+		custom []byte
+		want   *pkgdoc.PkgDoc
+	}{
+		{name: "Embedded", want: embeddedDoc},
+		{name: "CustomOverridesEmbedded", custom: newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": encodeDoc(customDoc)}), want: customDoc},
+		{name: "MissingCustomFallsBack", custom: newPkgdataZip(t, map[string]string{"example.com/other.pkgdoc": "{}"}), want: embeddedDoc},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setTestPackageData(t, newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": encodeDoc(embeddedDoc)}), tt.custom)
+			doc, err := GetPkgDoc(pkgPath)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, doc)
+			cachedDoc, err := GetPkgDoc(pkgPath)
+			require.NoError(t, err)
+			assert.Same(t, doc, cachedDoc)
+		})
+	}
+
+	for _, tt := range []struct {
+		name     string
+		embedded []byte
+		custom   []byte
+		wantErr  error
+		message  string
+	}{
+		{name: "Missing", embedded: newPkgdataZip(t, nil), custom: newPkgdataZip(t, nil), wantErr: fs.ErrNotExist, message: pkgPath},
+		{name: "InvalidEmbedded", embedded: []byte("invalid zip"), wantErr: zip.ErrFormat, message: "failed to create zip reader"},
+		{
+			name:     "InvalidCustomDoesNotFallBack",
+			embedded: newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": encodeDoc(embeddedDoc)}),
+			custom:   []byte("invalid zip"), wantErr: zip.ErrFormat, message: "failed to get custom package doc",
+		},
+		{
+			name:     "InvalidJSONDoesNotFallBack",
+			embedded: newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": encodeDoc(embeddedDoc)}),
+			custom:   newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": "{"}), wantErr: io.ErrUnexpectedEOF, message: "failed to decode doc",
+		},
+		{
+			name:     "UnsupportedCompressionDoesNotFallBack",
+			embedded: newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": encodeDoc(embeddedDoc)}),
+			custom:   unsupportedCompressionZip(t, pkgPath+".pkgdoc"), wantErr: zip.ErrAlgorithm, message: "failed to open doc file",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			setTestPackageData(t, tt.embedded, tt.custom)
+			doc, err := GetPkgDoc(pkgPath)
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.ErrorContains(t, err, tt.message)
+			assert.Nil(t, doc)
+			doc, err = GetPkgDoc(pkgPath)
+			require.ErrorIs(t, err, tt.wantErr, "failed lookups must not be cached as successful results")
+			assert.Nil(t, doc)
+
+			SetCustomPkgdataZip(newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": encodeDoc(customDoc)}))
+			doc, err = GetPkgDoc(pkgPath)
+			require.NoError(t, err)
+			assert.Equal(t, customDoc, doc)
+		})
+	}
+}
+
+func TestSetCustomPkgdataZip(t *testing.T) {
+	t.Run("PackageList", func(t *testing.T) {
+		const pkgPath = "example.com/custom"
+		setTestPackageData(t, newPkgdataZip(t, nil), nil)
+		SetCustomPkgdataZip(newPkgdataZip(t, map[string]string{pkgPath + ".pkgexport": "export"}))
+		pkgs, err := ListPkgs()
+		require.NoError(t, err)
+		assert.Equal(t, []string{pkgPath}, pkgs)
+
+		SetCustomPkgdataZip(nil)
+		pkgs, err = ListPkgs()
+		require.NoError(t, err)
+		assert.Empty(t, pkgs)
+	})
+
+	t.Run("DocumentationUpdates", func(t *testing.T) {
+		const pkgPath = "example.com/sample"
+		setTestPackageData(t, newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": `{"Doc":"embedded"}`}), nil)
+		for _, tt := range []struct {
+			data []byte
+			want string
+		}{
+			{want: "embedded"},
+			{data: newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": `{"Doc":"custom"}`}), want: "custom"},
+			{data: newPkgdataZip(t, map[string]string{pkgPath + ".pkgdoc": `{"Doc":"replacement"}`}), want: "replacement"},
+			{want: "embedded"},
+		} {
+			SetCustomPkgdataZip(tt.data)
+			doc, err := GetPkgDoc(pkgPath)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, doc.Doc)
+		}
+	})
+
+	t.Run("OpenExportSnapshot", func(t *testing.T) {
+		const pkgPath = "example.com/sample"
+		setTestPackageData(t, newPkgdataZip(t, nil), newPkgdataZip(t, map[string]string{pkgPath + ".pkgexport": "original"}))
+		original, err := OpenExport(pkgPath)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, original.Close()) })
+
+		SetCustomPkgdataZip(newPkgdataZip(t, map[string]string{pkgPath + ".pkgexport": "replacement"}))
+		replacement, err := OpenExport(pkgPath)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, replacement.Close()) })
+		SetCustomPkgdataZip(nil)
+
+		data, err := io.ReadAll(original)
+		require.NoError(t, err)
+		assert.Equal(t, "original", string(data))
+		data, err = io.ReadAll(replacement)
+		require.NoError(t, err)
+		assert.Equal(t, "replacement", string(data))
+	})
+
+	t.Run("ConcurrentAccess", func(t *testing.T) {
+		const pkgPath = "example.com/sample"
+		embedded := newPkgdataZip(t, map[string]string{
+			pkgPath + ".pkgexport": "embedded",
+			pkgPath + ".pkgdoc":    `{"Doc":"embedded"}`,
+		})
+		custom := newPkgdataZip(t, map[string]string{
+			pkgPath + ".pkgexport": "custom",
+			pkgPath + ".pkgdoc":    `{"Doc":"custom"}`,
+		})
+		replacement := newPkgdataZip(t, map[string]string{
+			pkgPath + ".pkgexport": "replacement",
+			pkgPath + ".pkgdoc":    `{"Doc":"replacement"}`,
+		})
+		setTestPackageData(t, embedded, nil)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			<-start
+			for range 100 {
+				SetCustomPkgdataZip(custom)
+				SetCustomPkgdataZip(nil)
+			}
+			SetCustomPkgdataZip(replacement)
+		})
+		for range 4 {
+			wg.Go(func() {
+				<-start
+				for range 100 {
+					pkgs, err := ListPkgs()
+					assert.NoError(t, err)
+					assert.Equal(t, []string{pkgPath}, pkgs)
+					rc, err := OpenExport(pkgPath)
+					if !assert.NoError(t, err) {
+						return
+					}
+					t.Cleanup(func() { require.NoError(t, rc.Close()) })
+					data, err := io.ReadAll(rc)
+					assert.NoError(t, err)
+					assert.Contains(t, []string{"embedded", "custom", "replacement"}, string(data))
+					doc, err := GetPkgDoc(pkgPath)
+					if assert.NoError(t, err) && assert.NotNil(t, doc) {
+						assert.Contains(t, []string{"embedded", "custom", "replacement"}, doc.Doc)
+					}
+				}
+			})
+		}
+		close(start)
+		wg.Wait()
+
+		doc, err := GetPkgDoc(pkgPath)
+		require.NoError(t, err)
+		assert.Equal(t, "replacement", doc.Doc)
+	})
+}
+
+func setTestPackageData(t *testing.T, embedded, custom []byte) {
+	t.Helper()
+
+	// These tests own package-level data and must not run in parallel.
+	pkgdataMu.Lock()
+	originalEmbedded, originalCustom := pkgdataZip, customPkgdataZip
+	t.Cleanup(func() {
+		pkgdataMu.Lock()
+		pkgdataZip, customPkgdataZip = originalEmbedded, originalCustom
+		pkgDocCache.Clear()
+		pkgdataMu.Unlock()
+	})
+	pkgdataZip, customPkgdataZip = embedded, custom
+	pkgDocCache.Clear()
+	pkgdataMu.Unlock()
+}
+
+func newPkgdataZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, name := range slices.Sorted(maps.Keys(files)) {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = io.WriteString(w, files[name])
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func unsupportedCompressionZip(t *testing.T, name string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	_, err := zw.CreateRaw(&zip.FileHeader{Name: name, Method: 0xffff})
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}

--- a/main.go
+++ b/main.go
@@ -107,7 +107,9 @@ func (s *JSScheduler) Sched() {
 }
 
 // SetCustomPkgdataZip sets custom package data that will be used with higher
-// priority than the embedded package data.
+// priority than the embedded package data and clears cached package documentation.
+// Set export data before creating a language server. Already imported types are
+// not refreshed.
 func SetCustomPkgdataZip(this js.Value, args []js.Value) any {
 	if len(args) != 1 {
 		return errors.New("SetCustomPkgdataZip: expected 1 argument")


### PR DESCRIPTION
Test package listing, export loading, documentation, and importer caching with synthetic archives and export data, without reading the embedded package archive. Allow importer tests to supply their export opener and cover dependency identity, concurrent imports, and failure recovery.

Generate temporary Go packages and the shared classfile framework to verify ZIP exports and documentation, including XGo markers, overloads, generic XGot signatures, and method documentation ownership. Cover build target filtering and invalid inputs, and retain the spx engine regression.

Use declared package names when generating documentation so packages whose names differ from their import paths are included.

Clear cached documentation when custom package data is replaced or removed, and synchronize replacement with reads and cache updates to prevent data races and stale entries. Cover concurrent access and open export readers, and document that already imported types are not refreshed.
