### PR TITLE
test(xgo): isolate project test environments

### DIFF
--- a/internal/server/dependency_test.go
+++ b/internal/server/dependency_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/goplus/xgolsw/jsonrpc2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckNonSpxDocumentation(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{name: "Spx", path: "github.com/goplus/spx"},
+		{name: "VersionedSpx", path: "github.com/goplus/spx/v3"},
+		{name: "SpxSubpackage", path: "github.com/goplus/spx/v3/internal/engine"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &testFailureRecorder{TB: t}
+			err := checkNonSpxDocumentation(recorder, tt.path)
+			assert.EqualError(t, err, "unexpected spx documentation lookup: "+tt.path)
+			messages := recorder.recordedFailures()
+			require.Len(t, messages, 1)
+			assert.Contains(t, messages[0], "unexpected spx documentation lookup: "+tt.path)
+		})
+	}
+	t.Run("OtherPackages", func(t *testing.T) {
+		for _, pkgPath := range []string{"fmt", testframework.PkgPath, "github.com/goplus/spxutils"} {
+			assert.NoError(t, checkNonSpxDocumentation(t, pkgPath))
+		}
+	})
+}
+
+func TestServerHandleMessageRejectedTestDependencies(t *testing.T) {
+	for _, environment := range []struct {
+		name      string
+		newServer testServerFactory
+	}{
+		{name: "PlainXGo", newServer: newTestServer},
+		{name: "Framework", newServer: newFrameworkTestServer},
+	} {
+		t.Run(environment.name, func(t *testing.T) {
+			for _, tt := range []struct {
+				name    string
+				source  string
+				method  string
+				params  any
+				message string
+			}{
+				{
+					name: "Import", source: "import \"github.com/goplus/spx/v3\"\nvar Count int\n",
+					method:  "textDocument/diagnostic",
+					params:  DocumentDiagnosticParams{TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}},
+					message: "unexpected spx import: github.com/goplus/spx/v3",
+				},
+				{
+					name: "Documentation", source: "import \"strings\"\nvar _ strings.Builder\n",
+					method: "textDocument/completion",
+					params: CompletionParams{TextDocumentPositionParams: TextDocumentPositionParams{
+						TextDocument: TextDocumentIdentifier{URI: "file:///main.xgo"}, Position: Position{Character: 8},
+					}},
+					message: "unexpected spx documentation lookup: github.com/goplus/spx/v3",
+				},
+			} {
+				t.Run(tt.name, func(t *testing.T) {
+					recorder := &testFailureRecorder{TB: t}
+					s := environment.newServer(recorder, map[string][]byte{"main.xgo": []byte(tt.source)})
+					s.listPkgs = func() ([]string, error) { return []string{"github.com/goplus/spx/v3"}, nil }
+					replier := newMockReplier()
+					s.replier = replier
+					initializeServerForTest(t, s, replier)
+					require.Empty(t, recorder.recordedFailures())
+					call, err := jsonrpc2.NewCall(jsonrpc2.NewIntID(1), tt.method, tt.params)
+					require.NoError(t, err)
+					require.NoError(t, s.HandleMessage(call))
+					response := replier.waitForResponse(call.ID(), 5*time.Second)
+					require.NotNil(t, response, "dependency rejection must not abort the request goroutine")
+					require.NoError(t, response.Err())
+					assert.True(t, json.Valid(response.Result()))
+					messages := recorder.recordedFailures()
+					require.NotEmpty(t, messages)
+					assert.Contains(t, strings.Join(messages, "\n"), tt.message)
+
+					if tt.name == "Documentation" {
+						doc, err := s.lookupPkgDoc("github.com/goplus/spx/v3")
+						assert.Nil(t, doc)
+						assert.EqualError(t, err, tt.message)
+						_, err = s.lookupPkgDoc("example.com/missing")
+						assert.ErrorIs(t, err, fs.ErrNotExist)
+					}
+
+					// A later request must still complete after the rejected dependency.
+					shutdown, err := jsonrpc2.NewCall(jsonrpc2.NewIntID(2), "shutdown", nil)
+					require.NoError(t, err)
+					require.NoError(t, s.HandleMessage(shutdown))
+					response = replier.waitForResponse(shutdown.ID(), 5*time.Second)
+					require.NotNil(t, response)
+					assert.NoError(t, response.Err())
+				})
+			}
+		})
+	}
+}
+
+type testFailureRecorder struct {
+	testing.TB
+	mu       sync.Mutex
+	messages []string
+}
+
+func (r *testFailureRecorder) Errorf(format string, args ...any) {
+	r.mu.Lock()
+	r.messages = append(r.messages, fmt.Sprintf(format, args...))
+	r.mu.Unlock()
+}
+
+func (r *testFailureRecorder) recordedFailures() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.messages)
+}

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -1,16 +1,15 @@
 package server
 
 import (
+	"fmt"
 	"io/fs"
-	"strings"
 	"testing"
 
-	"github.com/goplus/mod/modfile"
-	"github.com/goplus/mod/modload"
 	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgolsw/internal/testframework"
 	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/goplus/xgolsw/xgo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,15 +20,16 @@ func newTestServer(t testing.TB, files map[string][]byte) *Server {
 
 	proj := xgo.NewProject(nil, newFileMap(files), xgo.FeatAll)
 	proj.PkgPath = "main"
-	proj.Mod = xgomod.New(modload.Module{Opt: &modfile.File{}})
-	require.NoError(t, proj.Mod.ImportClasses())
+	proj.Mod = testframework.NewBaseModule(t)
 	proj.Importer = testframework.NewBaseImporter(t, proj.Fset)
 	return newServer(proj, nil, fileMapGetter(files), &MockScheduler{},
 		func() ([]string, error) { return nil, nil },
 		func(pkgPath string) (*pkgdoc.PkgDoc, error) {
 			t.Helper()
 
-			requireNonSpxDocumentation(t, pkgPath)
+			if err := checkNonSpxDocumentation(t, pkgPath); err != nil {
+				return nil, err
+			}
 			return nil, fs.ErrNotExist
 		},
 	)
@@ -65,7 +65,9 @@ func newFrameworkTestServerWithModule(t testing.TB, files map[string][]byte, mod
 	lookupPkgDoc := func(pkgPath string) (*pkgdoc.PkgDoc, error) {
 		t.Helper()
 
-		requireNonSpxDocumentation(t, pkgPath)
+		if err := checkNonSpxDocumentation(t, pkgPath); err != nil {
+			return nil, err
+		}
 		if pkgPath == testframework.PkgPath {
 			return frameworkDoc, nil
 		}
@@ -74,11 +76,15 @@ func newFrameworkTestServerWithModule(t testing.TB, files map[string][]byte, mod
 	return newServer(proj, nil, fileMapGetter(files), &MockScheduler{}, listPkgs, lookupPkgDoc)
 }
 
-func requireNonSpxDocumentation(t testing.TB, pkgPath string) {
+func checkNonSpxDocumentation(t testing.TB, pkgPath string) error {
 	t.Helper()
 
-	require.False(t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
-		"unexpected spx documentation lookup: %s", pkgPath)
+	if testframework.IsSpxPath(pkgPath) {
+		err := fmt.Errorf("unexpected spx documentation lookup: %s", pkgPath)
+		assert.Fail(t, err.Error())
+		return err
+	}
+	return nil
 }
 
 func newFileMap(files map[string][]byte) map[string]*xgo.File {

--- a/internal/testframework/framework.go
+++ b/internal/testframework/framework.go
@@ -3,6 +3,7 @@ package testframework
 
 import (
 	_ "embed"
+	"fmt"
 	goast "go/ast"
 	goparser "go/parser"
 	gotypes "go/types"
@@ -16,6 +17,7 @@ import (
 	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgo/token"
 	"github.com/goplus/xgolsw/pkgdoc"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +29,16 @@ const PkgPath = "example.com/framework"
 //go:embed testdata/framework.go
 var source string
 
-// NewModule returns a fresh module with the test framework registered.
+// NewBaseModule returns a fresh module with only XGo's builtin classfiles.
+func NewBaseModule(t testing.TB) *xgomod.Module {
+	t.Helper()
+
+	mod := xgomod.New(modload.Module{Opt: &modfile.File{}})
+	require.NoError(t, mod.ImportClasses())
+	return mod
+}
+
+// NewModule returns a fresh module with one framework project and one work class.
 func NewModule(t testing.TB) *xgomod.Module {
 	t.Helper()
 
@@ -77,8 +88,11 @@ type importer struct {
 func (i *importer) Import(pkgPath string) (*gotypes.Package, error) {
 	i.t.Helper()
 
-	require.False(i.t, pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/"),
-		"unexpected spx import: %s", pkgPath)
+	if IsSpxPath(pkgPath) {
+		err := fmt.Errorf("unexpected spx import: %s", pkgPath)
+		assert.Fail(i.t, err.Error())
+		return nil, err
+	}
 	if pkgPath == PkgPath {
 		if i.framework == nil {
 			return nil, fs.ErrNotExist
@@ -86,6 +100,11 @@ func (i *importer) Import(pkgPath string) (*gotypes.Package, error) {
 		return i.framework, nil
 	}
 	return i.fallback.Import(pkgPath)
+}
+
+// IsSpxPath reports whether pkgPath belongs to spx, including versioned packages.
+func IsSpxPath(pkgPath string) bool {
+	return pkgPath == "github.com/goplus/spx" || strings.HasPrefix(pkgPath, "github.com/goplus/spx/")
 }
 
 // NewPkgDoc returns documentation parsed from the framework source.

--- a/internal/testframework/framework_test.go
+++ b/internal/testframework/framework_test.go
@@ -1,13 +1,89 @@
 package testframework
 
 import (
+	"fmt"
+	gotypes "go/types"
 	"io/fs"
 	"testing"
 
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgo/token"
+	"github.com/goplus/xgolsw/pkgdoc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewBaseModule(t *testing.T) {
+	first := NewBaseModule(t)
+	second := NewBaseModule(t)
+	first.Opt.Projects = NewModule(t).Opt.Projects
+	require.NoError(t, first.ImportClasses())
+	assert.True(t, first.IsClass("_fixture.gox"))
+	for _, mod := range []*xgomod.Module{second, NewBaseModule(t)} {
+		assert.Empty(t, mod.Opt.Projects)
+		assert.Empty(t, mod.Opt.ClassMods)
+		assert.False(t, mod.IsClass("_fixture.gox"))
+		assert.False(t, mod.IsClass(".spx"))
+		_, isProject, ok := mod.ClassInfo("Check_test.gox")
+		assert.True(t, ok)
+		assert.False(t, isProject)
+	}
+}
+
+func TestNewModule(t *testing.T) {
+	first := NewModule(t)
+	second := NewModule(t)
+	class, ok := first.LookupClass("_fixture.gox")
+	require.True(t, ok)
+	require.Len(t, class.PkgPaths, 1)
+	require.Len(t, class.Works, 1)
+	class.Ext = "_changed.gox"
+	class.FullExt = "main_changed.gox"
+	class.Class = "Changed"
+	class.PkgPaths[0] = "example.com/changed"
+	class.Works[0].Ext = "_changed.gox"
+	class.Works[0].Class = "ChangedItem"
+	class.Works[0].Prefix = "Task"
+	require.NoError(t, first.ImportClasses())
+	assert.True(t, first.IsClass("_changed.gox"))
+	assert.False(t, first.IsClass("_fixture.gox"))
+
+	for _, mod := range []*xgomod.Module{second, NewModule(t)} {
+		assert.False(t, mod.IsClass("_changed.gox"))
+		assert.False(t, mod.IsClass(".spx"))
+		require.Len(t, mod.Opt.Projects, 1)
+		project, ok := mod.LookupClass("_fixture.gox")
+		require.True(t, ok)
+		assert.Equal(t, "main_fixture.gox", project.FullExt)
+		assert.Equal(t, "App", project.Class)
+		assert.Equal(t, []string{PkgPath}, project.PkgPaths)
+		require.Len(t, project.Works, 1)
+		assert.Equal(t, modfile.Class{Ext: "_fixture.gox", Class: "Item", Embedded: true}, *project.Works[0])
+	}
+}
+
+func TestNewImporter(t *testing.T) {
+	firstFset := token.NewFileSet()
+	firstFset.AddFile("padding.go", -1, 4096)
+	first := NewImporter(t, firstFset)
+	firstPkg, err := first.Import(PkgPath)
+	require.NoError(t, err)
+	secondFset := token.NewFileSet()
+	secondPkg, err := NewImporter(t, secondFset).Import(PkgPath)
+	require.NoError(t, err)
+	assert.NotSame(t, firstPkg, secondPkg)
+	firstApp := firstPkg.Scope().Lookup("App")
+	secondApp := secondPkg.Scope().Lookup("App")
+	require.NotNil(t, firstApp)
+	require.NotNil(t, secondApp)
+	assert.NotSame(t, firstApp.Type(), secondApp.Type())
+	assert.Equal(t, "testdata/framework.go", firstFset.Position(firstApp.Pos()).Filename)
+	assert.Equal(t, "testdata/framework.go", secondFset.Position(secondApp.Pos()).Filename)
+	again, err := first.Import(PkgPath)
+	require.NoError(t, err)
+	assert.Same(t, firstPkg, again)
+}
 
 func TestNewBaseImporter(t *testing.T) {
 	base := NewBaseImporter(t, token.NewFileSet())
@@ -31,4 +107,79 @@ func TestNewBaseImporter(t *testing.T) {
 		require.NoError(t, err)
 		assert.Same(t, pkg, again)
 	}
+}
+
+func TestImporterImport(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{name: "Spx", path: "github.com/goplus/spx"},
+		{name: "VersionedSpx", path: "github.com/goplus/spx/v3"},
+		{name: "SpxSubpackage", path: "github.com/goplus/spx/v3/internal/engine"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &failureRecorder{TB: t}
+			called := false
+			i := &importer{t: recorder, fallback: importerFunc(func(path string) (*gotypes.Package, error) {
+				called = true
+				return gotypes.NewPackage(path, "unexpected"), nil
+			})}
+			pkg, err := i.Import(tt.path)
+			assert.Nil(t, pkg)
+			assert.EqualError(t, err, "unexpected spx import: "+tt.path)
+			assert.False(t, called)
+			require.Len(t, recorder.messages, 1)
+			assert.Contains(t, recorder.messages[0], "unexpected spx import: "+tt.path)
+		})
+	}
+	t.Run("SimilarPackagePath", func(t *testing.T) {
+		const pkgPath = "github.com/goplus/spxutils"
+		want := gotypes.NewPackage(pkgPath, "spxutils")
+		i := &importer{t: t, fallback: importerFunc(func(path string) (*gotypes.Package, error) {
+			assert.Equal(t, pkgPath, path)
+			return want, nil
+		})}
+		pkg, err := i.Import(pkgPath)
+		require.NoError(t, err)
+		assert.Same(t, want, pkg)
+	})
+}
+
+func TestNewPkgDoc(t *testing.T) {
+	first := NewPkgDoc(t)
+	second := NewPkgDoc(t)
+	require.NotNil(t, first.Types["App"])
+	require.NotNil(t, first.Types["Item"])
+	first.Doc = "Changed package documentation."
+	first.Consts["Low"] = "Changed constant documentation."
+	first.Funcs["RunWhen"] = "Changed function documentation."
+	first.Types["App"].Methods["OnStart"] = "Changed method documentation."
+	first.Types["Item"].Fields["Value"] = "Changed field documentation."
+	for _, doc := range []*pkgdoc.PkgDoc{second, NewPkgDoc(t)} {
+		assert.Equal(t, PkgPath, doc.Path)
+		assert.Equal(t, "framework", doc.Name)
+		assert.Equal(t, "Package framework provides a minimal classfile framework for language tests.\n", doc.Doc)
+		assert.Equal(t, "Low and High are values used by framework methods.\n", doc.Consts["Low"])
+		assert.Equal(t, "RunWhen accepts a deferred condition and a callback.\n", doc.Funcs["RunWhen"])
+		require.NotNil(t, doc.Types["App"])
+		require.NotNil(t, doc.Types["Item"])
+		assert.Equal(t, "OnStart accepts a project callback.\n", doc.Types["App"].Methods["OnStart"])
+		assert.Equal(t, "Value stores the work item's value.\n", doc.Types["Item"].Fields["Value"])
+	}
+}
+
+type importerFunc func(string) (*gotypes.Package, error)
+
+func (f importerFunc) Import(path string) (*gotypes.Package, error) {
+	return f(path)
+}
+
+type failureRecorder struct {
+	testing.TB
+	messages []string
+}
+
+func (r *failureRecorder) Errorf(format string, args ...any) {
+	r.messages = append(r.messages, fmt.Sprintf(format, args...))
 }

--- a/xgo/ast_test.go
+++ b/xgo/ast_test.go
@@ -78,15 +78,16 @@ func Test() {
 			isClass     bool
 			isProj      bool
 			isNormalGox bool
+			newProject  testProjectFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "Gop", filename: "main.gop"},
-			{name: "NormalClass", filename: "Record.gox", isClass: true, isNormalGox: true},
-			{name: "ProjectClass", filename: "main_fixture.gox", isClass: true, isProj: true},
-			{name: "WorkClass", filename: "Worker_fixture.gox", isClass: true},
+			{name: "XGo", filename: "main.xgo", newProject: newTestProject},
+			{name: "Gop", filename: "main.gop", newProject: newTestProject},
+			{name: "NormalClass", filename: "Record.gox", isClass: true, isNormalGox: true, newProject: newTestProject},
+			{name: "ProjectClass", filename: "main_fixture.gox", isClass: true, isProj: true, newProject: newFrameworkTestProject},
+			{name: "WorkClass", filename: "Worker_fixture.gox", isClass: true, newProject: newFrameworkTestProject},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				proj := newTestProject(t, map[string]*File{tt.filename: file(`var value int`)}, FeatASTCache)
+				proj := tt.newProject(t, map[string]*File{tt.filename: file(`var value int`)}, FeatASTCache)
 				cache, err := buildASTFileCache(proj, tt.filename, proj.files[tt.filename])
 				require.NoError(t, err)
 				astCache, ok := cache.(*astFileCache)
@@ -239,7 +240,7 @@ func ValidFunc() {}
 
 func TestProjectASTPackage(t *testing.T) {
 	t.Run("ValidPackage", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		proj := newFrameworkTestProject(t, map[string]*File{
 			"main_fixture.gox": file(`
 // Main file.
 var mainVar int

--- a/xgo/constructor_test.go
+++ b/xgo/constructor_test.go
@@ -1,0 +1,138 @@
+package xgo
+
+import (
+	gotypes "go/types"
+	"io/fs"
+	"testing"
+
+	"github.com/goplus/xgolsw/internal/testframework"
+	"github.com/goplus/xgolsw/xgo/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTestProject(t *testing.T) {
+	files := map[string]*File{
+		"main.xgo":   file("import \"strings\"\n// Count stores the text length.\nvar Count = len(strings.ToUpper(\"text\"))\n"),
+		"Record.gox": file("// Value stores the count.\nvar value int\n"),
+	}
+	plain := newTestProject(t, files, FeatAll)
+	check := func(proj *Project) {
+		t.Helper()
+
+		assert.False(t, proj.Mod.IsClass("_fixture.gox"))
+		assert.False(t, proj.Mod.IsClass(".spx"))
+		_, err := proj.Importer.Import(testframework.PkgPath)
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+		astPkg, err := proj.ASTPackage()
+		require.NoError(t, err)
+		require.Len(t, astPkg.Files, 2)
+		require.NotNil(t, astPkg.Files["main.xgo"])
+		require.NotNil(t, astPkg.Files["Record.gox"])
+		assert.False(t, astPkg.Files["main.xgo"].IsClass)
+		assert.True(t, astPkg.Files["Record.gox"].IsNormalGox)
+		typeInfo, err := proj.TypeInfo()
+		require.NoError(t, err)
+		count := typeInfo.Pkg.Scope().Lookup("Count")
+		require.NotNil(t, count)
+		assert.Equal(t, gotypes.Typ[gotypes.Int], count.Type())
+		assert.Nil(t, typeInfo.Pkg.Scope().Lookup("App"))
+		for _, pkg := range typeInfo.Pkg.Imports() {
+			assert.NotEqual(t, testframework.PkgPath, pkg.Path())
+		}
+		doc, err := proj.PkgDoc()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"Count": "Count stores the text length.\n"}, doc.Vars)
+		require.Len(t, doc.Types, 1)
+		record := doc.Types["Record"]
+		require.NotNil(t, record)
+		assert.Equal(t, map[string]string{"value": "Value stores the count.\n"}, record.Fields)
+	}
+	check(plain)
+
+	framework := newFrameworkTestProject(t, map[string]*File{
+		"main_fixture.gox": file("onStart => {\n    measure 1\n}\n"),
+	}, FeatAll)
+	_, err := framework.TypeInfo()
+	require.NoError(t, err)
+	check(plain)
+	check(newTestProject(t, files, FeatAll))
+}
+
+func TestNewFrameworkTestProject(t *testing.T) {
+	files := map[string]*File{
+		"main_fixture.gox":   file("onStart => {\n    measure 1\n}\n"),
+		"Worker_fixture.gox": file("// Value stores the count.\nvar value int\n"),
+	}
+	first := newFrameworkTestProject(t, files, FeatAll)
+	second := newFrameworkTestProject(t, files, FeatAll)
+	assert.NotSame(t, first.Mod, second.Mod)
+	assert.NotSame(t, first.Importer, second.Importer)
+	assert.NotSame(t, first.Fset, second.Fset)
+	firstTypes, err := first.TypeInfo()
+	require.NoError(t, err)
+	secondTypes, err := second.TypeInfo()
+	require.NoError(t, err)
+	firstPkg, err := first.Importer.Import(testframework.PkgPath)
+	require.NoError(t, err)
+	secondPkg, err := second.Importer.Import(testframework.PkgPath)
+	require.NoError(t, err)
+	assert.NotSame(t, firstPkg, secondPkg)
+	for _, tt := range []struct {
+		typeInfo *types.Info
+		pkg      *gotypes.Package
+	}{
+		{typeInfo: firstTypes, pkg: firstPkg},
+		{typeInfo: secondTypes, pkg: secondPkg},
+	} {
+		var callback gotypes.Object
+		for ident, obj := range tt.typeInfo.Uses {
+			if ident.Name == "onStart" {
+				callback = obj
+				break
+			}
+		}
+		require.NotNil(t, callback)
+		assert.Same(t, tt.pkg, callback.Pkg())
+	}
+	firstAST, err := first.ASTFile("Worker_fixture.gox")
+	require.NoError(t, err)
+	secondAST, err := second.ASTFile("Worker_fixture.gox")
+	require.NoError(t, err)
+	firstDoc, err := first.PkgDoc()
+	require.NoError(t, err)
+	secondDoc, err := second.PkgDoc()
+	require.NoError(t, err)
+
+	first.PutFile("Worker_fixture.gox", file("// Value stores a label.\nvar value string\n"))
+	updatedTypes, err := first.TypeInfo()
+	require.NoError(t, err)
+	assert.NotSame(t, firstTypes, updatedTypes)
+	worker := updatedTypes.Pkg.Scope().Lookup("Worker")
+	require.NotNil(t, worker)
+	value, _, _ := gotypes.LookupFieldOrMethod(worker.Type(), true, updatedTypes.Pkg, "value")
+	require.NotNil(t, value)
+	assert.Equal(t, gotypes.Typ[gotypes.String], value.Type())
+	updatedAST, err := first.ASTFile("Worker_fixture.gox")
+	require.NoError(t, err)
+	assert.NotSame(t, firstAST, updatedAST)
+	updatedDoc, err := first.PkgDoc()
+	require.NoError(t, err)
+	assert.NotSame(t, firstDoc, updatedDoc)
+	require.NotNil(t, updatedDoc.Types["Worker"])
+	require.NotNil(t, firstDoc.Types["Worker"])
+	assert.Equal(t, "Value stores a label.\n", updatedDoc.Types["Worker"].Fields["value"])
+	assert.Equal(t, "Value stores the count.\n", firstDoc.Types["Worker"].Fields["value"])
+
+	unchangedTypes, err := second.TypeInfo()
+	require.NoError(t, err)
+	assert.Same(t, secondTypes, unchangedTypes)
+	unchangedAST, err := second.ASTFile("Worker_fixture.gox")
+	require.NoError(t, err)
+	assert.Same(t, secondAST, unchangedAST)
+	unchangedDoc, err := second.PkgDoc()
+	require.NoError(t, err)
+	assert.Same(t, secondDoc, unchangedDoc)
+	require.NotNil(t, unchangedDoc.Types["Worker"])
+	assert.Equal(t, "Value stores the count.\n", unchangedDoc.Types["Worker"].Fields["value"])
+}

--- a/xgo/pkgdoc_test.go
+++ b/xgo/pkgdoc_test.go
@@ -20,13 +20,14 @@ import (
 	"testing"
 
 	"github.com/goplus/xgo/scanner"
+	"github.com/goplus/xgolsw/internal/testframework"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBuildPkgDocCache(t *testing.T) {
 	t.Run("ValidProject", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		proj := newFrameworkTestProject(t, map[string]*File{
 			"main_fixture.gox": file(`var (
 	// Total counts the items.
 	total int
@@ -66,7 +67,7 @@ func Reset() {
 	})
 
 	t.Run("ParserError", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		proj := newFrameworkTestProject(t, map[string]*File{
 			"invalid_fixture.gox": file(`invalid syntax {{{`),
 		}, FeatASTCache)
 
@@ -81,24 +82,39 @@ func Reset() {
 func TestProjectPkgDoc(t *testing.T) {
 	t.Run("FileKinds", func(t *testing.T) {
 		for _, tt := range []struct {
-			name        string
-			filename    string
-			projectFile string
-			workPrefix  string
-			className   string
+			name       string
+			filename   string
+			className  string
+			newProject testProjectFactory
 		}{
-			{name: "XGo", filename: "main.xgo"},
-			{name: "Gop", filename: "main.gop"},
-			{name: "NormalClass", filename: "Record.gox", className: "Record"},
-			{name: "ProjectClass", filename: "main_fixture.gox", className: "App"},
-			{name: "WorkClass", filename: "items/Worker_fixture.gox", className: "Worker"},
-			{name: "NamedProject", filename: "Root_fixture.gox", projectFile: "Root_fixture.gox", className: "Root"},
-			{name: "PrefixedWork", filename: "Worker_fixture.gox", workPrefix: "Task", className: "TaskWorker"},
-			{name: "NormalizedClassName", filename: "work-item_fixture.gox", className: "work_item"},
-			{name: "TestClass", filename: "Check_test.gox", className: "caseCheck"},
+			{name: "XGo", filename: "main.xgo", newProject: newTestProject},
+			{name: "Gop", filename: "main.gop", newProject: newTestProject},
+			{name: "NormalClass", filename: "Record.gox", className: "Record", newProject: newTestProject},
+			{name: "ProjectClass", filename: "main_fixture.gox", className: "App", newProject: newFrameworkTestProject},
+			{name: "WorkClass", filename: "items/Worker_fixture.gox", className: "Worker", newProject: newFrameworkTestProject},
+			{name: "NamedProject", filename: "Root_fixture.gox", className: "Root", newProject: func(t *testing.T, files map[string]*File, feats uint) *Project {
+				t.Helper()
+
+				mod := testframework.NewModule(t)
+				class, ok := mod.LookupClass("_fixture.gox")
+				require.True(t, ok)
+				class.FullExt = "Root_fixture.gox"
+				return newFrameworkTestProjectWithModule(t, files, feats, mod)
+			}},
+			{name: "PrefixedWork", filename: "Worker_fixture.gox", className: "TaskWorker", newProject: func(t *testing.T, files map[string]*File, feats uint) *Project {
+				t.Helper()
+
+				mod := testframework.NewModule(t)
+				class, ok := mod.LookupClass("_fixture.gox")
+				require.True(t, ok)
+				class.Works[0].Prefix = "Task"
+				return newFrameworkTestProjectWithModule(t, files, feats, mod)
+			}},
+			{name: "NormalizedClassName", filename: "work-item_fixture.gox", className: "work_item", newProject: newFrameworkTestProject},
+			{name: "TestClass", filename: "Check_test.gox", className: "caseCheck", newProject: newTestProject},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
-				proj := newTestProject(t, map[string]*File{
+				proj := tt.newProject(t, map[string]*File{
 					tt.filename: file(`var (
 	// Value stores the count.
 	value int
@@ -110,13 +126,6 @@ func Increment() {
 }
 `),
 				}, FeatASTCache|FeatPkgDocCache)
-				framework, ok := proj.Mod.LookupClass("_fixture.gox")
-				require.True(t, ok)
-				if tt.projectFile != "" {
-					framework.FullExt = tt.projectFile
-				}
-				framework.Works[0].Prefix = tt.workPrefix
-
 				doc, err := proj.PkgDoc()
 				require.NoError(t, err)
 				require.NotNil(t, doc)
@@ -143,7 +152,7 @@ func Increment() {
 	})
 
 	t.Run("MixedFiles", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		proj := newFrameworkTestProject(t, map[string]*File{
 			"main_fixture.gox": file(`var (
 	// Total belongs to the project.
 	total int
@@ -201,7 +210,11 @@ func (a *App) Read() int { return a.total }
 	})
 
 	t.Run("EmptyClassName", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		mod := testframework.NewModule(t)
+		class, ok := mod.LookupClass("_fixture.gox")
+		require.True(t, ok)
+		class.Class = ""
+		proj := newFrameworkTestProjectWithModule(t, map[string]*File{
 			"main_fixture.gox": file(`var (
 	// Total belongs to the unnamed project class.
 	total int
@@ -221,10 +234,7 @@ func Reset() {}
 			"helpers.xgo": file(`// Reset is a package function.
 func Reset() {}
 `),
-		}, FeatASTCache|FeatPkgDocCache)
-		framework, ok := proj.Mod.LookupClass("_fixture.gox")
-		require.True(t, ok)
-		framework.Class = ""
+		}, FeatASTCache|FeatPkgDocCache, mod)
 
 		doc, err := proj.PkgDoc()
 		require.NoError(t, err)
@@ -266,7 +276,7 @@ type Color const (
 	})
 
 	t.Run("Cache", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		proj := newFrameworkTestProject(t, map[string]*File{
 			"Worker_fixture.gox": file(`var (
 	// Value stores the count.
 	value int

--- a/xgo/testutil_test.go
+++ b/xgo/testutil_test.go
@@ -3,14 +3,32 @@ package xgo
 import (
 	"testing"
 
+	"github.com/goplus/mod/xgomod"
 	"github.com/goplus/xgolsw/internal/testframework"
 )
+
+type testProjectFactory func(*testing.T, map[string]*File, uint) *Project
 
 func newTestProject(t *testing.T, files map[string]*File, feats uint) *Project {
 	t.Helper()
 
 	proj := NewProject(nil, files, feats)
-	proj.Mod = testframework.NewModule(t)
+	proj.Mod = testframework.NewBaseModule(t)
+	proj.Importer = testframework.NewBaseImporter(t, proj.Fset)
+	return proj
+}
+
+func newFrameworkTestProject(t *testing.T, files map[string]*File, feats uint) *Project {
+	t.Helper()
+
+	return newFrameworkTestProjectWithModule(t, files, feats, testframework.NewModule(t))
+}
+
+func newFrameworkTestProjectWithModule(t *testing.T, files map[string]*File, feats uint, mod *xgomod.Module) *Project {
+	t.Helper()
+
+	proj := NewProject(nil, files, feats)
+	proj.Mod = mod
 	proj.Importer = testframework.NewImporter(t, proj.Fset)
 	return proj
 }

--- a/xgo/typeinfo_test.go
+++ b/xgo/typeinfo_test.go
@@ -145,7 +145,7 @@ func Double() int {
 	})
 
 	t.Run("FrameworkClasses", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		proj := newFrameworkTestProject(t, map[string]*File{
 			"main_fixture.gox": file(`var total int
 
 onStart => {
@@ -227,7 +227,7 @@ echo label
 	})
 
 	t.Run("FrameworkTypeError", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		proj := newFrameworkTestProject(t, map[string]*File{
 			"main_fixture.gox": file(`var total int`),
 			"Worker_fixture.gox": file(`onValue amount => {
 	total = "invalid"
@@ -246,7 +246,7 @@ echo label
 	})
 
 	t.Run("FrameworkCacheInvalidation", func(t *testing.T) {
-		proj := newTestProject(t, map[string]*File{
+		proj := newFrameworkTestProject(t, map[string]*File{
 			"main_fixture.gox":   file(`var total int`),
 			"Worker_fixture.gox": file(`var value int`),
 		}, FeatASTCache|FeatTypeInfoCache)


### PR DESCRIPTION
Make plain XGo and standalone class project tests use fresh modules and importers without the test framework. Register the framework explicitly for classfile cases in AST, type information, and package documentation tests.

Verify isolation of module registrations, framework packages and source positions, documentation maps, and project caches across instances.

Report unexpected spx imports and documentation lookups as test failures and return errors without terminating request goroutines. Cover rejection through asynchronous diagnostic and completion requests, and verify that subsequent requests still complete.