### PR TITLE
test(server): isolate test server initialization

### DIFF
--- a/internal/server/completion_context_test.go
+++ b/internal/server/completion_context_test.go
@@ -14,12 +14,13 @@ func TestServerTextDocumentCompletionContext(t *testing.T) {
 			name         string
 			filename     string
 			needsProject bool
+			newServer    testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "LegacyXGo", filename: "main.gop"},
-			{name: "StandaloneClass", filename: "Record.gox"},
-			{name: "ProjectClass", filename: "main_fixture.gox"},
-			{name: "WorkClass", filename: "Worker_fixture.gox", needsProject: true},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", needsProject: true, newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{
@@ -37,7 +38,7 @@ func candidateVoid() {}
 				if tt.needsProject {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := tt.newServer(t, files)
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 
@@ -132,7 +133,7 @@ func candidateVoid() {}
 `
 						files := map[string][]byte{"main_fixture.gox": nil}
 						files[class.filename] = []byte(prefix + tt.body)
-						s := newTestServer(t, files)
+						s := newFrameworkTestServer(t, files)
 						_, err := s.workspaceRootFS.TypeInfo()
 						require.NoError(t, err)
 

--- a/internal/server/completion_enum_test.go
+++ b/internal/server/completion_enum_test.go
@@ -12,14 +12,15 @@ import (
 func TestServerTextDocumentCompletionEnums(t *testing.T) {
 	t.Run("SourceKinds", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
+			name      string
+			filename  string
+			newServer testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "LegacyXGo", filename: "main.gop"},
-			{name: "StandaloneClass", filename: "Record.gox"},
-			{name: "ProjectClass", filename: "main_fixture.gox"},
-			{name: "WorkClass", filename: "Worker_fixture.gox"},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{tt.filename: []byte(`type Color const (
@@ -33,7 +34,7 @@ echo color
 				if tt.name == "WorkClass" {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := tt.newServer(t, files)
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 
@@ -59,11 +60,12 @@ echo color
 			firstFile  string
 			secondFile string
 			useFile    string
+			newServer  testServerFactory
 		}{
-			{name: "XGo", firstFile: "first.xgo", secondFile: "second.xgo", useFile: "main.xgo"},
-			{name: "ProjectClass", firstFile: "first.xgo", secondFile: "second.xgo", useFile: "main_fixture.gox"},
-			{name: "WorkClass", firstFile: "first.xgo", secondFile: "second.xgo", useFile: "Worker_fixture.gox"},
-			{name: "ClassfileDeclarations", firstFile: "main_fixture.gox", secondFile: "Worker_fixture.gox", useFile: "main.xgo"},
+			{name: "XGo", firstFile: "first.xgo", secondFile: "second.xgo", useFile: "main.xgo", newServer: newTestServer},
+			{name: "ProjectClass", firstFile: "first.xgo", secondFile: "second.xgo", useFile: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "WorkClass", firstFile: "first.xgo", secondFile: "second.xgo", useFile: "Worker_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "ClassfileDeclarations", firstFile: "main_fixture.gox", secondFile: "Worker_fixture.gox", useFile: "main.xgo", newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{
@@ -87,7 +89,7 @@ echo color
 				if tt.name == "WorkClass" {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := tt.newServer(t, files)
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 
@@ -134,7 +136,7 @@ func run() {
 `
 				files := map[string][]byte{"main_fixture.gox": nil}
 				files[tt.filename] = []byte(prefix + tt.expression + "\n}\n")
-				s := newTestServer(t, files)
+				s := newFrameworkTestServer(t, files)
 				items := completionItemsAt(t, s, tt.filename, Position{
 					Line:      uint32(strings.Count(prefix, "\n")),
 					Character: uint32(UTF16Len(tt.expression[:strings.Index(tt.expression, "Un")+len("Un")])),
@@ -151,7 +153,7 @@ func run() {
 	})
 
 	t.Run("CrossFileDocumentUpdates", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"enums.xgo": []byte(`type Color const (
 	Ready = iota
 	// Red documentation.

--- a/internal/server/completion_import_test.go
+++ b/internal/server/completion_import_test.go
@@ -20,7 +20,7 @@ func TestServerTextDocumentCompletionImports(t *testing.T) {
 		{name: "InImportGroupStringLit", source: "\nimport (\n\t\"f\n", position: Position{Line: 2, Character: 3}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+			s := newFrameworkTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
 			s.listPkgs = func() ([]string, error) {
 				return []string{"fmt", testframework.PkgPath, "example.com/missing"}, nil
 			}

--- a/internal/server/completion_kwarg_test.go
+++ b/internal/server/completion_kwarg_test.go
@@ -16,12 +16,13 @@ func TestServerTextDocumentCompletionKwargs(t *testing.T) {
 			name         string
 			filename     string
 			needsProject bool
+			newServer    testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "LegacyXGo", filename: "main.gop"},
-			{name: "StandaloneClass", filename: "Record.gox"},
-			{name: "ProjectClass", filename: "main_fixture.gox"},
-			{name: "WorkClass", filename: "Worker_fixture.gox", needsProject: true},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", needsProject: true, newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{
@@ -40,7 +41,7 @@ func run() {
 				if tt.needsProject {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := tt.newServer(t, files)
 				items := completionItemsAt(t, s, tt.filename, Position{Line: 2, Character: 23})
 				assert.NotContains(t, completionItemLabels(items), "count")
 				item := completionItemByLabel(items, "name")
@@ -79,7 +80,7 @@ func run() {
 						t.Run(tt.name, func(t *testing.T) {
 							files := map[string][]byte{"main_fixture.gox": nil}
 							files[class.filename] = []byte("func configure(opts Item?) {}\n" + class.callback + "\n" + tt.call + "\n}\n")
-							s := newTestServer(t, files)
+							s := newFrameworkTestServer(t, files)
 							items := completionItemsAt(t, s, class.filename, Position{Line: 2, Character: 13})
 							item := completionItemByLabel(items, "value")
 							require.NotNil(t, item)
@@ -115,7 +116,7 @@ func run() {
 								"}",
 								"",
 							}, tt.eol))
-							s := newTestServer(t, files)
+							s := newFrameworkTestServer(t, files)
 							_, err := s.workspaceRootFS.TypeInfo()
 							require.NoError(t, err)
 
@@ -145,7 +146,7 @@ func run() {
 			{name: "ImplicitReceiver", factory: "func Params() Params { return nil }\n"},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"options.xgo": []byte(`type Params interface {
 	Count(n int) Params
 	Name(v string) Params

--- a/internal/server/completion_symbol_test.go
+++ b/internal/server/completion_symbol_test.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/goplus/mod/modfile"
-	"github.com/goplus/mod/modload"
-	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgolsw/internal/testframework"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +35,7 @@ func TestServerTextDocumentCompletionSymbols(t *testing.T) {
 			{name: "BuiltinAlias", pkgPath: "github.com/qiniu/x/osx"},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox": []byte("import \"fmt\"\nvar Count int\nCount = 1\n\n"),
 				})
 				proj := s.workspaceRootFS
@@ -56,32 +53,24 @@ func TestServerTextDocumentCompletionSymbols(t *testing.T) {
 
 	t.Run("SourceKinds", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
-			owner    string
+			name      string
+			filename  string
+			owner     string
+			newServer testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "LegacyXGo", filename: "main.gop"},
-			{name: "StandaloneClass", filename: "Record.gox", owner: "Record."},
-			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App."},
-			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker."},
-			{name: "OtherFrameworkWithSpxExtension", filename: "main.spx", owner: "App."},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", owner: "Record.", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App.", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker.", newServer: newFrameworkTestServer},
+			{name: "OtherFrameworkWithSpxExtension", filename: "main.spx", owner: "App.", newServer: newFrameworkTestServerWithSpxExtension},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{tt.filename: []byte("// Count documentation.\nvar Count int\nCount = 1\n\n")}
 				if tt.name == "WorkClass" {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
-				if tt.name == "OtherFrameworkWithSpxExtension" {
-					s.workspaceRootFS.Mod = xgomod.New(modload.Module{
-						Opt: &modfile.File{Projects: []*modfile.Project{{
-							Ext: ".spx", FullExt: "main.spx", Class: "App", PkgPaths: []string{testframework.PkgPath},
-							Works: []*modfile.Class{{Ext: ".spx", Class: "Item", Embedded: true}},
-						}}},
-					})
-					require.NoError(t, s.workspaceRootFS.Mod.ImportClasses())
-				}
+				s := tt.newServer(t, files)
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 				items := completionItemsAt(t, s, tt.filename, Position{Line: 3})
@@ -110,7 +99,7 @@ func TestServerTextDocumentCompletionSymbols(t *testing.T) {
 	})
 
 	t.Run("CallbackScope", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox":   nil,
 			"Worker_fixture.gox": []byte("var Count int\nonValue value => {\n\t\n}\n"),
 		})
@@ -133,7 +122,7 @@ func TestServerTextDocumentCompletionSymbols(t *testing.T) {
 			{name: "ExplicitReceiver", filename: "main.xgo", source: "import \"example.com/framework\"\nvar app framework.App\napp.measure(1)\n", position: Position{Line: 2, Character: 5}},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
+				s := newFrameworkTestServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 				items := completionItemsAt(t, s, tt.filename, tt.position)
@@ -196,12 +185,13 @@ func TestServerTextDocumentCompletionSymbols(t *testing.T) {
 					t.Run(tt.name, func(t *testing.T) {
 						files := map[string][]byte{"main_fixture.gox": nil}
 						files[sourceKind.filename] = []byte("func run() {\n\n}\n")
-						s := newTestServer(t, files)
+						mod := testframework.NewModule(t)
 						if tt.withMath {
-							class, ok := s.workspaceRootFS.Mod.LookupClass("_fixture.gox")
+							class, ok := mod.LookupClass("_fixture.gox")
 							require.True(t, ok)
 							class.PkgPaths = append(class.PkgPaths, "math")
 						}
+						s := newFrameworkTestServerWithModule(t, files, mod)
 						lookup := s.lookupPkgDoc
 						s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
 							if pkgPath == "math" {
@@ -324,55 +314,73 @@ func main() {
 
 	t.Run("DocumentationUpdates", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			source   string
-			position Position
-			label    string
-			pkgPath  string
-			setDoc   func(*pkgdoc.PkgDoc, string)
+			name      string
+			source    string
+			position  Position
+			label     string
+			pkgPath   string
+			newDoc    func(string) *pkgdoc.PkgDoc
+			newServer testServerFactory
 		}{
 			{name: "Package", source: "import f \"example.com/framework\"\n\n", position: Position{Line: 1}, label: "f", pkgPath: testframework.PkgPath,
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Doc = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Doc: text}
+				}, newServer: newFrameworkTestServer},
 			{name: "PackageType", source: "import \"example.com/framework\"\nframework.\n", position: Position{Line: 1, Character: 10}, label: "Item", pkgPath: testframework.PkgPath,
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Types["Item"].Doc = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Types: map[string]*pkgdoc.TypeDoc{"Item": {Doc: text}}}
+				}, newServer: newFrameworkTestServer},
 			{name: "PackageConstant", source: "import \"example.com/framework\"\nframework.\n", position: Position{Line: 1, Character: 10}, label: "Low", pkgPath: testframework.PkgPath,
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Consts["Low"] = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Consts: map[string]string{"Low": text}}
+				}, newServer: newFrameworkTestServer},
 			{name: "PackageFunction", source: "import \"example.com/framework\"\nframework.\n", position: Position{Line: 1, Character: 10}, label: "runWhen", pkgPath: testframework.PkgPath,
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Funcs["RunWhen"] = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Funcs: map[string]string{"RunWhen": text}}
+				}, newServer: newFrameworkTestServer},
 			{name: "StructField", source: "import \"example.com/framework\"\nvar item framework.Item\nitem.\n", position: Position{Line: 2, Character: 5}, label: "Value", pkgPath: testframework.PkgPath,
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Types["Item"].Fields["Value"] = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Types: map[string]*pkgdoc.TypeDoc{"Item": {Fields: map[string]string{"Value": text}}}}
+				}, newServer: newFrameworkTestServer},
 			{name: "StructMethod", source: "import \"example.com/framework\"\nvar item framework.Item\nitem.\n", position: Position{Line: 2, Character: 5}, label: "apply", pkgPath: testframework.PkgPath,
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Types["Item"].Methods["Apply"] = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Types: map[string]*pkgdoc.TypeDoc{"Item": {Methods: map[string]string{"Apply": text}}}}
+				}, newServer: newFrameworkTestServer},
 			{name: "StructLiteralField", source: "import \"example.com/framework\"\nitem := framework.Item{}\n", position: Position{Line: 1, Character: 23}, label: "Value", pkgPath: testframework.PkgPath,
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Types["Item"].Fields["Value"] = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Types: map[string]*pkgdoc.TypeDoc{"Item": {Fields: map[string]string{"Value": text}}}}
+				}, newServer: newFrameworkTestServer},
 			{name: "InterfaceMethod", source: "import \"fmt\"\nvar s fmt.Stringer\ns.\n", position: Position{Line: 2, Character: 2}, label: "string", pkgPath: "fmt",
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) {
-					doc.Types["Stringer"] = &pkgdoc.TypeDoc{Methods: map[string]string{"String": text}}
-				}},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Types: map[string]*pkgdoc.TypeDoc{"Stringer": {Methods: map[string]string{"String": text}}}}
+				}, newServer: newTestServer},
 			{name: "Builtin", source: "\n\n", position: Position{Line: 1}, label: "len", pkgPath: "builtin",
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Funcs["len"] = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Funcs: map[string]string{"len": text}}
+				}, newServer: newTestServer},
 			{name: "BuiltinAlias", source: "\n\n", position: Position{Line: 1}, label: "echo", pkgPath: "fmt",
-				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Funcs["Println"] = text }},
+				newDoc: func(text string) *pkgdoc.PkgDoc {
+					return &pkgdoc.PkgDoc{Funcs: map[string]string{"Println": text}}
+				}, newServer: newTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+				s := tt.newServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
 				lookup := s.lookupPkgDoc
 				var doc *pkgdoc.PkgDoc
 				s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
-					if pkgPath == tt.pkgPath {
-						if doc == nil {
-							return nil, fs.ErrNotExist
-						}
-						return doc, nil
+					if pkgPath != tt.pkgPath {
+						return lookup(pkgPath)
 					}
-					return lookup(pkgPath)
+					if doc == nil {
+						return nil, fs.ErrNotExist
+					}
+					return doc, nil
 				}
 				for _, text := range []string{"First documentation.", "Second documentation.", "", "Restored documentation."} {
 					if text == "" {
 						doc = nil
 					} else {
-						doc = testframework.NewPkgDoc(t)
-						tt.setDoc(doc, text)
+						doc = tt.newDoc(text)
 					}
 					items := completionItemsAt(t, s, "main.xgo", tt.position)
 					item := completionItemByLabel(items, tt.label)
@@ -408,7 +416,7 @@ func main() {
 	})
 
 	t.Run("UTF16Position", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main.xgo": []byte("import \"example.com/framework\"\r\nvar item framework.Item\r\necho \"\U0001f600\", item.\r\n"),
 		})
 		items := completionItemsAt(t, s, "main.xgo", Position{Line: 2, Character: 16})

--- a/internal/server/completion_test.go
+++ b/internal/server/completion_test.go
@@ -25,7 +25,7 @@ func TestServerTextDocumentCompletion(t *testing.T) {
 			{name: "WorkCallback", filename: "Worker_fixture.gox", position: Position{Line: 1, Character: 10}},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox": []byte("var worker *Worker\nworker.ap"), // Cursor at EOF.
 					"Worker_fixture.gox": []byte(`onValue value => {
 	worker.ap
@@ -42,10 +42,11 @@ func TestServerTextDocumentCompletion(t *testing.T) {
 		name         string
 		filename     string
 		needsProject bool
+		newServer    testServerFactory
 	}{
-		{name: "XGo", filename: "main.xgo"},
-		{name: "ProjectClass", filename: "main_fixture.gox"},
-		{name: "WorkClass", filename: "Worker_fixture.gox", needsProject: true},
+		{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+		{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+		{name: "WorkClass", filename: "Worker_fixture.gox", needsProject: true, newServer: newFrameworkTestServer},
 	} {
 		t.Run(sourceKind.name, func(t *testing.T) {
 			t.Run("FuncDecoratorArgument", func(t *testing.T) {
@@ -67,7 +68,7 @@ func run() {
 				if sourceKind.needsProject {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := sourceKind.newServer(t, files)
 
 				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 9, Character: 9})
 				labels := completionItemLabels(items)
@@ -94,7 +95,7 @@ func run() {
 				if sourceKind.needsProject {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := sourceKind.newServer(t, files)
 
 				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 9, Character: 12})
 				labels := completionItemLabels(items)
@@ -125,7 +126,7 @@ func run() {
 				if sourceKind.needsProject {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := sourceKind.newServer(t, files)
 
 				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 13, Character: 15})
 				labels := completionItemLabels(items)
@@ -155,7 +156,7 @@ func run() {
 				if sourceKind.needsProject {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := sourceKind.newServer(t, files)
 
 				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 13, Character: 17})
 				labels := completionItemLabels(items)
@@ -180,7 +181,7 @@ func run() {
 				if sourceKind.needsProject {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := sourceKind.newServer(t, files)
 				s.workspaceRootFS.Importer = xgoxTestImporter{fallback: s.workspaceRootFS.Importer}
 
 				items := completionItemsAt(t, s, sourceKind.filename, Position{Line: 8, Character: 31})
@@ -228,7 +229,7 @@ func run() {
 	})
 
 	t.Run("Autoclosure", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`const (
 	enabled = true
 	entry = "text"
@@ -255,7 +256,7 @@ onStart => {
 	})
 
 	t.Run("GeneralOrUnknown", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 
 onStart => {
@@ -277,7 +278,7 @@ onStart => {
 	})
 
 	t.Run("VarDecl", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 func test() {}
 onStart => {
@@ -300,7 +301,7 @@ onStart => {
 	})
 
 	t.Run("AtLineStartWithAnIdentifier", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 onStart => {
 	pr
@@ -314,7 +315,7 @@ onStart => {
 	})
 
 	t.Run("WithXGoBuiltins", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 onStart => {
 	var n in
@@ -337,7 +338,7 @@ onValue value => {
 	})
 
 	t.Run("UnresolvedFuncCall", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 onStar => {
 }

--- a/internal/server/completion_unit_test.go
+++ b/internal/server/completion_unit_test.go
@@ -42,7 +42,7 @@ func TestServerTextDocumentCompletionUnits(t *testing.T) {
 				const line = "\t/* \U0001f600 */ move 1m"
 				files := map[string][]byte{"main_fixture.gox": nil}
 				files[tt.filename] = []byte("import \"example.com/unit\"\r\nfunc move(d unit.Distance) {}\r\n" + tt.callback + "\r\n" + line + "\r\n}\r\n")
-				s := newTestServer(t, files)
+				s := newFrameworkTestServer(t, files)
 				s.workspaceRootFS.Importer = xgoUnitTestImporter{fallback: s.workspaceRootFS.Importer}
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)

--- a/internal/server/constructor_test.go
+++ b/internal/server/constructor_test.go
@@ -1,0 +1,223 @@
+package server
+
+import (
+	gotypes "go/types"
+	"io/fs"
+	"testing"
+
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/mod/modload"
+	"github.com/goplus/mod/xgomod"
+	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/goplus/xgolsw/xgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer(t *testing.T) {
+	t.Run("ConfiguredProject", func(t *testing.T) {
+		files := map[string][]byte{"main_fixture.gox": []byte("var Count = measure(1)\n")}
+		proj := xgo.NewProject(nil, newFileMap(files), xgo.FeatAll)
+		proj.PkgPath = "example.com/project"
+		mod := testframework.NewModule(t)
+		proj.Mod = mod
+		importer := testframework.NewImporter(t, proj.Fset)
+		proj.Importer = importer
+		typeInfo, err := proj.TypeInfo()
+		require.NoError(t, err)
+
+		s := newServer(proj, nil, fileMapGetter(files), &MockScheduler{},
+			func() ([]string, error) { return nil, nil },
+			func(string) (*pkgdoc.PkgDoc, error) { return nil, fs.ErrNotExist },
+		)
+		assert.Same(t, proj, s.getProj())
+		assert.Equal(t, "example.com/project", proj.PkgPath)
+		assert.Same(t, mod, proj.Mod)
+		assert.Same(t, importer, proj.Importer)
+		gotTypeInfo, err := s.getProj().TypeInfo()
+		require.NoError(t, err)
+		assert.Same(t, typeInfo, gotTypeInfo)
+		hover, err := s.textDocumentHover(&HoverParams{
+			TextDocumentPositionParams: TextDocumentPositionParams{
+				TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
+				Position:     Position{Character: 4},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, hover)
+		assert.Contains(t, hover.Contents.Value, `def-id="xgo:example.com/project?App.Count"`)
+		assert.Contains(t, hover.Contents.Value, `overview="var Count int"`)
+	})
+
+	t.Run("InstanceIsolation", func(t *testing.T) {
+		var checks []func()
+		for _, name := range []string{"first", "second"} {
+			filename := "main_" + name + ".gox"
+			pkgPath := "example.com/" + name
+			files := map[string][]byte{
+				filename:      []byte("onStart => {\n\n}\n"),
+				"imports.xgo": []byte("import \"example.com/framework\"\nvar _ framework.Item\n"),
+			}
+			proj := xgo.NewProject(nil, newFileMap(files), xgo.FeatAll)
+			proj.PkgPath = "main"
+			proj.Mod = testframework.NewModule(t)
+			class := proj.Mod.Opt.Projects[0]
+			class.Ext = "_" + name + ".gox"
+			class.FullExt = filename
+			class.Works[0].Ext = class.Ext
+			require.NoError(t, proj.Mod.ImportClasses())
+			proj.Importer = testframework.NewImporter(t, proj.Fset)
+			framework, err := proj.Importer.Import(testframework.PkgPath)
+			require.NoError(t, err)
+			doc := testframework.NewPkgDoc(t)
+			wantDoc := "Documentation for the " + name + " server."
+			doc.Types["App"].Methods["OnStart"] = wantDoc
+			listPkgs := func() ([]string, error) { return []string{pkgPath}, nil }
+			lookupPkgDoc := func(path string) (*pkgdoc.PkgDoc, error) {
+				switch path {
+				case testframework.PkgPath:
+					return doc, nil
+				case pkgPath:
+					return &pkgdoc.PkgDoc{Doc: wantDoc}, nil
+				default:
+					return nil, fs.ErrNotExist
+				}
+			}
+			s := newServer(proj, nil, fileMapGetter(files), &MockScheduler{}, listPkgs, lookupPkgDoc)
+			check := func() {
+				t.Helper()
+
+				// Rebuild types so cached results cannot mask shared configuration.
+				files[filename] = append(files[filename], '\n')
+				typeInfo, err := s.getProjWithFile().TypeInfo()
+				require.NoError(t, err)
+				assert.Equal(t, "main", typeInfo.Pkg.Path())
+				var method gotypes.Object
+				for ident, obj := range typeInfo.Uses {
+					if ident.Name == "onStart" {
+						method = obj
+						break
+					}
+				}
+				require.NotNil(t, method)
+				assert.Same(t, framework, method.Pkg())
+				hover, err := s.textDocumentHover(&HoverParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(filename)},
+						Position:     Position{Character: 1},
+					},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, hover)
+				assert.Contains(t, hover.Contents.Value, wantDoc)
+
+				items := completionItemsAt(t, s, filename, Position{Line: 1})
+				item := completionItemByLabel(items, "onStart")
+				require.NotNil(t, item)
+				require.NotNil(t, item.Documentation)
+				assert.Contains(t, requireValueAs[MarkupContent](t, item.Documentation.Value).Value, wantDoc)
+
+				items = completionItemsAt(t, s, "imports.xgo", Position{Character: 8})
+				require.Len(t, items, 1)
+				assert.Equal(t, pkgPath, items[0].Label)
+				require.NotNil(t, items[0].Documentation)
+				assert.Contains(t, requireValueAs[MarkupContent](t, items[0].Documentation.Value).Value, wantDoc)
+			}
+			check()
+			checks = append(checks, check)
+		}
+		for _, check := range checks {
+			check()
+		}
+	})
+}
+
+func TestNewTestServer(t *testing.T) {
+	t.Run("NoFrameworkDependencies", func(t *testing.T) {
+		files := map[string][]byte{
+			"main.xgo": []byte("import \"strings\"\nvar Count = len(strings.ToUpper(\"text\"))\nCount = 2\n\n"),
+		}
+		plain := newTestServer(t, files)
+		check := func(s *Server) {
+			t.Helper()
+
+			proj := s.getProj()
+			assert.False(t, proj.Mod.IsClass("_fixture.gox"))
+			assert.False(t, proj.Mod.IsClass(".spx"))
+			_, err := proj.TypeInfo()
+			require.NoError(t, err)
+			_, err = proj.Importer.Import(testframework.PkgPath)
+			assert.ErrorIs(t, err, fs.ErrNotExist)
+			_, err = s.lookupPkgDoc(testframework.PkgPath)
+			assert.ErrorIs(t, err, fs.ErrNotExist)
+			assert.Empty(t, completionItemsAt(t, s, "main.xgo", Position{Character: 8}))
+			labels := completionItemLabels(completionItemsAt(t, s, "main.xgo", Position{Line: 3}))
+			assert.Contains(t, labels, "Count")
+			assert.Contains(t, labels, "len")
+			assert.NotContains(t, labels, "Low")
+			assert.NotContains(t, labels, "runWhen")
+			hover, err := s.textDocumentHover(&HoverParams{
+				TextDocumentPositionParams: TextDocumentPositionParams{
+					TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"},
+					Position:     Position{Line: 2},
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, hover)
+			assert.Contains(t, hover.Contents.Value, `overview="var Count int"`)
+		}
+		check(plain)
+
+		frameworkServer := newFrameworkTestServer(t, map[string][]byte{
+			"main_fixture.gox": []byte("onStart => {\n\n}\n"),
+			"imports.xgo":      []byte("import \"example.com/framework\"\nvar _ framework.Item\n"),
+		})
+		_, err := frameworkServer.getProj().TypeInfo()
+		require.NoError(t, err)
+		item := completionItemByLabel(completionItemsAt(t, frameworkServer, "main_fixture.gox", Position{Line: 1}), "onStart")
+		require.NotNil(t, item)
+		require.NotNil(t, item.Documentation)
+		assert.Contains(t, requireValueAs[MarkupContent](t, item.Documentation.Value).Value, "OnStart accepts a project callback.")
+		assert.Equal(t, []string{testframework.PkgPath}, completionItemLabels(completionItemsAt(t, frameworkServer, "imports.xgo", Position{Character: 8})))
+
+		check(plain)
+		check(newTestServer(t, files))
+	})
+
+	t.Run("InvalidDefaultClasses", func(t *testing.T) {
+		defaultOpt := modload.Default.Opt
+		t.Cleanup(func() { modload.Default.Opt = defaultOpt })
+		modload.Default.Opt = &modfile.File{ClassMods: []string{"example.com/missing-framework"}}
+		require.PanicsWithError(t, "failed to import classes: "+xgomod.ErrNotFound.Error(), func() {
+			New(xgo.NewProject(nil, nil, xgo.FeatAll), nil, nil, nil)
+		})
+
+		for _, tt := range []struct {
+			name      string
+			filename  string
+			source    string
+			want      string
+			newServer testServerFactory
+		}{
+			{name: "PlainXGo", filename: "main.xgo", source: "var Count int\n", want: "var Count int", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", source: "var Count int\n", want: "var Count int", newServer: newTestServer},
+			{name: "Framework", filename: "main_fixture.gox", source: "measure 1\n", want: "Measure__0 is the integer overload of Measure.", newServer: newFrameworkTestServer},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				s := tt.newServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
+				_, err := s.getProj().TypeInfo()
+				require.NoError(t, err)
+				hover, err := s.textDocumentHover(&HoverParams{
+					TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
+						Position:     Position{Character: 4},
+					},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, hover)
+				assert.Contains(t, hover.Contents.Value, tt.want)
+			})
+		}
+	})
+}

--- a/internal/server/definition_test.go
+++ b/internal/server/definition_test.go
@@ -69,7 +69,7 @@ func TestServerTextDocumentDefinition(t *testing.T) {
 	})
 
 	t.Run("FrameworkClasses", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 Worker.apply Low
 `),
@@ -134,7 +134,7 @@ onValue amount => {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox": []byte("var total int\n"),
 					"Worker_fixture.gox": []byte(`onValue amount => {
     total = amount
@@ -172,17 +172,21 @@ var x int
 
 	t.Run("ThisPtr", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
+			name        string
+			filename    string
+			projectFile string
+			newServer   testServerFactory
 		}{
-			{name: "ProjectClass", filename: "main_fixture.gox"},
-			{name: "WorkClass", filename: "Worker_fixture.gox"},
-			{name: "NormalClass", filename: "Record.gox"},
+			{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "NormalClass", filename: "Record.gox", newServer: newTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				files := map[string][]byte{"main_fixture.gox": nil}
-				files[tt.filename] = []byte("println this\n")
-				s := newTestServer(t, files)
+				files := map[string][]byte{tt.filename: []byte("println this\n")}
+				if tt.projectFile != "" {
+					files[tt.projectFile] = nil
+				}
+				s := tt.newServer(t, files)
 				def, err := s.textDocumentDefinition(&DefinitionParams{
 					TextDocumentPositionParams: TextDocumentPositionParams{
 						TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
@@ -698,7 +702,7 @@ func main() {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox":   []byte(tt.source),
 					"Worker_fixture.gox": nil,
 				})

--- a/internal/server/diagnostic_test.go
+++ b/internal/server/diagnostic_test.go
@@ -4,9 +4,6 @@ import (
 	"io/fs"
 	"testing"
 
-	"github.com/goplus/mod/modfile"
-	"github.com/goplus/mod/modload"
-	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgo/parser"
 	"github.com/goplus/xgo/x/typesutil"
 	"github.com/goplus/xgolsw/internal/testframework"
@@ -62,7 +59,7 @@ func TestServerTextDocumentDiagnostic(t *testing.T) {
 )
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		report, err := s.textDocumentDiagnostic(&DocumentDiagnosticParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///Foo_fixture.gox"},
@@ -148,7 +145,7 @@ onStart => {
 	x, y = calcPos()
 }
 `)
-		s := newTestServer(t, fileMap)
+		s := newFrameworkTestServer(t, fileMap)
 		params := &DocumentDiagnosticParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -362,7 +359,7 @@ func TestServerDiagnosticsAt(t *testing.T) {
 			"main_fixture.gox": []byte("println 1\n"),
 			"broken.xgo":       []byte("var (\n    x int\n"),
 		}
-		s := newTestServer(t, files)
+		s := newFrameworkTestServer(t, files)
 		proj := s.getProj()
 		importer := proj.Importer
 		proj.Importer = completionTestImporter{Importer: importer, unavailablePath: testframework.PkgPath}
@@ -501,33 +498,24 @@ func TestServerDiagnosticsAt(t *testing.T) {
 
 	t.Run("Classfiles", func(t *testing.T) {
 		for _, tt := range []struct {
-			name         string
-			filename     string
-			projectFile  string
-			spxExtension bool
+			name        string
+			filename    string
+			projectFile string
+			newServer   testServerFactory
 		}{
-			{name: "PlainXGo", filename: "main.xgo"},
-			{name: "LegacyXGo", filename: "main.gop"},
-			{name: "StandaloneClass", filename: "Record.gox"},
-			{name: "ProjectClass", filename: "main_fixture.gox"},
-			{name: "WorkClass", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox"},
-			{name: "OtherFrameworkWithSpxExtension", filename: "main.spx", spxExtension: true},
+			{name: "PlainXGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "OtherFrameworkWithSpxExtension", filename: "main.spx", newServer: newFrameworkTestServerWithSpxExtension},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{tt.filename: []byte("println missing\n")}
 				if tt.projectFile != "" {
 					files[tt.projectFile] = nil
 				}
-				s := newTestServer(t, files)
-				if tt.spxExtension {
-					s.workspaceRootFS.Mod = xgomod.New(modload.Module{
-						Opt: &modfile.File{Projects: []*modfile.Project{{
-							Ext: ".spx", FullExt: "main.spx", Class: "App", PkgPaths: []string{testframework.PkgPath},
-							Works: []*modfile.Class{{Ext: ".spx", Class: "Item", Embedded: true}},
-						}}},
-					})
-					require.NoError(t, s.workspaceRootFS.Mod.ImportClasses())
-				}
+				s := tt.newServer(t, files)
 				report, err := s.workspaceDiagnostic(&WorkspaceDiagnosticParams{})
 				require.NoError(t, err)
 				require.Len(t, report.Items, len(files))

--- a/internal/server/document_test.go
+++ b/internal/server/document_test.go
@@ -5,10 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/goplus/mod/modfile"
-	"github.com/goplus/mod/modload"
-	"github.com/goplus/mod/xgomod"
-	"github.com/goplus/xgolsw/internal/testframework"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,17 +17,18 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 			filename     string
 			owner        string
 			needsProject bool
+			newServer    testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App."},
-			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker.", needsProject: true},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App.", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker.", needsProject: true, newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := documentLinkLargeListFiles(tt.filename, 20_001)
 				if tt.needsProject {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := tt.newServer(t, files)
 				links, err := s.textDocumentDocumentLink(&DocumentLinkParams{
 					TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
 				})
@@ -51,15 +48,8 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 	})
 
 	t.Run("OtherFrameworkWithSpxExtension", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{"main.spx": []byte("var Count = 1\nCount = 2\n")})
+		s := newFrameworkTestServerWithSpxExtension(t, map[string][]byte{"main.spx": []byte("var Count = 1\nCount = 2\n")})
 		proj := s.workspaceRootFS
-		proj.Mod = xgomod.New(modload.Module{
-			Opt: &modfile.File{Projects: []*modfile.Project{{
-				Ext: ".spx", FullExt: "main.spx", Class: "App", PkgPaths: []string{testframework.PkgPath},
-				Works: []*modfile.Class{{Ext: ".spx", Class: "Item", Embedded: true}},
-			}}},
-		})
-		require.NoError(t, proj.Mod.ImportClasses())
 		_, err := proj.TypeInfo()
 		require.NoError(t, err)
 		links, err := s.textDocumentDocumentLink(&DocumentLinkParams{
@@ -74,22 +64,23 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 
 	t.Run("SourceKinds", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
-			owner    string
+			name      string
+			filename  string
+			owner     string
+			newServer testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "LegacyXGo", filename: "main.gop"},
-			{name: "StandaloneClass", filename: "Record.gox", owner: "Record."},
-			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App."},
-			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker."},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", owner: "Record.", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App.", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker.", newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{tt.filename: []byte("var Count int\nCount = 1\n")}
 				if tt.name == "WorkClass" {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := tt.newServer(t, files)
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 				links, err := s.textDocumentDocumentLink(&DocumentLinkParams{
@@ -106,7 +97,7 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 	})
 
 	t.Run("CrossFileClassSymbols", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox":   []byte("var Count int\n"),
 			"Worker_fixture.gox": []byte("onValue value => {\n    Count = value\n    apply Count\n}\n"),
 		})
@@ -137,7 +128,7 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 	t.Run("ImportedSymbols", func(t *testing.T) {
 		for _, name := range []string{"WithDocumentation", "MissingDocumentation"} {
 			t.Run(name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main.xgo": []byte("import \"example.com/framework\"\nvar item framework.Item\nitem.apply 1\nvar number int128\n"),
 				})
 				if name == "MissingDocumentation" {
@@ -163,7 +154,7 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 	})
 
 	t.Run("FrameworkCalls", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte("measure 1\nmeasure \"one\"\ncreate int, \"item\"\nrunWhen true, => {}\n"),
 		})
 		_, err := s.workspaceRootFS.TypeInfo()
@@ -190,7 +181,7 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 	})
 
 	t.Run("CrossFileEnumMembers", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"types.xgo":        []byte("type Color const (\n    Red = iota\n)\n"),
 			"main_fixture.gox": []byte("var color Color = Red\n"),
 		})
@@ -209,16 +200,18 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 
 	t.Run("This", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
-			source   string
-			want     []DocumentLink
+			name      string
+			filename  string
+			source    string
+			want      []DocumentLink
+			newServer testServerFactory
 		}{
 			{
 				name: "Synthetic", filename: "main_fixture.gox", source: "onStart => {\n    _ = this\n}\n",
 				want: []DocumentLink{{
 					Range: Range{Start: Position{}, End: Position{Character: 7}}, Target: toURI("xgo:example.com/framework?App.onStart"),
 				}},
+				newServer: newFrameworkTestServer,
 			},
 			{
 				name: "UserVariable", filename: "main.xgo", source: "var this = 1\nthis = 2\n",
@@ -226,10 +219,11 @@ func TestServerTextDocumentDocumentLink(t *testing.T) {
 					{Range: Range{Start: Position{Character: 4}, End: Position{Character: 8}}, Target: toURI("xgo:main?this")},
 					{Range: Range{Start: Position{Line: 1}, End: Position{Line: 1, Character: 4}}, Target: toURI("xgo:main?this")},
 				},
+				newServer: newTestServer,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
+				s := tt.newServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
 				links, err := s.textDocumentDocumentLink(&DocumentLinkParams{
 					TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
 				})

--- a/internal/server/format_test.go
+++ b/internal/server/format_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/format"
 	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/internal/testframework"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,39 +18,45 @@ import (
 func TestServerTextDocumentFormatting(t *testing.T) {
 	t.Run("SourceKinds", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
-			source   string
-			want     string
+			name      string
+			filename  string
+			source    string
+			want      string
+			newServer testServerFactory
 		}{
 			{
 				name: "XGo", filename: "main.xgo",
-				source: "var first=1\nvar second=2\ntype Count int\necho first,second\n",
-				want:   "var first = 1\nvar second = 2\n\ntype Count int\n\necho first, second\n",
+				source:    "var first=1\nvar second=2\ntype Count int\necho first,second\n",
+				want:      "var first = 1\nvar second = 2\n\ntype Count int\n\necho first, second\n",
+				newServer: newTestServer,
 			},
 			{
 				name: "LegacyXGo", filename: "main.gop",
-				source: "var first=1\nvar second=2\ntype Count int\necho first,second\n",
-				want:   "var first = 1\nvar second = 2\n\ntype Count int\n\necho first, second\n",
+				source:    "var first=1\nvar second=2\ntype Count int\necho first,second\n",
+				want:      "var first = 1\nvar second = 2\n\ntype Count int\n\necho first, second\n",
+				newServer: newTestServer,
 			},
 			{
 				name: "StandaloneClass", filename: "Record.gox",
-				source: "var count Count\ntype Count int\n",
-				want:   "type Count int\n\nvar (\n\tcount Count\n)\n",
+				source:    "var count Count\ntype Count int\n",
+				want:      "type Count int\n\nvar (\n\tcount Count\n)\n",
+				newServer: newTestServer,
 			},
 			{
 				name: "ProjectClass", filename: "main_fixture.gox",
-				source: "var count Count\ntype Count int\n",
-				want:   "type Count int\n\nvar (\n\tcount Count\n)\n",
+				source:    "var count Count\ntype Count int\n",
+				want:      "type Count int\n\nvar (\n\tcount Count\n)\n",
+				newServer: newFrameworkTestServer,
 			},
 			{
 				name: "WorkClass", filename: "Worker_fixture.gox",
-				source: "var count Count\ntype Count int\n",
-				want:   "type Count int\n\nvar (\n\tcount Count\n)\n",
+				source:    "var count Count\ntype Count int\n",
+				want:      "type Count int\n\nvar (\n\tcount Count\n)\n",
+				newServer: newFrameworkTestServer,
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
+				s := tt.newServer(t, map[string][]byte{tt.filename: []byte(tt.source)})
 				params := &DocumentFormattingParams{
 					TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
 				}
@@ -67,7 +74,7 @@ func TestServerTextDocumentFormatting(t *testing.T) {
 	})
 
 	t.Run("ClassfileRegistration", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{"main.unit": []byte("var count Count\ntype Count int\n")})
+		s := newFrameworkTestServer(t, map[string][]byte{"main.unit": []byte("var count Count\ntype Count int\n")})
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main.unit"},
 		}
@@ -89,12 +96,13 @@ func TestServerTextDocumentFormatting(t *testing.T) {
 	})
 
 	t.Run("AutoLambda", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
-			"main_fixture.gox": []byte("onStart {echo \"ready\"}\nonEvent \"value\", (value)=>{echo \"value\"}\n"),
-		})
-		class, ok := s.workspaceRootFS.Mod.LookupClass("_fixture.gox")
+		mod := testframework.NewModule(t)
+		class, ok := mod.LookupClass("_fixture.gox")
 		require.True(t, ok)
 		class.AutoLambdas = map[string]int{"onStart": 0}
+		s := newFrameworkTestServerWithModule(t, map[string][]byte{
+			"main_fixture.gox": []byte("onStart {echo \"ready\"}\nonEvent \"value\", (value)=>{echo \"value\"}\n"),
+		}, mod)
 		_, err := s.workspaceRootFS.TypeInfo()
 		require.NoError(t, err)
 		params := &DocumentFormattingParams{
@@ -112,7 +120,7 @@ func TestServerTextDocumentFormatting(t *testing.T) {
 	})
 
 	t.Run("FileUpdates", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte("onStart => {\n\techo \"old\"\n}\n"),
 		})
 		_, err := s.workspaceRootFS.TypeInfo()
@@ -151,7 +159,7 @@ func TestServerTextDocumentFormatting(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox":   []byte(tt.source),
 					"Worker_fixture.gox": []byte("var count int\n"),
 				})
@@ -190,7 +198,7 @@ func TestServerTextDocumentFormatting(t *testing.T) {
 	})
 
 	t.Run("OtherFileASTIsolation", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox":   []byte("onEvent \"value\", (value) => {\n\techo \"ready\"\n}\n"),
 			"Worker_fixture.gox": []byte("var count int\n"),
 		})
@@ -211,7 +219,7 @@ func TestServerTextDocumentFormatting(t *testing.T) {
 	})
 
 	t.Run("PlainXGoLambda", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main.xgo": []byte("import \"example.com/framework\"\nvar app framework.App\napp.onEvent \"value\", (value)=>{echo \"ready\"}\n"),
 		})
 		_, err := s.workspaceRootFS.TypeInfo()
@@ -276,7 +284,7 @@ var (
 type Score int
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -318,7 +326,7 @@ func retry(delay time.Duration, fn func()) {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -355,7 +363,7 @@ width int
 type Rect int
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -390,7 +398,7 @@ var (
 	})
 
 	t.Run("FileNotFound", func(t *testing.T) {
-		s := newTestServer(t, nil)
+		s := newFrameworkTestServer(t, nil)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///notexist_fixture.gox"},
 		}
@@ -404,7 +412,7 @@ var (
 		m := map[string][]byte{
 			"main_fixture.gox": []byte("onStart => {\n\techo \"ready\"\n}\n"),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -422,7 +430,7 @@ var title string
 !InvalidSyntax
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -468,7 +476,7 @@ var (
 )
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -504,7 +512,7 @@ var (
 ) // Class fields.
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -529,7 +537,7 @@ var (
 	)
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -557,7 +565,7 @@ var (
 )
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -577,7 +585,7 @@ onStart => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -599,7 +607,7 @@ onEvent "value", (value) => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -688,7 +696,7 @@ onStart => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -740,7 +748,7 @@ onStart => {
 		m := map[string][]byte{
 			"main_fixture.gox": []byte(``),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -754,7 +762,7 @@ onStart => {
 		m := map[string][]byte{
 			"main_fixture.gox": []byte(` `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -798,7 +806,7 @@ const b = "123"
 // floating comment5
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -850,7 +858,7 @@ var a int // trailing comment for var a
 func test() {} // trailing comment for func test
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -891,7 +899,7 @@ func (Foo) Bar() {}
 func Bar() {}
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -932,7 +940,7 @@ var (
 
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -955,7 +963,7 @@ var (
 		m := map[string][]byte{
 			"main_fixture.gox": []byte("var ( )\n"),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -980,7 +988,7 @@ var (
 
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -1009,7 +1017,7 @@ var (
 
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -1045,7 +1053,7 @@ var name string = "Player"
 
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}
@@ -1069,7 +1077,7 @@ onStart => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 		params := &DocumentFormattingParams{
 			TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"},
 		}

--- a/internal/server/highlight_test.go
+++ b/internal/server/highlight_test.go
@@ -203,7 +203,7 @@ onValue amount => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		workerHighlights, err := s.textDocumentDocumentHighlight(&DocumentHighlightParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{

--- a/internal/server/hover_test.go
+++ b/internal/server/hover_test.go
@@ -14,15 +14,16 @@ import (
 func TestServerTextDocumentHover(t *testing.T) {
 	t.Run("SourceKinds", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
-			owner    string
+			name      string
+			filename  string
+			owner     string
+			newServer testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "LegacyXGo", filename: "main.gop"},
-			{name: "StandaloneClass", filename: "Record.gox", owner: "Record."},
-			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App."},
-			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker."},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", owner: "Record.", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", owner: "App.", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", owner: "Worker.", newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{
@@ -31,7 +32,7 @@ func TestServerTextDocumentHover(t *testing.T) {
 				if tt.name == "WorkClass" {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := tt.newServer(t, files)
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 				for _, position := range []Position{{Line: 1, Character: 4}, {Line: 2}} {
@@ -81,7 +82,7 @@ func TestServerTextDocumentHover(t *testing.T) {
 					want: "Low and High are values used by framework methods."},
 			} {
 				t.Run(tt.name+markup.name, func(t *testing.T) {
-					s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+					s := newFrameworkTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
 					_, err := s.initialize(&InitializeParams{XInitializeParams: protocol.XInitializeParams{
 						Capabilities: protocol.ClientCapabilities{TextDocument: protocol.TextDocumentClientCapabilities{
 							Hover: &protocol.HoverClientCapabilities{ContentFormat: []protocol.MarkupKind{markup.kind}},
@@ -108,19 +109,20 @@ func TestServerTextDocumentHover(t *testing.T) {
 
 	t.Run("MissingDocumentation", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			source   string
-			position Position
-			want     string
+			name      string
+			source    string
+			position  Position
+			want      string
+			newServer testServerFactory
 		}{
-			{name: "Import", source: "import \"example.com/framework\"\n", position: Position{Character: 8}},
+			{name: "Import", source: "import \"example.com/framework\"\n", position: Position{Character: 8}, newServer: newFrameworkTestServer},
 			{name: "Method", source: "import \"example.com/framework\"\nvar item framework.Item\nitem.apply 1\n", position: Position{Line: 2, Character: 5},
-				want: `overview="func apply(value int)"`},
+				want: `overview="func apply(value int)"`, newServer: newFrameworkTestServer},
 			{name: "BuiltinAlias", source: "var number int128\n", position: Position{Character: 12},
-				want: `overview="type Int128"`},
+				want: `overview="type Int128"`, newServer: newTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
+				s := tt.newServer(t, map[string][]byte{"main.xgo": []byte(tt.source)})
 				s.lookupPkgDoc = func(string) (*pkgdoc.PkgDoc, error) { return nil, fs.ErrNotExist }
 				hover, err := s.textDocumentHover(&HoverParams{
 					TextDocumentPositionParams: TextDocumentPositionParams{
@@ -174,7 +176,7 @@ func TestServerTextDocumentHover(t *testing.T) {
 				setDoc: func(doc *pkgdoc.PkgDoc, text string) { doc.Consts["Low"] = text }},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{"main_fixture.gox": []byte(tt.source)})
+				s := newFrameworkTestServer(t, map[string][]byte{"main_fixture.gox": []byte(tt.source)})
 				params := &HoverParams{TextDocumentPositionParams: TextDocumentPositionParams{
 					TextDocument: TextDocumentIdentifier{URI: "file:///main_fixture.gox"}, Position: tt.position,
 				}}
@@ -262,7 +264,7 @@ fmt.Println(int8(1))
 			"Worker_fixture.gox": []byte("imagePoint.X = 100\n"),
 		}
 
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		varHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
@@ -433,7 +435,7 @@ onStart => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
@@ -502,7 +504,7 @@ import (
 framework.RunWhen true, => {}
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		importHover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
@@ -664,7 +666,7 @@ onStart => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
@@ -723,7 +725,7 @@ onStart => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		hover, err := s.textDocumentHover(&HoverParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{
@@ -765,7 +767,7 @@ this = 1
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		// The characters on `onValue` should map to `onValue`, not synthetic `this`.
 		for _, ch := range []uint32{0, 1, 2, 3, 4, 5, 6} {

--- a/internal/server/implementation_test.go
+++ b/internal/server/implementation_test.go
@@ -106,7 +106,7 @@ func (Local) String() string { return "local" }
 			{name: "ImportedMethod", position: Position{Line: 0, Character: 7}},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox":   []byte("Worker.apply Low\n"),
 					"Worker_fixture.gox": nil,
 				})

--- a/internal/server/inlay_hint_test.go
+++ b/internal/server/inlay_hint_test.go
@@ -37,7 +37,7 @@ func TestServerTextDocumentInlayHint(t *testing.T) {
 	}
 
 	t.Run("FrameworkMethods", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox":   []byte("onStart => {\n    Worker.apply 3\n    _ = create(Item, \"sample\")\n}\n"),
 			"Worker_fixture.gox": []byte("onValue amount => {\n    apply amount\n}\n"),
 		})
@@ -202,7 +202,7 @@ func run() {
 	})
 
 	t.Run("Autoclosure", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 onStart => {
 	runWhen true, => {}

--- a/internal/server/input_slot_context_test.go
+++ b/internal/server/input_slot_context_test.go
@@ -93,7 +93,7 @@ func main() {
 	})
 
 	t.Run("ClassMembersAndCallback", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox":   nil,
 			"Worker_fixture.gox": []byte("var Count int\nonValue value => {\n\tprintln 5\n}\n"),
 		})
@@ -117,10 +117,11 @@ func main() {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{"main_fixture.gox": nil}
 				files[tt.filename] = []byte("println 5\n")
-				s := newTestServer(t, files)
-				class, ok := s.workspaceRootFS.Mod.LookupClass("_fixture.gox")
+				mod := testframework.NewModule(t)
+				class, ok := mod.LookupClass("_fixture.gox")
 				require.True(t, ok)
 				class.PkgPaths = append(class.PkgPaths, "os", "io")
+				s := newFrameworkTestServerWithModule(t, files, mod)
 				ctx := inputSlotTestContext(t, s, tt.filename)
 				literal := inputSlotLiteral(t, ctx, "5")
 				names := collectPredefinedNames(ctx, literal, nil)
@@ -139,7 +140,7 @@ func main() {
 	})
 
 	t.Run("UnavailableImplicitPackage", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{"main_fixture.gox": []byte("var Count int\nprintln 5\n")})
+		s := newFrameworkTestServer(t, map[string][]byte{"main_fixture.gox": []byte("var Count int\nprintln 5\n")})
 		_, err := s.workspaceRootFS.TypeInfo()
 		require.NoError(t, err)
 		s.workspaceRootFS.Importer = completionTestImporter{Importer: s.workspaceRootFS.Importer, unavailablePath: testframework.PkgPath}

--- a/internal/server/input_slot_test.go
+++ b/internal/server/input_slot_test.go
@@ -8,12 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/goplus/mod/modfile"
-	"github.com/goplus/mod/modload"
-	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgo/ast"
 	"github.com/goplus/xgo/token"
-	"github.com/goplus/xgolsw/internal/testframework"
 	"github.com/goplus/xgolsw/xgo/xgoutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -442,31 +438,23 @@ func main() {
 
 	t.Run("SourceKinds", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
+			name      string
+			filename  string
+			newServer testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "LegacyXGo", filename: "main.gop"},
-			{name: "StandaloneClass", filename: "Record.gox"},
-			{name: "ProjectClass", filename: "main_fixture.gox"},
-			{name: "WorkClass", filename: "Worker_fixture.gox"},
-			{name: "OtherFrameworkWithSpxExtension", filename: "main.spx"},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "OtherFrameworkWithSpxExtension", filename: "main.spx", newServer: newFrameworkTestServerWithSpxExtension},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{tt.filename: []byte("var Count int\nCount = 5\n")}
 				if tt.name == "WorkClass" {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
-				if tt.name == "OtherFrameworkWithSpxExtension" {
-					s.workspaceRootFS.Mod = xgomod.New(modload.Module{
-						Opt: &modfile.File{Projects: []*modfile.Project{{
-							Ext: ".spx", FullExt: "main.spx", Class: "App", PkgPaths: []string{testframework.PkgPath},
-							Works: []*modfile.Class{{Ext: ".spx", Class: "Item", Embedded: true}},
-						}}},
-					})
-					require.NoError(t, s.workspaceRootFS.Mod.ImportClasses())
-				}
+				s := tt.newServer(t, files)
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 				slots, err := s.xgoGetInputSlots([]XGoGetInputSlotsParams{{

--- a/internal/server/property_test.go
+++ b/internal/server/property_test.go
@@ -15,16 +15,17 @@ import (
 func TestServerXGoGetProperties(t *testing.T) {
 	t.Run("SourceKinds", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
-			target   string
-			class    bool
+			name      string
+			filename  string
+			target    string
+			class     bool
+			newServer testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo", target: "Record"},
-			{name: "LegacyXGo", filename: "main.gop", target: "Record"},
-			{name: "StandaloneClass", filename: "Record.gox", target: "Record", class: true},
-			{name: "ProjectClass", filename: "main_fixture.gox", target: "App", class: true},
-			{name: "WorkClass", filename: "Worker_fixture.gox", target: "Worker", class: true},
+			{name: "XGo", filename: "main.xgo", target: "Record", newServer: newTestServer},
+			{name: "LegacyXGo", filename: "main.gop", target: "Record", newServer: newTestServer},
+			{name: "StandaloneClass", filename: "Record.gox", target: "Record", class: true, newServer: newTestServer},
+			{name: "ProjectClass", filename: "main_fixture.gox", target: "App", class: true, newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", target: "Worker", class: true, newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				source := `type Record struct {
@@ -47,7 +48,7 @@ func GetScore() int { return score }
 				if tt.name == "WorkClass" {
 					files["main_fixture.gox"] = nil
 				}
-				s := newTestServer(t, files)
+				s := tt.newServer(t, files)
 				_, err := s.workspaceRootFS.TypeInfo()
 				require.NoError(t, err)
 				properties, err := s.xgoGetProperties(XGoGetPropertiesParams{Target: tt.target})
@@ -143,7 +144,7 @@ type RecordPointer = *Record
 	})
 
 	t.Run("ImportedDocumentationUpdates", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{"main.xgo": []byte(`import "example.com/framework"
+		s := newFrameworkTestServer(t, map[string][]byte{"main.xgo": []byte(`import "example.com/framework"
 type Record struct { framework.Item }
 `)})
 		lookupPkgDoc := s.lookupPkgDoc
@@ -219,7 +220,7 @@ var count int
 }
 
 func TestIsPropertyOfEnclosingType(t *testing.T) {
-	s := newTestServer(t, map[string][]byte{
+	s := newFrameworkTestServer(t, map[string][]byte{
 		"main_fixture.gox": nil,
 		"Worker_fixture.gox": []byte(`var (
     x int
@@ -264,7 +265,7 @@ func XGo_Internal() int { return 0 }
 
 func TestFindEnclosingType(t *testing.T) {
 	t.Run("ClassMembers", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": nil,
 			"Worker_fixture.gox": []byte(`var (
     x int

--- a/internal/server/reference_test.go
+++ b/internal/server/reference_test.go
@@ -120,7 +120,7 @@ onValue amount => {
 }
 `),
 		}
-		s := newTestServer(t, m)
+		s := newFrameworkTestServer(t, m)
 
 		workerRefs, err := s.textDocumentReferences(&ReferenceParams{
 			TextDocumentPositionParams: TextDocumentPositionParams{

--- a/internal/server/rename_test.go
+++ b/internal/server/rename_test.go
@@ -52,7 +52,7 @@ func TestServerTextDocumentPrepareRename(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox":   []byte("var total int\n"),
 					"Worker_fixture.gox": []byte("onValue amount => {\n    total = amount\n}\n"),
 				})
@@ -70,17 +70,21 @@ func TestServerTextDocumentPrepareRename(t *testing.T) {
 
 	t.Run("ThisPtr", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
+			name        string
+			filename    string
+			projectFile string
+			newServer   testServerFactory
 		}{
-			{name: "ProjectClass", filename: "main_fixture.gox"},
-			{name: "WorkClass", filename: "Worker_fixture.gox"},
-			{name: "NormalClass", filename: "Record.gox"},
+			{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "WorkClass", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "NormalClass", filename: "Record.gox", newServer: newTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				files := map[string][]byte{"main_fixture.gox": nil}
-				files[tt.filename] = []byte("_ = this\n")
-				s := newTestServer(t, files)
+				files := map[string][]byte{tt.filename: []byte("_ = this\n")}
+				if tt.projectFile != "" {
+					files[tt.projectFile] = nil
+				}
+				s := tt.newServer(t, files)
 				uri := s.toDocumentURI(tt.filename)
 				position := Position{Line: 0, Character: 4}
 				rng, err := s.textDocumentPrepareRename(&PrepareRenameParams{TextDocumentPositionParams: TextDocumentPositionParams{
@@ -104,24 +108,28 @@ func TestServerTextDocumentPrepareRename(t *testing.T) {
 
 	t.Run("NotRenameable", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
-			source   string
-			position Position
+			name        string
+			filename    string
+			source      string
+			position    Position
+			needsWorker bool
+			newServer   testServerFactory
 		}{
-			{name: "BlankIdent", filename: "main.xgo", source: "const _ = 1\n", position: Position{Line: 0, Character: 6}},
-			{name: "BuiltinType", filename: "main.xgo", source: "var value int\n", position: Position{Line: 0, Character: 10}},
-			{name: "BuiltinFunc", filename: "main.xgo", source: "println 1\n"},
-			{name: "ImportedPackage", filename: "main.xgo", source: "import \"fmt\"\nfmt.println 1\n", position: Position{Line: 1}},
-			{name: "ImportedMember", filename: "main.xgo", source: "import \"fmt\"\nfmt.println 1\n", position: Position{Line: 1, Character: 4}},
-			{name: "StringLiteral", filename: "main.xgo", source: "_ = \"value\"\n", position: Position{Line: 0, Character: 5}},
-			{name: "GeneratedClass", filename: "main_fixture.gox", source: "Worker.apply Low\n"},
-			{name: "ImportedFrameworkMember", filename: "main_fixture.gox", source: "Worker.apply Low\n", position: Position{Line: 0, Character: 7}},
+			{name: "BlankIdent", filename: "main.xgo", source: "const _ = 1\n", position: Position{Line: 0, Character: 6}, newServer: newTestServer},
+			{name: "BuiltinType", filename: "main.xgo", source: "var value int\n", position: Position{Line: 0, Character: 10}, newServer: newTestServer},
+			{name: "BuiltinFunc", filename: "main.xgo", source: "println 1\n", newServer: newTestServer},
+			{name: "ImportedPackage", filename: "main.xgo", source: "import \"fmt\"\nfmt.println 1\n", position: Position{Line: 1}, newServer: newTestServer},
+			{name: "ImportedMember", filename: "main.xgo", source: "import \"fmt\"\nfmt.println 1\n", position: Position{Line: 1, Character: 4}, newServer: newTestServer},
+			{name: "StringLiteral", filename: "main.xgo", source: "_ = \"value\"\n", position: Position{Line: 0, Character: 5}, newServer: newTestServer},
+			{name: "GeneratedClass", filename: "main_fixture.gox", source: "Worker.apply Low\n", needsWorker: true, newServer: newFrameworkTestServer},
+			{name: "ImportedFrameworkMember", filename: "main_fixture.gox", source: "Worker.apply Low\n", position: Position{Line: 0, Character: 7}, needsWorker: true, newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				files := map[string][]byte{"main_fixture.gox": nil, "Worker_fixture.gox": nil}
-				files[tt.filename] = []byte(tt.source)
-				s := newTestServer(t, files)
+				files := map[string][]byte{tt.filename: []byte(tt.source)}
+				if tt.needsWorker {
+					files["Worker_fixture.gox"] = nil
+				}
+				s := tt.newServer(t, files)
 				uri := s.toDocumentURI(tt.filename)
 				rng, err := s.textDocumentPrepareRename(&PrepareRenameParams{TextDocumentPositionParams: TextDocumentPositionParams{
 					TextDocument: TextDocumentIdentifier{URI: uri},
@@ -352,7 +360,7 @@ func TestServerTextDocumentRename(t *testing.T) {
 			{name: "Reference", uri: "file:///Worker_fixture.gox", position: Position{Line: 0, Character: 4}, want: Range{Start: Position{Line: 0, Character: 4}, End: Position{Line: 0, Character: 9}}},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox":   []byte("const title = \"Example\"\n"),
 					"Worker_fixture.gox": []byte("_ = title\n"),
 				})
@@ -418,7 +426,7 @@ func TestServerTextDocumentRename(t *testing.T) {
 			},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				s := newTestServer(t, map[string][]byte{
+				s := newFrameworkTestServer(t, map[string][]byte{
 					"main_fixture.gox":   []byte("var total int\n"),
 					"Worker_fixture.gox": []byte("var value int\nonValue amount => {\n    total = amount\n    value = amount\n}\n"),
 				})

--- a/internal/server/semantic_token_test.go
+++ b/internal/server/semantic_token_test.go
@@ -94,7 +94,7 @@ func TestServerTextDocumentSemanticTokensFull(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			s := newTestServer(t, map[string][]byte{
+			s := newFrameworkTestServer(t, map[string][]byte{
 				"main_fixture.gox":   []byte("\nWorker.apply Low\n"),
 				"Worker_fixture.gox": []byte("\nonValue amount => {\n\tWorker.apply amount\n}\n"),
 			})
@@ -110,30 +110,38 @@ func TestServerTextDocumentSemanticTokensFull(t *testing.T) {
 	}
 
 	for _, tt := range []struct {
-		name     string
-		filename string
-		source   string
+		name        string
+		filename    string
+		source      string
+		projectFile string
+		newServer   testServerFactory
 	}{
 		{
-			name:     "ProjectField",
-			filename: "main_fixture.gox",
-			source:   "var count int\nonStart => {\n\tcount = 1\n}\n",
+			name:      "ProjectField",
+			filename:  "main_fixture.gox",
+			source:    "var count int\nonStart => {\n\tcount = 1\n}\n",
+			newServer: newFrameworkTestServer,
 		},
 		{
-			name:     "WorkField",
-			filename: "Worker_fixture.gox",
-			source:   "var count int\nonValue amount => {\n\tcount = amount\n}\n",
+			name:        "WorkField",
+			filename:    "Worker_fixture.gox",
+			source:      "var count int\nonValue amount => {\n\tcount = amount\n}\n",
+			projectFile: "main_fixture.gox",
+			newServer:   newFrameworkTestServer,
 		},
 		{
-			name:     "NormalClassField",
-			filename: "Record.gox",
-			source:   "var count int\nfunc run() {\n\tcount = 1\n}\n",
+			name:      "NormalClassField",
+			filename:  "Record.gox",
+			source:    "var count int\nfunc run() {\n\tcount = 1\n}\n",
+			newServer: newTestServer,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			files := map[string][]byte{"main_fixture.gox": []byte("\n")}
-			files[tt.filename] = []byte(tt.source)
-			s := newTestServer(t, files)
+			files := map[string][]byte{tt.filename: []byte(tt.source)}
+			if tt.projectFile != "" {
+				files[tt.projectFile] = nil
+			}
+			s := tt.newServer(t, files)
 			tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
 				TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
 			})
@@ -578,23 +586,27 @@ func run() {
 
 	t.Run("CrossFileEnumReference", func(t *testing.T) {
 		for _, tt := range []struct {
-			name     string
-			filename string
+			name        string
+			filename    string
+			projectFile string
+			newServer   testServerFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "Project", filename: "main_fixture.gox"},
-			{name: "Work", filename: "Worker_fixture.gox"},
+			{name: "XGo", filename: "main.xgo", newServer: newTestServer},
+			{name: "Project", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+			{name: "Work", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox", newServer: newFrameworkTestServer},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				files := map[string][]byte{
-					"main_fixture.gox": []byte("\n"),
 					"enums.xgo": []byte(`type Color const (
 	Red = iota
 )
 `),
 				}
 				files[tt.filename] = []byte("var color Color = Red\n")
-				s := newTestServer(t, files)
+				if tt.projectFile != "" {
+					files[tt.projectFile] = nil
+				}
+				s := tt.newServer(t, files)
 
 				tokens, err := s.textDocumentSemanticTokensFull(&SemanticTokensParams{
 					TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,7 +72,7 @@ func (s *Server) getProjWithFile() *xgo.Project {
 	return proj
 }
 
-// New creates a new Server instance.
+// New creates a new Server instance with the default module and package data.
 func New(proj *xgo.Project, replier MessageReplier, fileMapGetter FileMapGetter, scheduler Scheduler) *Server {
 	mod := xgomod.New(modload.Default)
 	if err := mod.ImportClasses(); err != nil {
@@ -81,6 +81,18 @@ func New(proj *xgo.Project, replier MessageReplier, fileMapGetter FileMapGetter,
 	proj.PkgPath = "main"
 	proj.Mod = mod
 	proj.Importer = internal.Importer
+	return newServer(proj, replier, fileMapGetter, scheduler, pkgdata.ListPkgs, pkgdata.GetPkgDoc)
+}
+
+// newServer creates a server from a configured project and package data providers.
+func newServer(
+	proj *xgo.Project,
+	replier MessageReplier,
+	fileMapGetter FileMapGetter,
+	scheduler Scheduler,
+	listPkgs func() ([]string, error),
+	lookupPkgDoc func(string) (*pkgdoc.PkgDoc, error),
+) *Server {
 	return &Server{
 		workspaceRootURI: "file:///",
 		workspaceRootFS:  proj,
@@ -88,8 +100,8 @@ func New(proj *xgo.Project, replier MessageReplier, fileMapGetter FileMapGetter,
 		analyzers:        initAnalyzers(true),
 		fileMapGetter:    fileMapGetter,
 		scheduler:        scheduler,
-		listPkgs:         pkgdata.ListPkgs,
-		lookupPkgDoc:     pkgdata.GetPkgDoc,
+		listPkgs:         listPkgs,
+		lookupPkgDoc:     lookupPkgDoc,
 		language:         i18n.LanguageEN, // Default to English until initialize is called
 	}
 }

--- a/internal/server/signature_test.go
+++ b/internal/server/signature_test.go
@@ -70,7 +70,7 @@ func TestServerTextDocumentSignatureHelp(t *testing.T) {
 					"Worker_fixture.gox": {},
 				}
 				files[tt.filename] = []byte(tt.source)
-				s := newTestServer(t, files)
+				s := newFrameworkTestServer(t, files)
 				help, err := s.textDocumentSignatureHelp(&SignatureHelpParams{
 					TextDocumentPositionParams: TextDocumentPositionParams{
 						TextDocument: TextDocumentIdentifier{URI: s.toDocumentURI(tt.filename)},
@@ -231,7 +231,7 @@ func TestServerTextDocumentSignatureHelp(t *testing.T) {
 	}
 
 	t.Run("Autoclosure", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 onStart => {
 	runWhen true, => {}
@@ -349,7 +349,7 @@ func run() error {
 	}
 
 	t.Run("XGoxMethod", func(t *testing.T) {
-		s := newTestServer(t, map[string][]byte{
+		s := newFrameworkTestServer(t, map[string][]byte{
 			"main_fixture.gox": []byte(`
 onStart => {
 	create Item, "sample"

--- a/internal/server/spx_server_test.go
+++ b/internal/server/spx_server_test.go
@@ -7,10 +7,45 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goplus/xgolsw/internal"
+	"github.com/goplus/xgolsw/internal/pkgdata"
 	"github.com/goplus/xgolsw/jsonrpc2"
+	"github.com/goplus/xgolsw/xgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewSpx(t *testing.T) {
+	files := map[string][]byte{"main.spx": []byte("var Count int\nCount = 1\n")}
+	proj := xgo.NewProject(nil, newFileMap(files), xgo.FeatAll)
+	s := New(proj, nil, fileMapGetter(files), &MockScheduler{})
+	assert.Same(t, proj, s.getProj())
+	assert.Equal(t, "main", proj.PkgPath)
+	assert.Same(t, internal.Importer, proj.Importer)
+	_, isProject, ok := proj.Mod.ClassInfo("main.spx")
+	assert.True(t, isProject)
+	assert.True(t, ok)
+	_, err := proj.TypeInfo()
+	require.NoError(t, err)
+	hover, err := s.textDocumentHover(&HoverParams{
+		TextDocumentPositionParams: TextDocumentPositionParams{
+			TextDocument: TextDocumentIdentifier{URI: "file:///main.spx"},
+			Position:     Position{Line: 1},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, hover)
+	assert.Contains(t, hover.Contents.Value, `def-id="xgo:main?Game.Count"`)
+
+	pkgs, err := s.listPkgs()
+	require.NoError(t, err)
+	assert.Contains(t, pkgs, SpxPkgPath)
+	doc, err := s.lookupPkgDoc(SpxPkgPath)
+	require.NoError(t, err)
+	wantDoc, err := pkgdata.GetPkgDoc(SpxPkgPath)
+	require.NoError(t, err)
+	assert.Same(t, wantDoc, doc)
+}
 
 func TestHandleMessageCallSpx(t *testing.T) {
 	for _, command := range []struct {

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -5,32 +5,80 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/mod/modload"
+	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgolsw/internal/testframework"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/goplus/xgolsw/xgo"
 	"github.com/stretchr/testify/require"
 )
 
+type testServerFactory func(testing.TB, map[string][]byte) *Server
+
 func newTestServer(t testing.TB, files map[string][]byte) *Server {
 	t.Helper()
 
 	proj := xgo.NewProject(nil, newFileMap(files), xgo.FeatAll)
-	s := New(proj, nil, fileMapGetter(files), &MockScheduler{})
-	proj.Mod = testframework.NewModule(t)
+	proj.PkgPath = "main"
+	proj.Mod = xgomod.New(modload.Module{Opt: &modfile.File{}})
+	require.NoError(t, proj.Mod.ImportClasses())
+	proj.Importer = testframework.NewBaseImporter(t, proj.Fset)
+	return newServer(proj, nil, fileMapGetter(files), &MockScheduler{},
+		func() ([]string, error) { return nil, nil },
+		func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+			t.Helper()
+
+			requireNonSpxDocumentation(t, pkgPath)
+			return nil, fs.ErrNotExist
+		},
+	)
+}
+
+func newFrameworkTestServer(t testing.TB, files map[string][]byte) *Server {
+	t.Helper()
+
+	return newFrameworkTestServerWithModule(t, files, testframework.NewModule(t))
+}
+
+func newFrameworkTestServerWithSpxExtension(t testing.TB, files map[string][]byte) *Server {
+	t.Helper()
+
+	mod := testframework.NewModule(t)
+	class := mod.Opt.Projects[0]
+	class.Ext = ".spx"
+	class.FullExt = "main.spx"
+	class.Works[0].Ext = ".spx"
+	require.NoError(t, mod.ImportClasses())
+	return newFrameworkTestServerWithModule(t, files, mod)
+}
+
+func newFrameworkTestServerWithModule(t testing.TB, files map[string][]byte, mod *xgomod.Module) *Server {
+	t.Helper()
+
+	proj := xgo.NewProject(nil, newFileMap(files), xgo.FeatAll)
+	proj.PkgPath = "main"
+	proj.Mod = mod
 	proj.Importer = testframework.NewImporter(t, proj.Fset)
-	s.listPkgs = func() ([]string, error) { return []string{testframework.PkgPath}, nil }
+	listPkgs := func() ([]string, error) { return []string{testframework.PkgPath}, nil }
 	frameworkDoc := testframework.NewPkgDoc(t)
-	s.lookupPkgDoc = func(pkgPath string) (*pkgdoc.PkgDoc, error) {
+	lookupPkgDoc := func(pkgPath string) (*pkgdoc.PkgDoc, error) {
 		t.Helper()
 
-		require.False(t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
-			"unexpected spx documentation lookup: %s", pkgPath)
+		requireNonSpxDocumentation(t, pkgPath)
 		if pkgPath == testframework.PkgPath {
 			return frameworkDoc, nil
 		}
 		return nil, fs.ErrNotExist
 	}
-	return s
+	return newServer(proj, nil, fileMapGetter(files), &MockScheduler{}, listPkgs, lookupPkgDoc)
+}
+
+func requireNonSpxDocumentation(t testing.TB, pkgPath string) {
+	t.Helper()
+
+	require.False(t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
+		"unexpected spx documentation lookup: %s", pkgPath)
 }
 
 func newFileMap(files map[string][]byte) map[string]*xgo.File {

--- a/internal/server/text_synchronization_test.go
+++ b/internal/server/text_synchronization_test.go
@@ -156,17 +156,18 @@ func TestServerDocumentSynchronization(t *testing.T) {
 		name        string
 		filename    string
 		projectFile string
+		newServer   testServerFactory
 	}{
-		{name: "PlainXGo", filename: "main.xgo"},
-		{name: "ProjectClass", filename: "main_fixture.gox"},
-		{name: "WorkClass", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox"},
+		{name: "PlainXGo", filename: "main.xgo", newServer: newTestServer},
+		{name: "ProjectClass", filename: "main_fixture.gox", newServer: newFrameworkTestServer},
+		{name: "WorkClass", filename: "Worker_fixture.gox", projectFile: "main_fixture.gox", newServer: newFrameworkTestServer},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			files := map[string][]byte{tt.filename: nil}
 			if tt.projectFile != "" {
 				files[tt.projectFile] = nil
 			}
-			s := newTestServer(t, files)
+			s := tt.newServer(t, files)
 			replier := newMockReplier()
 			s.replier = replier
 			uri := s.toDocumentURI(tt.filename)

--- a/internal/testframework/framework.go
+++ b/internal/testframework/framework.go
@@ -6,6 +6,7 @@ import (
 	goast "go/ast"
 	goparser "go/parser"
 	gotypes "go/types"
+	"io/fs"
 	"strings"
 	"testing"
 
@@ -58,7 +59,14 @@ func NewImporter(t testing.TB, fset *token.FileSet) gotypes.Importer {
 	}
 }
 
-// importer supplies the test framework and delegates other imports.
+// NewBaseImporter returns an importer without the framework package and rejects spx.
+func NewBaseImporter(t testing.TB, fset *token.FileSet) gotypes.Importer {
+	t.Helper()
+
+	return &importer{t: t, fallback: packages.NewImporter(fset)}
+}
+
+// importer rejects spx, optionally supplies the test framework, and delegates other imports.
 type importer struct {
 	t         testing.TB
 	framework *gotypes.Package
@@ -72,6 +80,9 @@ func (i *importer) Import(pkgPath string) (*gotypes.Package, error) {
 	require.False(i.t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
 		"unexpected spx import: %s", pkgPath)
 	if pkgPath == PkgPath {
+		if i.framework == nil {
+			return nil, fs.ErrNotExist
+		}
 		return i.framework, nil
 	}
 	return i.fallback.Import(pkgPath)

--- a/internal/testframework/framework_test.go
+++ b/internal/testframework/framework_test.go
@@ -1,0 +1,34 @@
+package testframework
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/goplus/xgo/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBaseImporter(t *testing.T) {
+	base := NewBaseImporter(t, token.NewFileSet())
+	_, err := base.Import(PkgPath)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	framework, err := NewImporter(t, token.NewFileSet()).Import(PkgPath)
+	require.NoError(t, err)
+	require.NotNil(t, framework.Scope().Lookup("App"))
+	_, err = base.Import(PkgPath)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	_, err = NewBaseImporter(t, token.NewFileSet()).Import(PkgPath)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+
+	for _, pkgPath := range []string{"strings", "github.com/qiniu/x/osx"} {
+		pkg, err := base.Import(pkgPath)
+		require.NoError(t, err)
+		assert.Equal(t, pkgPath, pkg.Path())
+		assert.True(t, pkg.Complete())
+		again, err := base.Import(pkgPath)
+		require.NoError(t, err)
+		assert.Same(t, pkg, again)
+	}
+}


### PR DESCRIPTION
Construct test servers from configured projects and package data providers without running the default module setup in `New`. Preserve the public constructor's defaults and cover them with a dedicated spx regression.

Make plain XGo and standalone class tests use an environment without the test framework's registration, types, or documentation. Require framework cases to opt in explicitly, including tables covering multiple source kinds, and prepare custom modules before server construction.

Cover invalid default class modules, preservation of configured projects and cached types, and isolation of modules, importers, package lists, and documentation between server instances.